### PR TITLE
chore(ci): GitHub Actions CI ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Run CI
+        run: make ci
+
+      - name: Fail if auto-fix produced diffs
+        run: |
+          git diff --exit-code || {
+            echo "::error::Auto-fix により差分が発生しました。ローカルで make ci を実行してコミットしてください。"
+            git diff --stat
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Fail if auto-fix produced diffs
         run: |
           git diff --exit-code || {
-            echo "::error::Auto-fix により差分が発生しました。ローカルで make ci を実行してコミットしてください。"
+            echo "::error::Auto-fix produced diffs. Run 'make ci' locally and commit the changes."
             git diff --stat
             exit 1
           }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci ci-check ts-check-diff ts-fix-diff html-check-diff html-fix-diff watch-dev repomix test test-debug type-check check-ts-rules check-non-ascii sync-ruler
+.PHONY: ci ts-check-diff ts-fix-diff html-check-diff html-fix-diff watch-dev repomix test test-debug type-check check-ts-rules check-non-ascii sync-ruler
 
 # Rebuild when changes are detected in code (for development)
 watch-dev:
@@ -14,18 +14,11 @@ repomix:
 	# Version further excluding test files
 	npx repomix --ignore "**/package-lock.json,**/node_modules/**,**/*.png,**/*.jpg,**/*.jpeg,**/*.gif,**/*.svg,**/*.ico,LICENSE,**/.cursor/**,**/*.test.ts,**/test/**,public/robots.txt,public/sitemap.xml,public/site.webmanifest,.gitignore,scripts/check_ts_rules.py,Makefile,vitest.config.ts,README.ja.md" --output tmp/repomix/repomix-lite-no-tests.txt
 
-# For local execution: Auto-fix if possible -> Check -> Test
+# CI entrypoint (local and GitHub Actions)
+# Strategy: run auto-fix, then GitHub Actions detects diffs via git diff --exit-code
+# NOTE: if you change this target, also check .github/workflows/ci.yml
 ci:
 	python3 scripts/run_ci.py
-
-# For CI (Server): Do not auto-fix, fail if there are diffs
-ci-check:
-	$(MAKE) ts-check-diff
-	$(MAKE) html-check-diff
-	$(MAKE) type-check
-	$(MAKE) check-ts-rules
-	$(MAKE) check-non-ascii
-	$(MAKE) test
 
 test:
 	npm run test


### PR DESCRIPTION
## 概要

ローカルと GitHub Actions で同一の `make ci` を実行し、CI ロジックを一元管理できるようにする。auto-fix 後に差分があれば GitHub Actions 側で `git diff --exit-code` により検出して失敗させる方針を採用し、メンテナンスコストを最小化する。

## 変更内容

- `.github/workflows/ci.yml` を新規作成 — `make ci` 実行後に `git diff --exit-code` で auto-fix による差分を検出してエラーにする GitHub Actions ワークフローを追加
- `Makefile` から `ci-check` ターゲットを削除 — GitHub Actions 専用だった `ci-check` が不要になったため除去し、`ci` ターゲットのコメントをローカル・CI 共通の方針に更新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 継続的インテグレーション（CI）ワークフローを新たに設定しました。プルリクエストとメインブランチへのプッシュ時に、自動的にコード検証とテストが実行されます。
  * 開発プロセスの効率化に向けて、ビルドツールチェーンを最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->