### PR TITLE
chore: Ready変更時のQuality Report再実行を停止

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -2,7 +2,7 @@ name: Quality Report
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, closed]
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

PRをReadyに変更した際にQuality Reportが再実行されないよう、起動イベントを調整します。

## 変更内容

- Quality ReportはPRの作成・再オープン・更新・クローズ時のみ起動し、DraftからReadyへの変更時には起動しないようになります。
