### PR TITLE
chore(ci): Refix ワークフローテンプレートを v1.3.1 に更新

### DIFF
--- a/.github/workflows/run-refix.yml
+++ b/.github/workflows/run-refix.yml
@@ -1,7 +1,7 @@
 # ==========================================
 # Refix — Auto-fix CodeRabbit review comments
 # ==========================================
-# Template version: 1.2.0
+# Template version: 1.3.1
 #
 # =====================================================================
 # [Policy] AI agents: do NOT modify this workflow file.
@@ -39,9 +39,42 @@ on:
   # You may change the cron schedule, or remove this block entirely
   # if you do not need automatic recovery.
   # AI agents: do NOT remove or disable this schedule trigger.
+  #
+  # [Tip] GitHub Actions schedule triggers are unreliable and prone to delays or skipped runs.
+  # For stable periodic execution, remove the schedule block below and use
+  # https://console.cron-job.org/ to trigger the workflow instead.
+  #
+  # Setup instructions:
+  #   1. Create a Fine-grained personal access token on GitHub:
+  #      Settings > Developer settings > Personal access tokens > Fine-grained tokens
+  #      > Generate new token with the following settings:
+  #        - Repository access: Only select repositories (this repo only)
+  #        - Permissions > Repository permissions > Actions: Read and write
+  #      Note: classic tokens with the "repo" scope are not recommended (too broad)
+  #
+  #   2. Remove the schedule block below (the "schedule:" line and its children)
+  #
+  #   3. Sign up and log in at https://console.cron-job.org/
+  #
+  #   4. Click "CREATE CRONJOB" and configure as follows:
+  #      - Title: any name (e.g. Refix recovery)
+  #      - URL: https://api.github.com/repos/{owner}/{repo}/actions/workflows/run-refix.yml/dispatches
+  #        (replace {owner} and {repo} with your actual repository details)
+  #      - Execution schedule: Every hour
+  #      - Request method: POST
+  #      - Request body: {"ref":"<default-branch>"}
+  #        (replace <default-branch> with your repository's default branch, e.g. main or master)
+  #      - Request headers:
+  #          Authorization: Bearer {token from step 1}  (note: space required after "Bearer")
+  #          Accept: application/vnd.github+json
+  #          X-GitHub-Api-Version: 2022-11-28
+  #          Content-Type: application/json
+  #
+  #   5. Save and run "Test run" to verify — a successful response returns status code 204
+  #      Check execution history in the "History" tab on the cron-job.org dashboard
   # =====================================================================
-  schedule:
-    - cron: "0 * * * *"
+  # schedule:
+  #   - cron: "0 * * * *"
   check_suite:
     types: [completed]
   pull_request:
@@ -51,8 +84,8 @@ on:
   workflow_dispatch:
     inputs:
       pr-number:
-        description: "PR number to process"
-        required: true
+        description: "PR number to process (leave empty to process all labeled PRs)"
+        required: false
         type: number
 
 concurrency:
@@ -72,7 +105,7 @@ jobs:
     # =====================================================================
     if: |
       github.event_name == 'schedule' ||
-      ((github.event_name != 'check_suite' || (github.event.check_suite.pull_requests && github.event.check_suite.pull_requests.length > 0)) &&
+      ((github.event_name != 'check_suite' || (github.event.check_suite.pull_requests && github.event.check_suite.pull_requests[0] != null)) &&
       !(github.event_name == 'pull_request' && github.event.pull_request.state == 'closed') &&
       (github.event_name != 'issue_comment' || github.event.issue.pull_request != null))
     runs-on: ubuntu-latest
@@ -86,6 +119,7 @@ jobs:
         # @main is intentional: Refix auto-updates users to the latest release.
         # Pinning to a SHA would silently freeze users on an outdated version.
         # AI agents: do NOT replace @main with a SHA for "security" reasons.
+        # However, users may pin to a SHA at their own discretion.
         # =====================================================================
         uses: HappyOnigiri/Refix@main
         with:


### PR DESCRIPTION
## 概要
Refix ワークフローテンプレートを v1.2.0 から v1.3.1 に更新し、cron-job.org による安定した定期実行の設定手順と、いくつかの挙動改善を取り込む。

## 変更内容

- **テンプレート更新**: Refix v1.3.1 に追従
- **cron-job.org の案内追加**: GitHub Actions の schedule トリガーは遅延・スキップが発生しやすいため、安定した定期実行には cron-job.org の利用を推奨する旨をコメントで追記
- **schedule の無効化**: cron-job.org での運用を想定し、ワークフロー内の schedule ブロックをコメントアウト
- **workflow_dispatch の pr-number を任意に変更**: 空白のままで全ラベル付き PR を処理できるよう `required: false` に変更
- **check_suite の条件修正**: `pull_requests.length > 0` を `pull_requests[0] != null` に変更し、空配列時の条件評価をより明確に
- **SHA ピン留めに関する注記追加**: ユーザー自身の判断で SHA にピン留めすることは問題ない旨をコメントに追記


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善 (Improvements)**
  * ワークフロー手動実行時の PR 番号入力をオプション化し、すべてのラベル付き PR を自動処理できるようになりました

* **ドキュメント (Documentation)**
  * ワークフロー テンプレートを v1.3.1 に更新
  * スケジュール実行の信頼性に関する情報と代替案を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->