### PR TITLE
chore(workflows): release-please から ShareSettings Composite Action に移行

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,22 @@
+name: Publish Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: HappyOnigiri/ShareSettings/actions/publish-release@main
+        with:
+          branch: ${{ github.event.pull_request.head.ref }}
+          pr-body: ${{ github.event.pull_request.body }}
+          github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -1,0 +1,17 @@
+name: Release Reminder
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: HappyOnigiri/ShareSettings/actions/release-reminder@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 1.3.0)"
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ inputs.version }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: HappyOnigiri/ShareSettings/actions/prepare-release@main
+        with:
+          version: ${{ inputs.version }}
+          version-bump-type: npm
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary

- release-please ベースのワークフローを廃止
- `release.yml` / `publish-release.yml` / `release-reminder.yml` を新規作成
- 手動 `workflow_dispatch` でリリースを制御できるようになる

## Test plan

- [ ] `workflow_dispatch` でリリース PR が正常に作成されることを確認
- [ ] リリース PR をマージし、タグ・GitHub Release が作成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * リリースプロセスの自動化ワークフローを導入しました。リリースブランチがメインブランチにマージされると、自動的にリリースを公開します。また、PRが作成または更新されるとリリースリマインダーが表示されます。さらに手動でリリース準備をトリガーすることも可能になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->