### PR TITLE
feat: 処理診断メタデータと警告モデルを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  pull_request: {}
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -21,6 +21,7 @@ import { ImageComparer } from "./compare";
 import { i18n, type Language } from "./i18n";
 import { drawRawImageToCanvas, imageToRawImage } from "./io";
 import { PresetManager } from "./presets";
+import { translateProcessingWarnings } from "./processing-warnings";
 import { ResultViewer } from "./result-viewer";
 import { ImageSession } from "./session";
 
@@ -299,6 +300,24 @@ const showInfo = (message: string) => {
 			{ once: true },
 		);
 	}, 3000);
+};
+
+const showWarning = (message: string) => {
+	const toast = document.createElement("div");
+	toast.className = "warning-toast";
+	toast.setAttribute("role", "status");
+	const text = document.createElement("span");
+	text.textContent = message;
+	toast.appendChild(text);
+	document.body.appendChild(toast);
+
+	requestAnimationFrame(() => toast.classList.add("show"));
+	setTimeout(() => {
+		toast.classList.remove("show");
+		toast.addEventListener("transitionend", () => toast.remove(), {
+			once: true,
+		});
+	}, 5000);
 };
 
 const STORAGE_KEY = "pixel-refiner-display-settings";
@@ -987,6 +1006,7 @@ export const initApp = (): void => {
 				extractedPalette,
 				compareBefore,
 				compareBeforeSanitized,
+				analysis,
 			} = await processor.process(currentImage, {
 				detectionQuantStep,
 				forcePixelsW,
@@ -1097,6 +1117,9 @@ export const initApp = (): void => {
 				updateGrid();
 			});
 			els.outputPanel.classList.add("has-image");
+			if (analysis.warnings.length > 0) {
+				showWarning(translateProcessingWarnings(analysis.warnings).join("\n"));
+			}
 			// els.outputSize.textContent = `${resultImage.width}x${resultImage.height} px`; // Handled by ResultViewer
 
 			// If background removal method is corner-based, reflect extracted color in UI

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -187,6 +187,17 @@ const resources = {
 		"error.process_failed": "処理失敗",
 		"error.load_failed": "読み込み失敗",
 		"info.grid_updated": "グリッドサイズを {w}x{h} に更新しました",
+		"warning.low_grid_confidence":
+			"グリッド判定の信頼度が低いため、結果を確認してください。",
+		"warning.background_uncertain": "背景の判定が不確かです。",
+		"warning.content_loss_risk":
+			"処理によって内容が大きく失われた可能性があります。",
+		"warning.one_axis_detection_failed":
+			"片方向のグリッドを検出できませんでした。",
+		"warning.extreme_output_size": "出力サイズが非常に大きくなっています。",
+		"warning.no_content": "処理対象の内容を検出できませんでした。",
+		"warning.fallback_to_preserve": "安全のため元のサイズを維持しました。",
+		"warning.unknown": "不明な処理警告です（{code}）。",
 
 		"error.palette_limit":
 			"警告: 画像には{count}色が含まれています。パレットは256色に制限されます。",
@@ -384,6 +395,14 @@ const resources = {
 		"error.process_failed": "处理失败",
 		"error.load_failed": "加载失败",
 		"info.grid_updated": "网格尺寸已更新为 {w}x{h}",
+		"warning.low_grid_confidence": "网格判断可信度较低，请检查结果。",
+		"warning.background_uncertain": "背景判断存在不确定性。",
+		"warning.content_loss_risk": "处理可能导致大量内容丢失。",
+		"warning.one_axis_detection_failed": "无法检测一个方向的网格。",
+		"warning.extreme_output_size": "输出尺寸非常大。",
+		"warning.no_content": "未检测到可处理的内容。",
+		"warning.fallback_to_preserve": "为安全起见，已保留原始尺寸。",
+		"warning.unknown": "未知处理警告（{code}）。",
 
 		"error.palette_limit": "警告：图片包含{count}种颜色。调色板将限制为256色。",
 		"error.no_processed_images": "没有可下载的已处理图片。",
@@ -580,6 +599,18 @@ const resources = {
 		"error.process_failed": "Processing failed",
 		"error.load_failed": "Loading failed",
 		"info.grid_updated": "Grid updated to {w}x{h}",
+		"warning.low_grid_confidence":
+			"Grid confidence is low. Please check the result.",
+		"warning.background_uncertain": "The background detection is uncertain.",
+		"warning.content_loss_risk":
+			"Processing may have removed a large amount of content.",
+		"warning.one_axis_detection_failed":
+			"The grid could not be detected on one axis.",
+		"warning.extreme_output_size": "The output size is extremely large.",
+		"warning.no_content": "No processable content was detected.",
+		"warning.fallback_to_preserve":
+			"The original size was preserved for safety.",
+		"warning.unknown": "Unknown processing warning ({code}).",
 
 		"error.palette_limit":
 			"Warning: The image contains {count} colors. Palette will be limited to 256 colors.",

--- a/src/browser/processing-warnings.test.ts
+++ b/src/browser/processing-warnings.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { i18n, type Language } from "./i18n";
+import { translateProcessingWarning } from "./processing-warnings";
+
+const originalLanguage: Language = i18n.currentLang;
+
+afterEach(() => {
+	i18n.currentLang = originalLanguage;
+});
+
+describe("translateProcessingWarning", () => {
+	it("translates known warning codes", () => {
+		i18n.currentLang = "en";
+		expect(translateProcessingWarning("CONTENT_LOSS_RISK")).toContain(
+			"removed",
+		);
+	});
+
+	it("falls back safely for warning codes added by newer workers", () => {
+		i18n.currentLang = "en";
+		expect(translateProcessingWarning("FUTURE_WARNING")).toBe(
+			"Unknown processing warning (FUTURE_WARNING).",
+		);
+	});
+});

--- a/src/browser/processing-warnings.ts
+++ b/src/browser/processing-warnings.ts
@@ -1,0 +1,26 @@
+import { i18n } from "./i18n";
+
+export const translateProcessingWarning = (code: string): string => {
+	switch (code) {
+		case "LOW_GRID_CONFIDENCE":
+			return i18n.t("warning.low_grid_confidence");
+		case "BACKGROUND_UNCERTAIN":
+			return i18n.t("warning.background_uncertain");
+		case "CONTENT_LOSS_RISK":
+			return i18n.t("warning.content_loss_risk");
+		case "ONE_AXIS_DETECTION_FAILED":
+			return i18n.t("warning.one_axis_detection_failed");
+		case "EXTREME_OUTPUT_SIZE":
+			return i18n.t("warning.extreme_output_size");
+		case "NO_CONTENT":
+			return i18n.t("warning.no_content");
+		case "FALLBACK_TO_PRESERVE":
+			return i18n.t("warning.fallback_to_preserve");
+		default:
+			return i18n.t("warning.unknown", { code });
+	}
+};
+
+export const translateProcessingWarnings = (
+	codes: readonly string[],
+): string[] => codes.map(translateProcessingWarning);

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -971,8 +971,9 @@ select:focus {
   background: rgba(255, 255, 255, 0.05);
 }
 
-/* Error Toast */
-.error-toast {
+/* Error and processing warning toasts */
+.error-toast,
+.warning-toast {
   position: fixed;
   bottom: 32px;
   left: 50%;
@@ -993,7 +994,13 @@ select:focus {
   pointer-events: none;
 }
 
-.error-toast.show {
+.warning-toast {
+	background: #b45309;
+	white-space: pre-line;
+}
+
+.error-toast.show,
+.warning-toast.show {
   transform: translateX(-50%) translateY(0);
   opacity: 1;
 }

--- a/src/core/detector.ts
+++ b/src/core/detector.ts
@@ -598,8 +598,12 @@ export const detectGrid = (
 			cropH: fOutH * fCellH,
 			outW: fOutW,
 			outH: fOutH,
-			scoreX: fallbackX.score,
-			scoreY: fallbackY.score,
+			scoreX: finalX?.score,
+			scoreY: finalY?.score,
+			detectionFailedAxes: [
+				...(finalX ? [] : (["x"] as const)),
+				...(finalY ? [] : (["y"] as const)),
+			],
 		};
 	}
 

--- a/src/core/processing-analysis.test.ts
+++ b/src/core/processing-analysis.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { RawImage } from "../shared/types";
+import { processImage } from "./processor";
+
+const solidImage = (
+	width: number,
+	height: number,
+	rgba: readonly [number, number, number, number],
+): RawImage => {
+	const data = new Uint8ClampedArray(width * height * 4);
+	for (let i = 0; i < data.length; i += 4) {
+		data[i] = rgba[0];
+		data[i + 1] = rgba[1];
+		data[i + 2] = rgba[2];
+		data[i + 3] = rgba[3];
+	}
+	return { width, height, data };
+};
+
+const stripedImage = (): RawImage => {
+	const width = 32;
+	const height = 32;
+	const data = new Uint8ClampedArray(width * height * 4);
+	for (let y = 0; y < height; y += 1) {
+		for (let x = 0; x < width; x += 1) {
+			const value = Math.floor(x / 4) % 2 === 0 ? 0 : 255;
+			const i = (y * width + x) * 4;
+			data[i] = value;
+			data[i + 1] = value;
+			data[i + 2] = value;
+			data[i + 3] = 255;
+		}
+	}
+	return { width, height, data };
+};
+
+describe("processing analysis", () => {
+	it("reports convert and preserve routes", () => {
+		const image = solidImage(16, 16, [20, 40, 60, 255]);
+		const converted = processImage(image, {
+			forcePixelsW: 4,
+			forcePixelsH: 4,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+			postRemoveBackground: false,
+		});
+		const preserved = processImage(image, {
+			enableGridDetection: false,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+		});
+
+		expect(converted.analysis.route).toBe("convert");
+		expect(converted.analysis.confidence).toBe(1);
+		expect(preserved.analysis.route).toBe("preserve");
+		expect(preserved.analysis.gridCandidates[0].method).toBe("grid-disabled");
+	});
+
+	it("exposes the selected grid and ranked candidates", () => {
+		const image = stripedImage();
+		const processed = processImage(image, {
+			autoGridFromTrimmed: true,
+			fastAutoGridFromTrimmed: true,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+			postRemoveBackground: false,
+			trimToContent: false,
+		});
+
+		expect(processed.analysis.route).toBe("refine");
+		expect(processed.analysis.selectedCandidateIndex).toBe(0);
+		expect(processed.analysis.gridCandidates.length).toBeGreaterThan(1);
+		expect(processed.analysis.gridCandidates[0]).toMatchObject({
+			outW: processed.grid.outW,
+			outH: processed.grid.outH,
+			totalScore: processed.grid.score,
+		});
+		expect(
+			processed.analysis.gridCandidates.every(
+				(candidate) => candidate.confidence >= 0 && candidate.confidence <= 1,
+			),
+		).toBe(true);
+	});
+
+	it("warns when detection succeeds on only one axis", () => {
+		const processed = processImage(stripedImage(), {
+			autoGridFromTrimmed: false,
+			backgroundMask: false,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+			postRemoveBackground: false,
+			trimToContent: false,
+		});
+
+		expect(processed.grid.detectionFailedAxes).toEqual(["y"]);
+		expect(processed.analysis.warnings).toContain("ONE_AXIS_DETECTION_FAILED");
+	});
+
+	it("warns about content loss and empty input", () => {
+		const removed = processImage(solidImage(8, 8, [255, 255, 255, 255]), {
+			enableGridDetection: false,
+			preRemoveBackground: true,
+			bgRemovalScope: "all",
+			backgroundTolerance: 0,
+		});
+		const empty = processImage(solidImage(8, 8, [0, 0, 0, 0]), {
+			enableGridDetection: false,
+			preRemoveBackground: false,
+			bgRemovalScope: "off",
+		});
+
+		expect(removed.analysis.contentLossRatio).toBe(1);
+		expect(removed.analysis.warnings).toContain("CONTENT_LOSS_RISK");
+		expect(empty.analysis.warnings).toContain("NO_CONTENT");
+	});
+
+	it("is structured-clone compatible for worker transport", () => {
+		const processed = processImage(solidImage(4, 4, [0, 0, 0, 255]), {
+			enableGridDetection: false,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+		});
+
+		const cloned = structuredClone(processed);
+		expect(cloned.analysis).toEqual(processed.analysis);
+		expect(cloned.result.data).toBeInstanceOf(Uint8ClampedArray);
+	});
+});

--- a/src/core/processing-analysis.test.ts
+++ b/src/core/processing-analysis.test.ts
@@ -114,6 +114,58 @@ describe("processing analysis", () => {
 		expect(empty.analysis.warnings).toContain("NO_CONTENT");
 	});
 
+	it("does not treat transparent padding as content loss", () => {
+		const processed = processImage(solidImage(10, 4, [255, 0, 0, 255]), {
+			enableGridDetection: false,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+			makeSquare: true,
+		});
+
+		expect(processed.result.width).toBe(10);
+		expect(processed.result.height).toBe(10);
+		expect(processed.analysis.contentLossRatio).toBe(0);
+		expect(processed.analysis.warnings).not.toContain("CONTENT_LOSS_RISK");
+	});
+
+	it("keeps all alternatives in the detector coordinate space", () => {
+		const stripes = stripedImage();
+		const padded: RawImage = {
+			width: 40,
+			height: 32,
+			data: new Uint8ClampedArray(40 * 32 * 4),
+		};
+		for (let y = 0; y < stripes.height; y += 1) {
+			const sourceStart = y * stripes.width * 4;
+			const targetStart = (y * padded.width + 4) * 4;
+			padded.data.set(
+				stripes.data.subarray(sourceStart, sourceStart + stripes.width * 4),
+				targetStart,
+			);
+		}
+		const processed = processImage(padded, {
+			autoGridFromTrimmed: true,
+			fastAutoGridFromTrimmed: true,
+			bgRemovalScope: "off",
+			preRemoveBackground: false,
+			postRemoveBackground: false,
+			trimToContent: true,
+			makeSquare: true,
+		});
+
+		const candidates = processed.analysis.gridCandidates;
+		expect(candidates.length).toBeGreaterThan(1);
+		expect(candidates[0].outW).not.toBe(processed.grid.outW);
+		expect(
+			new Set(
+				candidates.map(
+					(candidate) =>
+						`${candidate.outW}:${candidate.outH}:${candidate.totalScore}`,
+				),
+			).size,
+		).toBe(candidates.length);
+	});
+
 	it("is structured-clone compatible for worker transport", () => {
 		const processed = processImage(solidImage(4, 4, [0, 0, 0, 255]), {
 			enableGridDetection: false,

--- a/src/core/processor.test.ts
+++ b/src/core/processor.test.ts
@@ -424,7 +424,7 @@ describe("processImage", () => {
 
 		// [Policy] Grid detection can exceed Vitest's 5s default under shared CI runner load.
 		it("should match expected image perfectly (size and pixels)", () => {
-			const { result, grid } = processImage(img, {
+			const { result, grid, analysis } = processImage(img, {
 				detectionQuantStep: 64,
 				preRemoveBackground: true,
 				postRemoveBackground: true,
@@ -452,6 +452,7 @@ describe("processImage", () => {
 			expect(result.height).toBe(expected.height);
 			expect(grid.outW).toBe(88);
 			expect(grid.outH).toBe(61);
+			expect(analysis.warnings).not.toContain("LOW_GRID_CONFIDENCE");
 
 			expectSameImage(result, expected, getExpectPath("auto_grid_detection"));
 		}, 15_000);

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -327,6 +327,7 @@ const toCandidateReport = (
 const createProcessingAnalysis = (
 	source: RawImage,
 	result: RawImage,
+	comparisonBefore: RawImage,
 	grid: PixelGrid,
 	route: ProcessingRoute,
 	method: string,
@@ -345,7 +346,7 @@ const createProcessingAnalysis = (
 		}
 	}
 
-	const before = foregroundRatio(source, alphaThreshold);
+	const before = foregroundRatio(comparisonBefore, alphaThreshold);
 	const after = foregroundRatio(result, alphaThreshold);
 	const contentLossRatio =
 		before === 0 ? 0 : clampUnit((before - after) / before);
@@ -1988,6 +1989,7 @@ export const processImage = (
 		const analysis = createProcessingAnalysis(
 			img,
 			finalResult,
+			compareBeforeSanitized,
 			finalGridForForce,
 			"convert",
 			"forced-size",
@@ -2144,6 +2146,7 @@ export const processImage = (
 		const analysis = createProcessingAnalysis(
 			img,
 			finalResult,
+			compareBeforeSanitized,
 			finalGridForNoGrid,
 			"preserve",
 			"grid-disabled",
@@ -2307,6 +2310,9 @@ export const processImage = (
 	}
 
 	const downsampleStart = performance.now();
+	// [Intended] Candidate diagnostics stay in the detector's shared coordinate
+	// space while the selected output grid may later be trimmed or padded.
+	const diagnosticGrid = grid;
 	const down = downsample(working, grid, o.sampleWindow);
 	log(
 		`Downsampling done in ${(performance.now() - downsampleStart).toFixed(2)}ms`,
@@ -2559,7 +2565,8 @@ export const processImage = (
 	const analysis = createProcessingAnalysis(
 		img,
 		finalResult,
-		trimmedGrid,
+		compareBeforeSanitized,
+		diagnosticGrid,
 		"refine",
 		gridMethod,
 		trimAlphaThreshold,

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -352,12 +352,8 @@ const createProcessingAnalysis = (
 		before === 0 ? 0 : clampUnit((before - after) / before);
 	const warnings: ProcessingWarningCode[] = [];
 	if (before === 0) warnings.push("NO_CONTENT");
-	if (
-		route === "refine" &&
-		selected.confidence < PROCESS_ANALYSIS_THRESHOLDS.lowGridConfidence
-	) {
-		warnings.push("LOW_GRID_CONFIDENCE");
-	}
+	// [Intended] Confidence remains diagnostic until PRF-100 calibrates scores
+	// across the different grid-detection methods.
 	if (grid.detectionFailedAxes?.length === 1) {
 		warnings.push("ONE_AXIS_DETECTION_FAILED");
 	}

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -1,6 +1,7 @@
 import {
 	clampInt,
 	clampOptionalInt,
+	PROCESS_ANALYSIS_THRESHOLDS,
 	PROCESS_DEFAULTS,
 	PROCESS_RANGES,
 	RETRO_PALETTES,
@@ -12,9 +13,16 @@ import type {
 	OutlineStyle,
 	PixelData,
 	PixelGrid,
+	ProcessingAnalysis,
+	ProcessingRoute,
+	ProcessingWarningCode,
+	ProcessResult,
 	RawImage,
 	RGB,
 } from "../shared/types";
+
+export type { ProcessResult } from "../shared/types";
+
 import { type DetectOptions, detectGrid } from "./detector";
 import { floodFillTransparent } from "./floodfill";
 import { applyOutline } from "./outline";
@@ -255,21 +263,123 @@ const cropRawImageNearestFromGrid = (
 	return resizeRawImageNearest(img, cropX, cropY, cropW, cropH, cropW, cropH);
 };
 
-export type ProcessResult = {
-	result: RawImage;
-	grid: PixelGrid;
-	extractedPalette: RGB[];
-	/**
-	 * Comparison view "before" image.
-	 * This is the original image normalized to the same output geometry (downsample + trimming + padding)
-	 * as `result`, so it aligns pixel-perfect in the comparison slider.
-	 */
-	compareBefore: RawImage;
-	/**
-	 * Comparison view "before" image, but sanitized using the same downsample/median sampling
-	 * settings (grid detection + color sampling) as the processing pipeline.
-	 */
-	compareBeforeSanitized: RawImage;
+const clampUnit = (value: number): number => Math.min(1, Math.max(0, value));
+
+const foregroundRatio = (img: RawImage, alphaThreshold: number): number => {
+	const pixelCount = img.width * img.height;
+	if (pixelCount === 0) return 0;
+	let foregroundCount = 0;
+	for (let i = 3; i < img.data.length; i += 4) {
+		if (img.data[i] >= alphaThreshold) foregroundCount += 1;
+	}
+	return foregroundCount / pixelCount;
+};
+
+const getAxisAgreement = (grid: PixelGrid): number => {
+	if (grid.detectionFailedAxes && grid.detectionFailedAxes.length > 0) return 0;
+	if (grid.scoreX === undefined || grid.scoreY === undefined) return 1;
+	const denominator = Math.abs(grid.scoreX) + Math.abs(grid.scoreY) + 1;
+	return clampUnit(1 - Math.abs(grid.scoreX - grid.scoreY) / denominator);
+};
+
+const getGridConfidence = (grid: PixelGrid, route: ProcessingRoute): number => {
+	if (route !== "refine") return 1;
+	const scoreConfidence =
+		1 /
+		(1 + Math.max(0, grid.score) / PROCESS_ANALYSIS_THRESHOLDS.gridScoreScale);
+	return clampUnit(scoreConfidence * getAxisAgreement(grid));
+};
+
+const toCandidateReport = (
+	grid: PixelGrid,
+	source: RawImage,
+	route: ProcessingRoute,
+	method: string,
+) => {
+	const outW =
+		grid.outW ??
+		Math.max(1, Math.floor((source.width - grid.offsetX) / grid.cellW));
+	const outH =
+		grid.outH ??
+		Math.max(1, Math.floor((source.height - grid.offsetY) / grid.cellH));
+	const cropX = grid.cropX ?? grid.offsetX;
+	const cropY = grid.cropY ?? grid.offsetY;
+	const cropW = grid.cropW ?? outW * grid.cellW;
+	const cropH = grid.cropH ?? outH * grid.cellH;
+	const axisAgreement = getAxisAgreement(grid);
+	const { candidates: _candidates, ...reportGrid } = grid;
+
+	return {
+		grid: reportGrid,
+		outW,
+		outH,
+		cropX,
+		cropY,
+		cropW,
+		cropH,
+		method,
+		totalScore: grid.score,
+		confidence: getGridConfidence(grid, route),
+		subscores: { axisAgreement },
+	};
+};
+
+const createProcessingAnalysis = (
+	source: RawImage,
+	result: RawImage,
+	grid: PixelGrid,
+	route: ProcessingRoute,
+	method: string,
+	alphaThreshold: number,
+): ProcessingAnalysis => {
+	const selected = toCandidateReport(grid, source, route, method);
+	const gridCandidates = [selected];
+	if (grid.candidates) {
+		for (const candidate of grid.candidates) {
+			const report = toCandidateReport(candidate, source, route, method);
+			const isSelected =
+				report.outW === selected.outW &&
+				report.outH === selected.outH &&
+				report.totalScore === selected.totalScore;
+			if (!isSelected) gridCandidates.push(report);
+		}
+	}
+
+	const before = foregroundRatio(source, alphaThreshold);
+	const after = foregroundRatio(result, alphaThreshold);
+	const contentLossRatio =
+		before === 0 ? 0 : clampUnit((before - after) / before);
+	const warnings: ProcessingWarningCode[] = [];
+	if (before === 0) warnings.push("NO_CONTENT");
+	if (
+		route === "refine" &&
+		selected.confidence < PROCESS_ANALYSIS_THRESHOLDS.lowGridConfidence
+	) {
+		warnings.push("LOW_GRID_CONFIDENCE");
+	}
+	if (grid.detectionFailedAxes?.length === 1) {
+		warnings.push("ONE_AXIS_DETECTION_FAILED");
+	}
+	if (contentLossRatio > PROCESS_ANALYSIS_THRESHOLDS.contentLossRatio) {
+		warnings.push("CONTENT_LOSS_RISK");
+	}
+	if (
+		result.width > PROCESS_ANALYSIS_THRESHOLDS.extremeOutputDimension ||
+		result.height > PROCESS_ANALYSIS_THRESHOLDS.extremeOutputDimension
+	) {
+		warnings.push("EXTREME_OUTPUT_SIZE");
+	}
+
+	return {
+		route,
+		confidence: selected.confidence,
+		warnings,
+		gridCandidates,
+		selectedCandidateIndex: 0,
+		foregroundRatioBefore: before,
+		foregroundRatioAfter: after,
+		contentLossRatio,
+	};
 };
 
 export type ProcessOptions = DetectOptions & {
@@ -1875,12 +1985,22 @@ export const processImage = (
 			`Total processing time: ${(performance.now() - startTime).toFixed(2)}ms`,
 		);
 		const extracted = extractUsedColors(finalResult);
+		const analysis = createProcessingAnalysis(
+			img,
+			finalResult,
+			finalGridForForce,
+			"convert",
+			"forced-size",
+			trimAlphaThreshold,
+		);
+		log("Processing analysis", analysis);
 		return {
 			result: finalResult,
 			grid: finalGridForForce,
 			extractedPalette: extracted,
 			compareBefore,
 			compareBeforeSanitized,
+			analysis,
 		};
 	}
 
@@ -2021,12 +2141,22 @@ export const processImage = (
 			`Total processing time: ${(performance.now() - startTime).toFixed(2)}ms`,
 		);
 
+		const analysis = createProcessingAnalysis(
+			img,
+			finalResult,
+			finalGridForNoGrid,
+			"preserve",
+			"grid-disabled",
+			trimAlphaThreshold,
+		);
+		log("Processing analysis", analysis);
 		return {
 			result: finalResult,
 			grid: finalGridForNoGrid,
 			extractedPalette: extracted,
 			compareBefore,
 			compareBeforeSanitized,
+			analysis,
 		};
 	}
 
@@ -2088,6 +2218,7 @@ export const processImage = (
 	}
 
 	let grid: PixelGrid | null = null;
+	let gridMethod = "detect-grid";
 
 	if (autoGridFromTrimmed && maskedForDebugOrAuto) {
 		log("Auto grid from trimmed mode");
@@ -2120,6 +2251,9 @@ export const processImage = (
 				est,
 			);
 			if (est) {
+				gridMethod = o.fastAutoGridFromTrimmed
+					? "trimmed-reconstruction-fast"
+					: "trimmed-reconstruction";
 				// NOTE:
 				// - Even when trimming is OFF, we want to use the "estimated grid from content BBox" (to prevent crushing).
 				// - However, trimming OFF just leaves background (margins), so apply downsampling to the whole image (working).
@@ -2422,11 +2556,21 @@ export const processImage = (
 	log(`Total processing time: ${(performance.now() - startTime).toFixed(2)}ms`);
 
 	const extracted = extractUsedColors(finalResult);
+	const analysis = createProcessingAnalysis(
+		img,
+		finalResult,
+		trimmedGrid,
+		"refine",
+		gridMethod,
+		trimAlphaThreshold,
+	);
+	log("Processing analysis", analysis);
 	return {
 		result: finalResult,
 		grid: trimmedGrid,
 		extractedPalette: extracted,
 		compareBefore,
 		compareBeforeSanitized,
+		analysis,
 	};
 };

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -1,6 +1,6 @@
 import { expose } from "comlink";
-import type { RawImage } from "../shared/types";
-import type { ProcessOptions, ProcessResult } from "./processor";
+import type { ProcessResult, RawImage } from "../shared/types";
+import type { ProcessOptions } from "./processor";
 import { processImage } from "./processor";
 
 export type ProcessorWorker = {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -31,7 +31,6 @@ export const PROCESS_RANGES = {
 } as const satisfies Record<string, IntRange | RGB>;
 
 export const PROCESS_ANALYSIS_THRESHOLDS = {
-	lowGridConfidence: 0.35,
 	contentLossRatio: 0.5,
 	gridScoreScale: 16,
 	extremeOutputDimension: 4096,

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -30,6 +30,13 @@ export const PROCESS_RANGES = {
 	outlineColor: { r: 255, g: 255, b: 255 }, // Default white
 } as const satisfies Record<string, IntRange | RGB>;
 
+export const PROCESS_ANALYSIS_THRESHOLDS = {
+	lowGridConfidence: 0.35,
+	contentLossRatio: 0.5,
+	gridScoreScale: 16,
+	extremeOutputDimension: 4096,
+} as const;
+
 export const RETRO_PALETTES: Record<
 	string,
 	{ name: string; colors: string[] }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,8 @@ export type RawImage = {
 
 export type Pixel = [number, number, number, number] | Uint8ClampedArray;
 
+export type Axis = "x" | "y";
+
 export type PixelGrid = {
 	cellW: number;
 	cellH: number;
@@ -21,9 +23,8 @@ export type PixelGrid = {
 	scoreX?: number;
 	scoreY?: number;
 	candidates?: PixelGrid[];
+	detectionFailedAxes?: Axis[];
 };
-
-export type Axis = "x" | "y";
 
 export interface RGB {
 	r: number; // 0-255
@@ -63,3 +64,70 @@ export interface Palette {
 	name: string;
 	colors: RGB[];
 }
+
+export type ProcessingRoute = "refine" | "convert" | "preserve";
+
+export type InputClassification =
+	| "native-pixel"
+	| "scaled-pixel"
+	| "soft-pixel"
+	| "continuous"
+	| "uncertain";
+
+export type ProcessingWarningCode =
+	| "LOW_GRID_CONFIDENCE"
+	| "BACKGROUND_UNCERTAIN"
+	| "CONTENT_LOSS_RISK"
+	| "ONE_AXIS_DETECTION_FAILED"
+	| "EXTREME_OUTPUT_SIZE"
+	| "NO_CONTENT"
+	| "FALLBACK_TO_PRESERVE";
+
+export type GridCandidateSubscores = {
+	periodicity: number;
+	edgeAlignment: number;
+	reconstruction: number;
+	complexity: number;
+	coverage: number;
+	axisAgreement: number;
+};
+
+export type GridCandidateReport = {
+	grid: PixelGrid;
+	angle?: number;
+	outW: number;
+	outH: number;
+	cropX: number;
+	cropY: number;
+	cropW: number;
+	cropH: number;
+	method: string;
+	totalScore: number;
+	/** A relative 0-1 comparison indicator, not a calibrated probability. */
+	confidence: number;
+	subscores?: Partial<GridCandidateSubscores>;
+};
+
+export type ProcessingAnalysis = {
+	classification?: InputClassification;
+	route: ProcessingRoute;
+	/** A relative 0-1 comparison indicator, not a calibrated probability. */
+	confidence: number;
+	warnings: ProcessingWarningCode[];
+	gridCandidates: GridCandidateReport[];
+	selectedCandidateIndex?: number;
+	foregroundRatioBefore?: number;
+	foregroundRatioAfter?: number;
+	contentLossRatio?: number;
+};
+
+export type ProcessResult = {
+	result: RawImage;
+	grid: PixelGrid;
+	extractedPalette: RGB[];
+	/** Original image normalized to the output geometry for comparison. */
+	compareBefore: RawImage;
+	/** Sanitized input normalized to the output geometry for comparison. */
+	compareBeforeSanitized: RawImage;
+	analysis: ProcessingAnalysis;
+};

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -151,6 +151,19 @@ export const runQualityCase = (
 			baselineImage === null ? null : `${caseDirectory}/baseline-diff.png`,
 		backgroundMask: `${caseDirectory}/background-mask.png`,
 	};
+	const selectedCandidate =
+		currentRun.analysis.gridCandidates[
+			currentRun.analysis.selectedCandidateIndex ?? 0
+		];
+	const rankedCandidates = [...currentRun.analysis.gridCandidates].sort(
+		(left, right) => left.totalScore - right.totalScore,
+	);
+	let topCandidates = rankedCandidates.slice(0, 3);
+	if (selectedCandidate && !topCandidates.includes(selectedCandidate)) {
+		topCandidates = [...topCandidates.slice(0, 2), selectedCandidate].sort(
+			(left, right) => left.totalScore - right.totalScore,
+		);
+	}
 	if (writeArtifacts) {
 		const outputDirectory = path.join(REPORT_ROOT, caseDirectory);
 		mkdirSync(outputDirectory, { recursive: true });
@@ -192,7 +205,7 @@ export const runQualityCase = (
 		route: currentRun.analysis.route,
 		confidence: currentRun.analysis.confidence,
 		warnings: currentRun.analysis.warnings,
-		gridCandidates: currentRun.analysis.gridCandidates.map((candidate) => ({
+		gridCandidates: topCandidates.map((candidate) => ({
 			width: candidate.outW,
 			height: candidate.outH,
 			score: candidate.totalScore,

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -10,7 +10,6 @@ import {
 	calculateMetrics,
 	createBackgroundMaskImage,
 	createDiffImage,
-	topGridCandidates,
 } from "./metrics";
 import { runQualityReportClient } from "./report/client";
 import { DETAIL_REPORT_STYLES, INDEX_REPORT_STYLES } from "./report/styles";
@@ -189,15 +188,14 @@ export const runQualityCase = (
 		changedPixelCount: imageComparison.changedPixelCount,
 		changedPixelRate: imageComparison.changedPixelRate,
 		diffBoundingBox: imageComparison.diffBoundingBox,
-		classification: qualityCase.inputKind,
-		route:
-			qualityCase.options.enableGridDetection === false ? "preserve" : "refine",
-		confidence: null,
-		warnings: failed,
-		gridCandidates: topGridCandidates(currentRun.grid).map((candidate) => ({
-			width: candidate.outW ?? null,
-			height: candidate.outH ?? null,
-			score: candidate.score,
+		classification: currentRun.analysis.classification ?? qualityCase.inputKind,
+		route: currentRun.analysis.route,
+		confidence: currentRun.analysis.confidence,
+		warnings: currentRun.analysis.warnings,
+		gridCandidates: currentRun.analysis.gridCandidates.map((candidate) => ({
+			width: candidate.outW,
+			height: candidate.outH,
+			score: candidate.totalScore,
 		})),
 		expectation: qualityCase.expectation,
 		options: qualityCase.options,

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -289,7 +289,7 @@ const REPORT_TRANSLATIONS = {
 		backgroundMask: "Background mask",
 		inputKind: "Input kind",
 		route: "Route",
-		confidence: "Confidence",
+		confidence: "Confidence (diagnostic)",
 		notAvailable: "not available",
 		warnings: "Warnings",
 		none: "none",
@@ -368,7 +368,7 @@ const REPORT_TRANSLATIONS = {
 		backgroundMask: "背景マスク",
 		inputKind: "入力種別",
 		route: "処理ルート",
-		confidence: "信頼度",
+		confidence: "信頼度（診断値）",
 		notAvailable: "取得不可",
 		warnings: "警告",
 		none: "なし",
@@ -447,7 +447,7 @@ const REPORT_TRANSLATIONS = {
 		backgroundMask: "背景蒙版",
 		inputKind: "输入类型",
 		route: "处理路径",
-		confidence: "置信度",
+		confidence: "置信度（诊断值）",
 		notAvailable: "不可用",
 		warnings: "警告",
 		none: "无",
@@ -522,6 +522,9 @@ const renderClientScript = (): string =>
 
 const formatMetric = (value: number | undefined): string =>
 	value === undefined ? "-" : Number(value.toFixed(3)).toString();
+
+const formatConfidence = (value: number | null): string =>
+	value === null ? "-" : value.toFixed(4);
 
 // [Policy] A case description must stand on its own: name the input characteristic,
 // the processing being exercised, and what must remain unchanged. Avoid vague text
@@ -712,7 +715,9 @@ const renderHtml = (results: QualityResults): string => {
 				'<strong data-i18n="meanRgbaErrorShort">Error</strong> ',
 				`${formatMetric(result.metrics.meanRgbaError)}/${errorTarget}`,
 				' &middot; <strong data-i18n="processingTime">Time</strong> ',
-				`${result.metrics.runtimeMs.toFixed(2)}ms</small>`,
+				`${result.metrics.runtimeMs.toFixed(2)}ms`,
+				' &middot; <strong data-i18n="confidence">Confidence (diagnostic)</strong> ',
+				`${formatConfidence(result.confidence)}</small>`,
 			].join("");
 			const searchable = [
 				result.id,
@@ -934,6 +939,7 @@ ${DETAIL_REPORT_STYLES}	</style>
 			<dl>
 				<dt data-i18n="inputKind">Input kind</dt><dd>${escapeHtml(result.inputKind)}</dd>
 				<dt data-i18n="route">Route</dt><dd data-i18n="${result.route}">${result.route}</dd>
+				<dt data-i18n="confidence">Confidence (diagnostic)</dt><dd>${formatConfidence(result.confidence)}</dd>
 				<dt data-i18n="warnings">Warnings</dt><dd>${warnings}</dd>
 				<dt data-i18n="topCandidates">Top candidates</dt><dd><code>${escapeHtml(JSON.stringify(result.gridCandidates))}</code></dd>
 				<dt data-i18n="metrics">Metrics</dt><dd><code>${escapeHtml(JSON.stringify(result.metrics))}</code></dd>
@@ -955,6 +961,7 @@ const renderMarkdown = (results: QualityResults): string => {
 				`|${result.id}`,
 				`|${result.status}`,
 				`|${result.metrics.outputWidth}x${result.metrics.outputHeight}`,
+				`|${formatConfidence(result.confidence)}`,
 				`|${result.metrics.meanRgbaError.toFixed(3)}`,
 				`|${result.metrics.edgeF1.toFixed(3)}`,
 				`|${result.metrics.runtimeMs.toFixed(2)}|`,
@@ -975,8 +982,8 @@ const renderMarkdown = (results: QualityResults): string => {
 		1,
 	)}%
 
-|Case|Status|Output|Mean RGBA error|Edge F1|Runtime (ms)|
-|---|---|---:|---:|---:|---:|
+|Case|Status|Output|Confidence (diagnostic)|Mean RGBA error|Edge F1|Runtime (ms)|
+|---|---|---:|---:|---:|---:|---:|
 ${rows}
 `;
 };

--- a/test/quality/cases.json
+++ b/test/quality/cases.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "remove-background-trim-auto-grid",
-    "featureIds": ["PRF-001", "resize"],
+    "featureIds": ["PRF-001", "PRF-002", "resize"],
     "optionNames": ["fastAutoGridFromTrimmed", "bgRemovalScope"],
     "profile": "smoke",
     "inputKind": "scaled-pixel-art",
@@ -54,7 +54,7 @@
   },
   {
     "id": "remove-background-trim-resize-46x13",
-    "featureIds": ["PRF-001", "force-size"],
+    "featureIds": ["PRF-001", "PRF-002", "force-size"],
     "optionNames": ["forcePixelsW", "forcePixelsH", "trimToContent"],
     "profile": "smoke",
     "inputKind": "scaled-pixel-art",
@@ -1607,7 +1607,7 @@
   },
   {
     "id": "preserve-continuous-tone",
-    "featureIds": ["PRF-001", "continuous-tone"],
+    "featureIds": ["PRF-001", "PRF-002", "continuous-tone"],
     "profile": "smoke",
     "inputKind": "continuous-tone",
     "degradationPatterns": ["continuous-tone"],

--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -71,7 +71,11 @@ describe.skipIf(!enabled)("quality report", () => {
 		expect(html.match(/data-i18n="processingTime"/g)).toHaveLength(
 			selectedCases.length,
 		);
+		expect(html.match(/data-i18n="confidence"/g)).toHaveLength(
+			selectedCases.length,
+		);
 		expect(html).toContain('processingTime":"時間"');
+		expect(html).toContain('confidence":"信頼度（診断値）"');
 		const paletteCaseId = "convert-game-boy-pocket-palette";
 		const paletteCaseIdIndex = html.indexOf(paletteCaseId);
 		const paletteCaseStart = html.lastIndexOf("<article", paletteCaseIdIndex);
@@ -140,6 +144,14 @@ describe.skipIf(!enabled)("quality report", () => {
 		expect(compactDetail).toContain(".back-link:hover { border-color: #c2b4ff");
 		expect(compactDetail).toContain('<h2 data-i18n="comparison">');
 		expect(compactDetail).toContain('<h2 data-i18n="options">');
+		expect(compactDetail).toContain(
+			'<dt data-i18n="confidence">Confidence (diagnostic)</dt>',
+		);
+		expect(compactDetail).toContain(
+			`<dd>${results.cases
+				.find((result) => result.id === compactCaseId)
+				?.confidence?.toFixed(4)}</dd>`,
+		);
 		expect(compactDetail).toContain('class="case-description"');
 		expect(compactDetail).toContain('class="image-stage dialog-stage"');
 		for (const imageKey of [
@@ -154,6 +166,8 @@ describe.skipIf(!enabled)("quality report", () => {
 			expect(compactDetail).toContain(`data-i18n="${imageKey}"`);
 		}
 		expect(html).toContain("品質レポート");
+		const markdown = readFileSync(path.join(reportRoot, "summary.md"), "utf8");
+		expect(markdown).toContain("|Confidence (diagnostic)|");
 		expect(html).toContain(
 			`href="${results.metadata.repositoryUrl}/pull/${encodeURIComponent(results.metadata.prNumber)}"`,
 		);


### PR DESCRIPTION
## Task
PRF-002: 診断メタデータと警告モデル

## Problem
- 処理経路やグリッド候補の判断根拠を Worker の呼び出し元へ返せず、低信頼度や内容消失を UI と品質テストで扱えませんでした。

## Changes
- 画像処理結果で route、比較指標としての confidence、候補スコア、前景比率、warning code を返し、後続の安全な処理選択に利用できるようにしました。
- 片軸検出失敗と内容消失リスクを検出し、未知の warning code も含めて UI で安全にローカライズ表示します。
- 品質レポートが実際の診断情報を表示するようにし、候補選択や警告を既存画像ケースから追跡できるようにしました。

## Tests
- `make ci`: 成功。
- `pnpm build`: 成功。
- `pnpm run test:quality:report`: 成功。

## Quality comparison
|Metric|Before|After|
|---|---:|---:|
|変更画像ケース|0|0|
|Blocking failures|0|0|
|決定論的出力|34/34|34/34|

## Expected image changes
- 変更した fixture: なし。
- 比較 HTML で全34ケースがベースラインと同一であることを確認しました。

## Risks
- confidence は既存スコアを正規化した比較指標であり、確率ではありません。
- 後続タスクで候補評価を高度化しても public 型と warning code を維持して差し替えられます。
