### PR TITLE
chore: remove wrong license data and redundant SEO info

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,83 +133,6 @@
       }
     </script>
 
-    <!-- JSON-LD Structured Data: FAQPage -->
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "FAQPage",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "What is Pixel Refiner?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Pixel Refiner is a free online tool for optimizing AI-generated pixel art. It features anti-aliasing removal, background transparency, and automatic grid detection to create production-ready game assets."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Are images uploaded to a server?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "No, all image processing is done locally within your browser. Your images are never sent to a server, ensuring complete privacy."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "What image formats are supported?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "We support common browser-compatible formats like PNG, JPEG, GIF, and WebP. The output is in PNG format, which supports transparency."
-            }
-          },
-          {
-            "@type": "Question",
-            "name": "Is it free to use?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Yes, it is completely free to use. No registration is required."
-            }
-          }
-        ]
-      }
-    </script>
-
-    <!-- JSON-LD Structured Data: HowTo -->
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "HowTo",
-        "name": "How to optimize AI pixel art for game assets",
-        "description": "Steps to remove anti-aliasing and background from AI-generated pixel art using Pixel Refiner.",
-        "step": [
-          {
-            "@type": "HowToStep",
-            "position": 1,
-            "name": "Upload Image",
-            "text": "Drag and drop your pixel art image or click to select a file."
-          },
-          {
-            "@type": "HowToStep",
-            "position": 2,
-            "name": "Run Processing",
-            "text": "Click the 'Process Image' button to automatically detect the grid, remove anti-aliasing, and make the background transparent."
-          },
-          {
-            "@type": "HowToStep",
-            "position": 3,
-            "name": "Download Result",
-            "text": "Check the result and click 'Download' to save the optimized PNG. You can also select the scaling factor."
-          }
-        ],
-        "totalTime": "PT30S",
-        "tool": {
-          "@type": "HowToTool",
-          "name": "Web Browser"
-        }
-      }
-    </script>
-
     <style>
       html,
       body {
@@ -1311,37 +1234,10 @@
         </div>
       </main>
 
-      <!-- SEO: Additional content for search engines (visually hidden) -->
-      <aside class="visually-hidden" aria-hidden="true">
-        <h2>Pixel Refiner Features</h2>
-        <ul>
-          <li>Automatically clean up AI-generated pixel art</li>
-          <li>Remove anti-aliasing for crisp pixel art</li>
-          <li>One-click background transparency</li>
-          <li>Automatic grid detection for optimal pixel size</li>
-          <li>Fully browser-based, images are not uploaded to server</li>
-          <li>Completely free and no registration required</li>
-          <li>High-quality PNG download, supports up to 32x upscaling</li>
-        </ul>
-        <h2>Recommended For</h2>
-        <ul>
-          <li>
-            Users who create pixel art with AI tools (Stable Diffusion,
-            Midjourney, etc.)
-          </li>
-          <li>Indie game developers needing sprite assets</li>
-          <li>People tired of manually removing anti-aliasing</li>
-          <li>
-            Those wanting to automate background transparency for game assets
-          </li>
-        </ul>
-      </aside>
-
       <footer class="app-footer">
         <div class="footer-content">
           <p>
-            &copy; 2026 Pixel Refiner. All rights reserved.
-            <span id="app-version" class="app-version"></span>
+            Pixel Refiner<span id="app-version" class="app-version"></span>
           </p>
           <div class="footer-links">
             <a
@@ -1362,25 +1258,7 @@
             >
               <img src="/logo_github.svg" alt="GitHub" width="20" height="20" />
             </a>
-            <span class="separator">|</span>
-            <span class="privacy-note" data-i18n="footer.privacy">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                style="vertical-align: middle; margin-right: 4px"
-              >
-                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-              </svg>
-              Images are processed safely within your browser
-            </span>
+
           </div>
         </div>
       </footer>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,83 @@
       }
     </script>
 
