### PR TITLE
fix: CI環境でのCorepackダウンロードプロンプトブロックを解消

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,5 @@ html-fix-diff:
 setup:
 	curl -fsSL https://raw.githubusercontent.com/HappyOnigiri/ShareSettings/main/SyncRule/run.sh | bash
 	corepack enable
-	pnpm install --frozen-lockfile
+	COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack prepare pnpm --activate
+	COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm install --frozen-lockfile


### PR DESCRIPTION
## 概要

Refix などの CI 環境で \`make setup\` を実行すると、Corepack がダウンロード前に確認プロンプトを出し、非インタラクティブ環境では exit 1 で失敗する問題を修正。

## 変更内容

- \`corepack prepare pnpm --activate\` を追加（\`COREPACK_ENABLE_DOWNLOAD_PROMPT=0\` 付き）
- \`pnpm install --frozen-lockfile\` に \`COREPACK_ENABLE_DOWNLOAD_PROMPT=0\` を付与

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * セットアップ処理の改善により、インストール時の安定性と信頼性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->