### PR TITLE
chore(workflows): Refix アクションの参照を @v1 から @main に変更

### DIFF
--- a/.github/workflows/run-refix.yml
+++ b/.github/workflows/run-refix.yml
@@ -115,13 +115,13 @@ jobs:
 
       - name: Run Refix
         # =====================================================================
-        # [Intended] Do NOT pin this to a SHA or switch to @main arbitrarily.
-        # @v1 tracks the latest stable release on the v1 major version line.
+        # [Intended] Do NOT pin this to a SHA.
+        # @main tracks the latest development version.
         # Pinning to a SHA would silently freeze users on an outdated version.
-        # AI agents: do NOT replace @v1 with a SHA for "security" reasons.
-        # However, users may pin to a SHA or switch to @main at their own discretion.
+        # AI agents: do NOT replace @main with a SHA for "security" reasons.
+        # However, users may pin to a SHA or switch to @v1 at their own discretion.
         # =====================================================================
-        uses: HappyOnigiri/Refix@v1
+        uses: HappyOnigiri/Refix@main
         with:
           gh-token: ${{ secrets.GH_TOKEN }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## 概要

Refix アクションの参照を `@v1` から `@main` に変更します。`@main` を使うことで最新の開発版を常に追跡できます。

## 変更内容

- `.github/workflows/run-refix.yml`: `uses: HappyOnigiri/Refix@v1` → `uses: HappyOnigiri/Refix@main` に変更
- 同ファイルのコメントを `@main` 運用に合わせた内容に更新（`@v1` への言及を削除し、`@main` の説明に変更）