+    <!-- JSON-LD Structured Data: FAQPage -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is Pixel Refiner?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Pixel Refiner is a free online tool for optimizing AI-generated pixel art. It features anti-aliasing removal, background transparency, and automatic grid detection to create production-ready game assets."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are images uploaded to a server?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No, all image processing is done locally within your browser. Your images are never sent to a server, ensuring complete privacy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What image formats are supported?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "We support common browser-compatible formats like PNG, JPEG, GIF, and WebP. The output is in PNG format, which supports transparency."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is it free to use?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, it is completely free to use. No registration is required."
+            }
+          }
+        ]
+      }
+    </script>
+
+    <!-- JSON-LD Structured Data: HowTo -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "HowTo",
+        "name": "How to optimize AI pixel art for game assets",
+        "description": "Steps to remove anti-aliasing and background from AI-generated pixel art using Pixel Refiner.",
+        "step": [
+          {
+            "@type": "HowToStep",
+            "position": 1,
+            "name": "Upload Image",
+            "text": "Drag and drop your pixel art image or click to select a file."
+          },
+          {
+            "@type": "HowToStep",
+            "position": 2,
+            "name": "Run Processing",
+            "text": "Click the 'Process Image' button to automatically detect the grid, remove anti-aliasing, and make the background transparent."
+          },
+          {
+            "@type": "HowToStep",
+            "position": 3,
+            "name": "Download Result",
+            "text": "Check the result and click 'Download' to save the optimized PNG. You can also select the scaling factor."
+          }
+        ],
+        "totalTime": "PT30S",
+        "tool": {
+          "@type": "HowToTool",
+          "name": "Web Browser"
+        }
+      }
+    </script>
+
     <style>
       html,
       body {
@@ -1258,7 +1335,25 @@
             >
               <img src="/logo_github.svg" alt="GitHub" width="20" height="20" />
             </a>
-
+            <span class="separator">|</span>
+            <span class="privacy-note" data-i18n="footer.privacy">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                style="vertical-align: middle; margin-right: 4px"
+              >
+                <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+              </svg>
+              Images are processed safely within your browser
+            </span>
           </div>
         </div>
       </footer>

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -19,7 +19,7 @@ const resources = {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AIドット絵の最適化・背景透過ツール",
 		"app.description":
-			'ローカルでAI生成のドット絵を、<span class="text-highlight">素材</span>や<span class="text-highlight">アイコン</span>として使えるクオリティに。<br />' +
+			'AIで生成したドット絵を、<span class="text-highlight">素材</span>や<span class="text-highlight">アイコン</span>として使えるクオリティに。<br />' +
 			'<span class="text-highlight">アンチエイリアス除去</span>・<span class="text-highlight">背景透過</span>を数秒で完了します。',
 		"section.input": "入力画像",
 		"section.result": "処理結果",
@@ -210,13 +210,14 @@ const resources = {
 		"modal.eyedropper.instruction":
 			"画像内の背景にしたい色をクリックしてください",
 
-
+		// Footer
+		"footer.privacy": "画像はブラウザ内で安全に処理されます",
 	},
 	"zh-CN": {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AI 像素画优化与背景透明工具",
 		"app.description":
-			'本地将 AI 生成的像素画优化为可直接用于<span class="text-highlight">素材</span>和<span class="text-highlight">图标</span>的品质。<br />' +
+			'将 AI 生成的像素画优化为可直接用于<span class="text-highlight">素材</span>和<span class="text-highlight">图标</span>的品质。<br />' +
 			'数秒内完成<span class="text-highlight">抗锯齿清理</span>和<span class="text-highlight">背景透明化</span>。',
 		"section.input": "输入图片",
 		"section.result": "处理结果",
@@ -404,13 +405,14 @@ const resources = {
 		"modal.eyedropper.title": "选择背景色",
 		"modal.eyedropper.instruction": "点击图片中要作为背景的颜色",
 
-
+		// Footer
+		"footer.privacy": "图片会在浏览器内安全处理",
 	},
 	en: {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AI Pixel Art Optimizer & Background Remover",
 		"app.description":
-			'Locally optimize AI-generated pixel art into <span class="text-highlight">high-quality assets</span> and <span class="text-highlight">icons</span>.<br />' +
+			'Optimize AI-generated pixel art into <span class="text-highlight">high-quality assets</span> and <span class="text-highlight">icons</span>.<br />' +
 			'Complete <span class="text-highlight">anti-aliasing removal</span> and <span class="text-highlight">background transparency</span> in seconds.',
 		"section.input": "Input Image",
 		"section.result": "Result",
@@ -601,7 +603,8 @@ const resources = {
 		"modal.eyedropper.instruction":
 			"Click on the color in the image you want to set as background",
 
-
+		// Footer
+		"footer.privacy": "Images are processed safely within your browser",
 	},
 };
 

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -19,7 +19,7 @@ const resources = {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AIドット絵の最適化・背景透過ツール",
 		"app.description":
-			'AIで生成したドット絵を、<span class="text-highlight">素材</span>や<span class="text-highlight">アイコン</span>として使えるクオリティに。<br />' +
+			'ローカルでAI生成のドット絵を、<span class="text-highlight">素材</span>や<span class="text-highlight">アイコン</span>として使えるクオリティに。<br />' +
 			'<span class="text-highlight">アンチエイリアス除去</span>・<span class="text-highlight">背景透過</span>を数秒で完了します。',
 		"section.input": "入力画像",
 		"section.result": "処理結果",
@@ -210,14 +210,13 @@ const resources = {
 		"modal.eyedropper.instruction":
 			"画像内の背景にしたい色をクリックしてください",
 
-		// Footer
-		"footer.privacy": "画像はブラウザ内で安全に処理されます",
+
 	},
 	"zh-CN": {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AI 像素画优化与背景透明工具",
 		"app.description":
-			'将 AI 生成的像素画优化为可直接用于<span class="text-highlight">素材</span>和<span class="text-highlight">图标</span>的品质。<br />' +
+			'本地将 AI 生成的像素画优化为可直接用于<span class="text-highlight">素材</span>和<span class="text-highlight">图标</span>的品质。<br />' +
 			'数秒内完成<span class="text-highlight">抗锯齿清理</span>和<span class="text-highlight">背景透明化</span>。',
 		"section.input": "输入图片",
 		"section.result": "处理结果",
@@ -405,14 +404,13 @@ const resources = {
 		"modal.eyedropper.title": "选择背景色",
 		"modal.eyedropper.instruction": "点击图片中要作为背景的颜色",
 
-		// Footer
-		"footer.privacy": "图片会在浏览器内安全处理",
+
 	},
 	en: {
 		// UI Headings & Labels
 		"app.title": "Pixel Refiner | AI Pixel Art Optimizer & Background Remover",
 		"app.description":
-			'Optimize AI-generated pixel art into <span class="text-highlight">high-quality assets</span> and <span class="text-highlight">icons</span>.<br />' +
+			'Locally optimize AI-generated pixel art into <span class="text-highlight">high-quality assets</span> and <span class="text-highlight">icons</span>.<br />' +
 			'Complete <span class="text-highlight">anti-aliasing removal</span> and <span class="text-highlight">background transparency</span> in seconds.',
 		"section.input": "Input Image",
 		"section.result": "Result",
@@ -603,8 +601,7 @@ const resources = {
 		"modal.eyedropper.instruction":
 			"Click on the color in the image you want to set as background",
 
-		// Footer
-		"footer.privacy": "Images are processed safely within your browser",
+
 	},
 };
 


### PR DESCRIPTION
Everything looks fine, but currently the page is a bit flooded with AI text noise:

- removed "All rights reserved" (as for `LICENSE`(MIT))
- removed SEO that may considered as "Spam"
- removed random footer and moved to description