### PR TITLE
chore: Dependabot による依存関係の自動更新を有効化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 概要

Dependabot を有効化し、npm パッケージと GitHub Actions の依存関係を自動で最新に保てるようにする。

## 変更内容

- npm パッケージと GitHub Actions の2つのエコシステムに対して、週次で依存関係の更新 PR が自動作成されるようになる。
  セキュリティパッチや破壊的変更への追従が漏れにくくなる。

## 動作確認

なし
