### PR TITLE
chore: CLAUDE.mdを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,6 @@ out
 /.cursor
 /.agent
 /.claude
+
+# AI Rules
+/CLAUDE.md


### PR DESCRIPTION
## 概要

`CLAUDE.md` は Claude Code のプロジェクト固有設定ファイルであり、各開発者環境に合わせたローカル設定を記述するもの。リポジトリに含めるべきでないため `.gitignore` に追加する。

## 変更内容

- `.gitignore` に `/CLAUDE.md` を追加（Claude Code のローカル設定ファイルを追跡対象外に）
