### PR TITLE
chore: fork PRでsecrets依存のCIをスキップ

### DIFF
--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   remind:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - uses: HappyOnigiri/ShareSettings/actions/release-reminder@main

--- a/.github/workflows/run-refix.yml
+++ b/.github/workflows/run-refix.yml
@@ -53,6 +53,7 @@ jobs:
   run-refix:
     # Dependabot の PR は secrets にアクセスできないため、Refix は実行できません。
     if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'dependabot[bot]' &&
       (github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && github.event.pull_request.state != 'closed'))


### PR DESCRIPTION
## 概要

fork からの PR で secrets にアクセスできず CI が失敗する問題を解消する。

## 変更内容

- `release-reminder` と `run-refix` の workflow に、fork PR ではジョブをスキップする条件を追加した。どちらも secrets (`GITHUB_TOKEN` の書き込み権限、`GH_TOKEN`、`CLAUDE_CODE_OAUTH_TOKEN`) が必要だが、GitHub のセキュリティ仕様により fork PR では secrets が渡されないため必ず失敗していた。
- `ci` workflow は secrets 不要のため変更なし。fork PR でも引き続き実行される。

## 動作確認

なし
