### PR TITLE
chore: TypeScriptの行長制限をCIに追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci ts-check-diff ts-fix-diff html-check-diff html-fix-diff repomix test test-debug type-check check-ts-rules setup
+.PHONY: ci ts-check-diff ts-fix-diff html-check-diff html-fix-diff repomix test test-debug type-check check-ts-rules check-ts-line-length setup
 
 # Run repomix to bundle files into tmp/repomix/ folder
 repomix:
@@ -28,6 +28,9 @@ type-check:
 
 check-ts-rules:
 	python3 scripts/check_ts_rules.py
+
+check-ts-line-length:
+	python3 scripts/check_ts_line_length.py
 
 ts-check-diff:
 	@files="$$( ( \

--- a/scripts/check_ts_line_length.py
+++ b/scripts/check_ts_line_length.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+MAX_LINE_LENGTH = 160
+TAB_WIDTH = 4
+
+# [Policy] Translation resources contain intentionally uninterrupted localized
+# strings. Splitting them would obscure the text and make translation reviews harder.
+EXCLUDED_FILES = {Path("src/browser/i18n.ts")}
+
+
+def find_typescript_files() -> list[Path]:
+    result = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+            "*.ts",
+            "*.tsx",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return sorted(
+        Path(path.decode("utf-8"))
+        for path in result.stdout.split(b"\0")
+        if path
+    )
+
+
+def check_file(path: Path) -> list[str]:
+    errors = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(),
+        1,
+    ):
+        line_length = len(line.expandtabs(TAB_WIDTH))
+        if line_length > MAX_LINE_LENGTH:
+            errors.append(
+                f"{path}:{line_number}: line has {line_length} characters "
+                f"(maximum is {MAX_LINE_LENGTH})",
+            )
+    return errors
+
+
+def main() -> int:
+    errors = []
+    for path in find_typescript_files():
+        if path in EXCLUDED_FILES:
+            continue
+        try:
+            errors.extend(check_file(path))
+        except (OSError, UnicodeError) as error:
+            errors.append(f"{path}: failed to read file: {error}")
+
+    if errors:
+        print("\n".join(errors))
+        print(f"\nTotal line-length violations: {len(errors)}")
+        return 1
+
+    print(f"No TypeScript lines exceed {MAX_LINE_LENGTH} characters.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_ci.py
+++ b/scripts/run_ci.py
@@ -88,6 +88,7 @@ def main():
         ("HTML Check", ["make", "html-check-diff"]),
         ("Type Check", ["make", "type-check"]),
         ("Custom Rules", ["make", "check-ts-rules"]),
+        ("TS Line Length", ["make", "check-ts-line-length"]),
         ("Tests", ["make", "test"]),
     ]
 

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -254,7 +254,14 @@ const showError = (message: string) => {
 	const toast = document.createElement("div");
 	toast.className = "error-toast";
 	toast.setAttribute("role", "alert");
-	toast.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg><span>${message}</span>`;
+	toast.innerHTML =
+		'<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" ' +
+		'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+		'stroke-linecap="round" stroke-linejoin="round">' +
+		'<circle cx="12" cy="12" r="10"></circle>' +
+		'<line x1="12" y1="8" x2="12" y2="12"></line>' +
+		'<line x1="12" y1="16" x2="12.01" y2="16"></line></svg>' +
+		`<span>${message}</span>`;
 	document.body.appendChild(toast);
 
 	// Start showing in the next frame
@@ -282,7 +289,13 @@ const showInfo = (message: string) => {
 	const toast = document.createElement("div");
 	toast.className = "info-toast";
 	toast.setAttribute("role", "status");
-	toast.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg><span>${message}</span>`;
+	toast.innerHTML =
+		'<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" ' +
+		'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" ' +
+		'stroke-linecap="round" stroke-linejoin="round">' +
+		'<path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>' +
+		'<polyline points="22 4 12 14.01 9 11.01"></polyline></svg>' +
+		`<span>${message}</span>`;
 	document.body.appendChild(toast);
 
 	requestAnimationFrame(() => {

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -521,8 +521,14 @@ const describeCase = (
 	const options = result.options;
 	if (result.id === "convert-deterministic-auto-palette") {
 		return {
-			en: "Keep the image at its original 32 x 32 pixel dimensions and preserve fully transparent pixels while reducing its 947 opaque input colors to an automatically selected eight-color palette with full-strength Ordered dithering.",
-			ja: "画像を32×32ピクセルの原寸に保ち、完全透明な画素を維持したまま、947色ある不透明な入力色をAutoで選択した8色のパレットへ減色し、強度100%のOrderedディザリングを適用します。",
+			en:
+				"Keep the image at its original 32 x 32 pixel dimensions and preserve " +
+				"fully transparent pixels while reducing its 947 opaque input colors " +
+				"to an automatically selected eight-color palette with full-strength Ordered dithering.",
+			ja:
+				"画像を32×32ピクセルの原寸に保ち、完全透明な画素を維持したまま、" +
+				"947色ある不透明な入力色をAutoで選択した8色のパレットへ減色し、" +
+				"強度100%のOrderedディザリングを適用します。",
 		};
 	}
 	if (options.reduceColorMode === "gb_pocket") {
@@ -584,11 +590,15 @@ const describeCase = (
 		return target
 			? {
 					en: `Resize the input image to ${target} pixels without background removal, transparent-margin trimming, or pixel-grid restoration.`,
-					ja: `背景除去、透明余白のトリミング、ピクセルグリッド復元を行わず、入力画像を${target}ピクセルへ変換します。`,
+					ja:
+						"背景除去、透明余白のトリミング、ピクセルグリッド復元を行わず、" +
+						`入力画像を${target}ピクセルへ変換します。`,
 				}
 			: {
 					en: "Output the input image at its current dimensions without background removal, transparent-margin trimming, or pixel-grid restoration.",
-					ja: "背景除去、透明余白のトリミング、ピクセルグリッド復元を行わず、入力画像を現在の寸法のまま出力します。",
+					ja:
+						"背景除去、透明余白のトリミング、ピクセルグリッド復元を行わず、" +
+						"入力画像を現在の寸法のまま出力します。",
 				};
 	}
 	return {
@@ -620,11 +630,14 @@ const renderReportSidebar = (results: QualityResults): string => {
 			<dt data-i18n="pullRequest">Pull request</dt>
 			<dd><a href="${repositoryUrl}/pull/${encodeURIComponent(results.metadata.prNumber)}">#${escapeHtml(results.metadata.prNumber)}</a></dd>
 			<dt data-i18n="headCommit">Head</dt>
-			<dd><a href="${commitUrl(results.metadata.headCommit)}" title="${escapeHtml(results.metadata.headCommit)}"><code>${shortCommit(results.metadata.headCommit)}</code></a></dd>
+			<dd><a href="${commitUrl(results.metadata.headCommit)}"
+				title="${escapeHtml(results.metadata.headCommit)}"><code>${shortCommit(results.metadata.headCommit)}</code></a></dd>
 			<dt data-i18n="baseCommit">PR base</dt>
-			<dd><a href="${commitUrl(results.metadata.baseCommit)}" title="${escapeHtml(results.metadata.baseCommit)}"><code>${shortCommit(results.metadata.baseCommit)}</code></a></dd>
+			<dd><a href="${commitUrl(results.metadata.baseCommit)}"
+				title="${escapeHtml(results.metadata.baseCommit)}"><code>${shortCommit(results.metadata.baseCommit)}</code></a></dd>
 			<dt data-i18n="baselineCommit">Baseline snapshot</dt>
-			<dd><a href="${commitUrl(results.metadata.baselineCommit)}" title="${escapeHtml(results.metadata.baselineCommit)}"><code>${shortCommit(results.metadata.baselineCommit)}</code></a></dd>
+			<dd><a href="${commitUrl(results.metadata.baselineCommit)}"
+				title="${escapeHtml(results.metadata.baselineCommit)}"><code>${shortCommit(results.metadata.baselineCommit)}</code></a></dd>
 			<dt data-i18n="generatedAt">Generated</dt>
 			<dd><time datetime="${escapeHtml(results.metadata.generatedAt)}">${escapeHtml(results.metadata.generatedAt)}</time></dd>
 			<dt data-i18n="workflow">Workflow</dt>
@@ -643,19 +656,33 @@ const renderReportSidebar = (results: QualityResults): string => {
 		<fieldset class="filter-group">
 			<legend data-i18n="changeStatus">Change status</legend>
 			<div class="filter-row">
-				<button class="filter-button active" type="button" data-change-filter="" aria-pressed="true"><span data-i18n="allChanges">All</span>: ${results.summary.caseCount}</button>
-				<button class="filter-button" type="button" data-change-filter="changed" aria-pressed="false"><span data-i18n="changed">changed</span>: ${results.summary.changed}</button>
-				<button class="filter-button" type="button" data-change-filter="regressed" aria-pressed="false"><span data-i18n="regressed">regressed</span>: ${results.summary.regressed}</button>
-				<button class="filter-button" type="button" data-change-filter="improved" aria-pressed="false"><span data-i18n="improved">improved</span>: ${results.summary.improved}</button>
-				<button class="filter-button" type="button" data-change-filter="unchanged" aria-pressed="false"><span data-i18n="unchanged">unchanged</span>: ${results.summary.unchanged}</button>
+				<button class="filter-button active" type="button" data-change-filter="" aria-pressed="true">
+					<span data-i18n="allChanges">All</span>: ${results.summary.caseCount}
+				</button>
+				<button class="filter-button" type="button" data-change-filter="changed" aria-pressed="false">
+					<span data-i18n="changed">changed</span>: ${results.summary.changed}
+				</button>
+				<button class="filter-button" type="button" data-change-filter="regressed" aria-pressed="false">
+					<span data-i18n="regressed">regressed</span>: ${results.summary.regressed}
+				</button>
+				<button class="filter-button" type="button" data-change-filter="improved" aria-pressed="false">
+					<span data-i18n="improved">improved</span>: ${results.summary.improved}
+				</button>
+				<button class="filter-button" type="button" data-change-filter="unchanged" aria-pressed="false">
+					<span data-i18n="unchanged">unchanged</span>: ${results.summary.unchanged}
+				</button>
 			</div>
 		</fieldset>
 		<fieldset class="filter-group">
 			<legend data-i18n="qualityStatus">Quality status</legend>
 			<div class="filter-row">
 				<button class="filter-button active" type="button" data-status-filter="" aria-pressed="true"><span data-i18n="allStatuses">All</span></button>
-				<button class="filter-button" type="button" data-status-filter="passed" aria-pressed="false"><span data-i18n="passed">passed</span>: ${results.summary.passed}</button>
-				<button class="filter-button" type="button" data-status-filter="failed" aria-pressed="false"><span data-i18n="failed">target unmet</span>: ${results.summary.failed}</button>
+				<button class="filter-button" type="button" data-status-filter="passed" aria-pressed="false">
+					<span data-i18n="passed">passed</span>: ${results.summary.passed}
+				</button>
+				<button class="filter-button" type="button" data-status-filter="failed" aria-pressed="false">
+					<span data-i18n="failed">target unmet</span>: ${results.summary.failed}
+				</button>
 			</div>
 		</fieldset>
 		<label class="search-row" for="search">
@@ -693,7 +720,9 @@ const renderHtml = (results: QualityResults): string => {
 				? "0"
 				: `&le;${formatMetric(result.expectation.maxMeanRgbaError)}`;
 			const exactMeasurement = result.expectation.exact
-				? `<strong data-i18n="exactMatchShort">Exact</strong> <span data-i18n="${exactMatch ? "yes" : "no"}">${exactMatch ? "yes" : "no"}</span> &middot; `
+				? '<strong data-i18n="exactMatchShort">Exact</strong> ' +
+					`<span data-i18n="${exactMatch ? "yes" : "no"}">` +
+					`${exactMatch ? "yes" : "no"}</span> &middot; `
 				: "";
 			const qualityMeasurement = [
 				'<small class="case-metrics">',
@@ -724,22 +753,27 @@ const renderHtml = (results: QualityResults): string => {
 					)
 					.map(
 						([key, label, source]) =>
-							`<figure><figcaption data-i18n="${key}">${label}</figcaption><div class="image-stage"><img src="${escapeHtml(source)}" alt="${label}" data-i18n-alt="${key}" loading="lazy"></div></figure>`,
+							`<figure><figcaption data-i18n="${key}">${label}</figcaption>` +
+							`<div class="image-stage"><img src="${escapeHtml(source)}" alt="${label}" ` +
+							`data-i18n-alt="${key}" loading="lazy"></div></figure>`,
 					)
 					.join("");
 			const primaryImages = renderImages([
 				["input", "Input", result.files.input],
 				["result", "Result", result.files.result],
 			]);
-			return `<article class="case ${result.status} ${result.changeStatus}" data-status="${result.status}" data-change="${result.changeStatus}" data-search="${escapeHtml(searchable)}">
+			return `<article class="case ${result.status} ${result.changeStatus}"
+			data-status="${result.status}" data-change="${result.changeStatus}" data-search="${escapeHtml(searchable)}">
 			<h2>
 				${escapeHtml(result.id)}
 				<span class="badge ${result.status}" data-i18n="${result.status}">${result.status}</span>
 				<span class="badge ${result.changeStatus}" data-i18n="${result.changeStatus}">${result.changeStatus}</span>
 				${qualityMeasurement}
 			</h2>
-			<p class="case-description" data-description-en="${escapeHtml(description.en)}" data-description-ja="${escapeHtml(description.ja)}">${escapeHtml(description.en)}</p>
-			<div class="images primary">${primaryImages}</div><p><a class="detail-link" href="${escapeHtml(path.posix.dirname(result.files.result))}/index.html" data-i18n="details">Details</a></p>
+			<p class="case-description" data-description-en="${escapeHtml(description.en)}"
+				data-description-ja="${escapeHtml(description.ja)}">${escapeHtml(description.en)}</p>
+			<div class="images primary">${primaryImages}</div><p><a class="detail-link"
+				href="${escapeHtml(path.posix.dirname(result.files.result))}/index.html" data-i18n="details">Details</a></p>
 		</article>`;
 		})
 		.join("\n");
@@ -772,7 +806,11 @@ const renderCaseDetailHtml = (result: QualityCaseResult): string => {
 			.filter((image): image is [string, string, string] => image[2] !== null)
 			.map(([key, label, source]) => {
 				const fileName = escapeHtml(path.posix.basename(source));
-				return `<figure><figcaption data-i18n="${key}">${label}</figcaption><div class="image-stage"><img src="${fileName}" alt="${label}" data-i18n-alt="${key}" loading="lazy"></div></figure>`;
+				return (
+					`<figure><figcaption data-i18n="${key}">${label}</figcaption>` +
+					`<div class="image-stage"><img src="${fileName}" alt="${label}" ` +
+					`data-i18n-alt="${key}" loading="lazy"></div></figure>`
+				);
 			})
 			.join("");
 	const allImages = renderImages([
@@ -893,7 +931,8 @@ ${DETAIL_REPORT_STYLES}	</style>
 			<span class="badge ${result.status}" data-i18n="${result.status}">${result.status}</span>
 			<span class="badge ${result.changeStatus}" data-i18n="${result.changeStatus}">${result.changeStatus}</span>
 		</h1>
-		<p class="case-description" data-description-en="${escapeHtml(description.en)}" data-description-ja="${escapeHtml(description.ja)}">${escapeHtml(description.en)}</p>
+		<p class="case-description" data-description-en="${escapeHtml(description.en)}"
+			data-description-ja="${escapeHtml(description.ja)}">${escapeHtml(description.en)}</p>
 		<p>${tags}</p>
 		<p><strong data-i18n="changedPixels">Changed pixels</strong>: ${changedPixels}</p>
 		<section>

--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -99,10 +99,14 @@ describe.skipIf(!enabled)("quality report", () => {
 			deterministicCaseEnd,
 		);
 		expect(deterministicCase).toContain(
-			"Keep the image at its original 32 x 32 pixel dimensions and preserve fully transparent pixels while reducing its 947 opaque input colors to an automatically selected eight-color palette with full-strength Ordered dithering.",
+			"Keep the image at its original 32 x 32 pixel dimensions and preserve " +
+				"fully transparent pixels while reducing its 947 opaque input colors " +
+				"to an automatically selected eight-color palette with full-strength Ordered dithering.",
 		);
 		expect(deterministicCase).toContain(
-			"画像を32×32ピクセルの原寸に保ち、完全透明な画素を維持したまま、947色ある不透明な入力色をAutoで選択した8色のパレットへ減色し、強度100%のOrderedディザリングを適用します。",
+			"画像を32×32ピクセルの原寸に保ち、完全透明な画素を維持したまま、" +
+				"947色ある不透明な入力色をAutoで選択した8色のパレットへ減色し、" +
+				"強度100%のOrderedディザリングを適用します。",
 		);
 		const compactCaseId = "remove-background-trim-auto-grid";
 		const compactCaseIdIndex = html.indexOf(compactCaseId);


### PR DESCRIPTION
## 概要

TypeScriptの1行を160文字以内に保つ静的検査を、ローカルとGitHub Actionsの共通CIへ導入します。

## 変更内容

- TypeScriptとTSXの文字列・コメントを含む各行を検査し、160文字を超えた場合にCIが失敗するようにしました。
- 翻訳リソースは文面を分断するとレビュー性が下がるため対象外とし、その他の既存超過行は出力内容を維持したまま分割しました。
- ローカルの `make ci` とGitHub Actionsで同じ制限が適用されるようにしました。

## 動作確認

手動操作への影響はありません。
