### PR TITLE
fix: restore copyright notice in footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1314,7 +1314,10 @@
       <footer class="app-footer">
         <div class="footer-content">
           <p>
-            Pixel Refiner<span id="app-version" class="app-version"></span>
+            Pixel Refiner &copy; 2026<span
+              id="app-version"
+              class="app-version"
+            ></span>
           </p>
           <div class="footer-links">
             <a


### PR DESCRIPTION
## Summary
- Restore `© 2026` copyright notice that was removed in #34
- `All rights reserved` is intentionally kept removed (incompatible with MIT license)

## Context
Follow-up to #34. The copyright symbol and year are compatible with the MIT license and should be retained.