### PR TITLE
chore: 品質レポートの閲覧可能期間を明記

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -159,7 +159,7 @@ jobs:
           existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate --jq ".[] | select(.body | contains(\"${marker}\")) | .id" | head -n 1)"
           if [ -z "$existing" ]; then
             gh pr comment "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "${marker}
-          Quality report: ${report_url}"
+          Quality report (available while this PR is open): ${report_url}"
           fi
 
   cleanup:


### PR DESCRIPTION
## 概要

PRクローズ後にリンク切れとなる品質レポートについて、閲覧可能期間をコメント上で明確にします。

## 変更内容

- PRへ投稿する品質レポートリンクに、PRがopenの間のみ閲覧できる旨を併記します。
