### PR TITLE
feat(ui): 言語切替ボタンをフッターからヘッダーに移動

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-.PHONY: ci ts-check-diff ts-fix-diff html-check-diff html-fix-diff watch-dev repomix test test-debug type-check check-ts-rules check-non-ascii sync-ruler setup
-
-# Rebuild when changes are detected in code (for development)
-watch-dev:
-	npm run build -- --watch
+.PHONY: ci ts-check-diff ts-fix-diff html-check-diff html-fix-diff repomix test test-debug type-check check-ts-rules check-non-ascii sync-ruler setup
 
 # Run repomix to bundle files into tmp/repomix/ folder
 repomix:

--- a/index.html
+++ b/index.html
@@ -275,7 +275,14 @@
   <body>
     <div class="app">
       <header>
-        <h1><span class="logo-p">P</span>ixel Refiner</h1>
+        <div class="header-top">
+          <h1><span class="logo-p">P</span>ixel Refiner</h1>
+          <div class="lang-selector">
+            <button class="lang-btn" data-lang-btn="en">EN</button>
+            <span class="separator">/</span>
+            <button class="lang-btn" data-lang-btn="ja">JA</button>
+          </div>
+        </div>
         <p class="app-description" data-i18n="app.description" data-i18n-html>
           Optimize AI-generated pixel art into
           <span class="text-highlight">production-ready sprites</span>.<br />
@@ -1334,12 +1341,6 @@
             >
               <img src="/logo_github.svg" alt="GitHub" width="20" height="20" />
             </a>
-            <span class="separator">|</span>
-            <div class="lang-selector">
-              <button class="lang-btn" data-lang-btn="en">EN</button>
-              <span class="separator">/</span>
-              <button class="lang-btn" data-lang-btn="ja">JA</button>
-            </div>
             <span class="separator">|</span>
             <span class="privacy-note" data-i18n="footer.privacy">
               <svg

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -77,6 +77,13 @@ h1 {
   -webkit-text-fill-color: transparent;
 }
 
+.header-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
 .lang-selector {
   display: flex;
   align-items: center;

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -78,10 +78,16 @@ h1 {
 }
 
 .header-top {
+  position: relative;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   width: 100%;
+}
+
+.header-top .lang-selector {
+  position: absolute;
+  right: 0;
 }
 
 .lang-selector {


### PR DESCRIPTION
## 概要

言語切替ボタン（EN/JA）をフッターからヘッダー右上に移動する。ページ上部に常時表示することで、ユーザーがどのスクロール位置にいても言語を即座に切り替えられるようにする。

## 変更内容

- `index.html`: ヘッダー内に `.header-top` ラッパーを追加し、`<h1>` と `.lang-selector` を横並びで配置（ユーザーが最初に目に入る場所に言語切替を露出させるため）
- `index.html`: フッターの `.lang-selector` と前後の separator を削除（重複配置を解消するため）
- `src/browser/style.css`: `.header-top` に `display: flex; justify-content: space-between` を追加し、タイトル左・言語切替右のレイアウトを実現
- `Makefile`: 未使用の `watch-dev` ターゲットを削除（`npm run build -- --watch` はスクリプトから直接実行可能なため）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * ヘッダーに言語選択機能を追加しました。英語と日本語の切り替えボタンがヘッダーに移動され、より簡単にアクセスできるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->