### PR TITLE
release: v0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixel-refiner",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Bug Fixes

- [#45](https://github.com/HappyOnigiri/PixelRefiner/pull/45) fix: restore copyright notice in footer

## Maintenance

- [#35](https://github.com/HappyOnigiri/PixelRefiner/pull/35) chore: fork PRでsecrets依存のCIをスキップ
- [#36](https://github.com/HappyOnigiri/PixelRefiner/pull/36) chore: Dependabot による依存関係の自動更新を有効化
- [#37](https://github.com/HappyOnigiri/PixelRefiner/pull/37) chore(deps): bump actions/setup-node from 4 to 6
- [#38](https://github.com/HappyOnigiri/PixelRefiner/pull/38) chore(deps): bump pnpm/action-setup from 4 to 6
- [#39](https://github.com/HappyOnigiri/PixelRefiner/pull/39) chore(deps): bump actions/checkout from 4 to 7
- [#40](https://github.com/HappyOnigiri/PixelRefiner/pull/40) chore(deps-dev): bump vitest from 4.1.2 to 4.1.9
- [#41](https://github.com/HappyOnigiri/PixelRefiner/pull/41) chore(deps): bump @vercel/analytics from 1.6.1 to 2.0.1
- [#42](https://github.com/HappyOnigiri/PixelRefiner/pull/42) chore(deps-dev): bump prettier from 3.8.1 to 3.9.4
- [#34](https://github.com/HappyOnigiri/PixelRefiner/pull/34) chore: remove wrong license data and redundant SEO info


