### PR TITLE
test: 品質ベンチマークをシャード並列化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    # [Policy] make ci は品質ケースを全件実行する。自動判定ケースの追加で
-    # テスト時間が伸びたため上限を広げる。
-    timeout-minutes: 30
+    # [Policy] make ci は品質ケースを全件実行する。ケースはシャードファイル単位で
+    # 並列に流れるが、共有ランナーのコア数に律速されるため余裕を持たせる。
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -15,9 +15,10 @@ jobs:
   build:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
-    # [Policy] 自動判定ケース（fixture 全点をAuto+既定設定で処理）が加わり、
-    # 比較レポート生成と品質ゲートで各 1 周ずつ全ケースを流すため時間を確保する。
-    timeout-minutes: 45
+    # [Policy] 比較レポート生成と品質ゲートで各 1 周ずつ全ケースを流す。
+    # どちらもシャードファイル単位でランナーのコア数ぶん並列に実行されるので、
+    # 4 コアの共有ランナーで詰まっても収まる範囲に上限を置く。
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:quality": "QUALITY_PROFILE=smoke vitest run test/quality/cases.test.ts",
-    "test:quality:full": "QUALITY_PROFILE=full vitest run test/quality/cases.test.ts",
-    "test:quality:update": "UPDATE_QUALITY_BASELINE=1 QUALITY_PROFILE=full vitest run test/quality/cases.test.ts",
-    "test:quality:report": "QUALITY_REPORT=1 QUALITY_PROFILE=full vitest run test/quality/report.test.ts --reporter=default --reporter=./test/quality/quality-reporter.ts"
+    "test:quality": "QUALITY_PROFILE=smoke vitest run test/quality/cases.test.ts test/quality/shards",
+    "test:quality:full": "QUALITY_PROFILE=full vitest run test/quality/cases.test.ts test/quality/shards",
+    "test:quality:update": "pnpm run quality:update:generate && pnpm run quality:update:apply",
+    "quality:update:generate": "rm -rf tmp/quality-baseline-update && UPDATE_QUALITY_BASELINE=1 QUALITY_PROFILE=full vitest run test/quality/shards",
+    "quality:update:apply": "UPDATE_QUALITY_BASELINE=1 QUALITY_PROFILE=full vitest run test/quality/cases.test.ts",
+    "test:quality:report": "pnpm run quality:report:cases && pnpm run quality:report:aggregate",
+    "quality:report:cases": "rm -rf tmp/quality-report/latest tmp/quality-report/partial && QUALITY_REPORT=1 QUALITY_PROFILE=full vitest run test/quality/shards",
+    "quality:report:aggregate": "QUALITY_REPORT=1 QUALITY_PROFILE=full vitest run test/quality/report.test.ts --reporter=default --reporter=./test/quality/quality-reporter.ts"
   },
   "devDependencies": {
     "@types/jszip": "^3.4.0",

--- a/test/quality/README.md
+++ b/test/quality/README.md
@@ -14,6 +14,36 @@ pnpm test:quality:report   # write tmp/quality-report/latest
 pnpm test:quality:update   # intentionally replace the stored baseline
 ```
 
+## Parallel execution
+
+Vitest parallelizes per test file, so the cases are split across the shard files
+in [`shards/`](./shards). Each file calls `runCasesShard` from
+[`shard.ts`](./shard.ts), which distributes the selected cases over
+`QUALITY_SHARD_COUNT` groups by input pixel count, largest first, so the slowest
+case never shares a shard with another heavy one. `cases.test.ts` fails if the
+number of shard files stops matching `QUALITY_SHARD_COUNT` or if the split no
+longer covers every selected case exactly once.
+
+`pnpm test:quality:report` therefore runs Vitest twice. The first run executes
+the shards, writes the per-case images under `tmp/quality-report/latest`, and
+stores each shard's case results in `tmp/quality-report/partial`. The second run
+executes [`report.test.ts`](./report.test.ts), which merges the partial results
+back into manifest order and writes `results.json`, `summary.md`, and the HTML
+report. Because ordering is restored from the manifest, the report is identical
+to a serial run apart from the measured runtime and memory values.
+
+`pnpm test:quality:update` also runs Vitest twice. The first run
+(`quality:update:generate`) executes the shards with
+`UPDATE_QUALITY_BASELINE=1`: each case is measured against the still-unchanged
+baseline images (read-only, so parallel shards cannot race each other) and the
+resulting metrics and output image are written to
+`tmp/quality-baseline-update`. The second run (`quality:update:apply`)
+executes `cases.test.ts`, which merges the staged results back into manifest
+order and performs the only write to `test/quality/baseline.json` and
+`test/quality/baseline/`. Splitting the write from the measurement keeps the
+"measure against the old baseline, then replace it" requirement intact while
+letting the measurement itself run in parallel.
+
 Open `tmp/quality-report/latest/index.html` directly in a browser after
 generating a report. The report includes JSON and Markdown summaries plus
 ground truth, input, approved baseline, current, ground-truth difference,

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -1,4 +1,4 @@
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { processBatchImages } from "../../src/core/batch";
@@ -16,12 +16,10 @@ import {
 	createDiffImage,
 } from "./metrics";
 import type {
+	QualityBaselineCase,
 	QualityCaseResult,
 	QualityImageCase,
-	QualityMetadata,
-	QualityResults,
 } from "./types";
-import { QUALITY_BENCHMARK_VERSION, QUALITY_REPORT_VERSION } from "./types";
 
 const REPORT_ROOT = path.resolve("tmp/quality-report/latest");
 
@@ -78,27 +76,6 @@ const processQualityCase = (
 		);
 	}
 	return primary.processResult;
-};
-
-const metadataFromEnvironment = (): QualityMetadata => {
-	const repository =
-		process.env.GITHUB_REPOSITORY ?? "HappyOnigiri/PixelRefiner";
-	const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
-	const runId = process.env.GITHUB_RUN_ID ?? "";
-	const baseline = loadBaseline();
-	return {
-		repositoryUrl: `${server}/${repository}`,
-		prNumber: process.env.QUALITY_PR_NUMBER ?? "local",
-		headCommit:
-			process.env.QUALITY_HEAD_SHA ?? process.env.GITHUB_SHA ?? "local",
-		baseCommit: process.env.QUALITY_BASE_SHA ?? "local",
-		generatedAt: new Date().toISOString(),
-		workflowRunUrl:
-			runId === "" ? "local" : `${server}/${repository}/actions/runs/${runId}`,
-		benchmarkVersion: QUALITY_BENCHMARK_VERSION,
-		reportVersion: QUALITY_REPORT_VERSION,
-		baselineCommit: baseline.commit,
-	};
 };
 
 const failedAssertions = (
@@ -300,6 +277,25 @@ export const runQualityCase = (
 	};
 };
 
+// [Intended] QualityCaseResult からベースラインへ書き込むフィールドだけを取り出す。
+// ベースライン更新の並列生成側（shard.ts）から呼ぶ。抽出ロジックを1箇所にまとめ、
+// 書き込むフィールドの定義がベースラインの型定義から離れて重複しないようにする。
+export const toBaselineCaseEntry = (
+	result: QualityCaseResult,
+): QualityBaselineCase => ({
+	id: result.id,
+	status: result.status,
+	outputWidth: result.metrics.outputWidth,
+	outputHeight: result.metrics.outputHeight,
+	meanRgbaError: Number(result.metrics.meanRgbaError.toFixed(6)),
+	edgeF1: Number(result.metrics.edgeF1.toFixed(6)),
+	backgroundMaskIou: Number(result.metrics.backgroundMaskIou.toFixed(6)),
+	smallComponentRetention: Number(
+		result.metrics.smallComponentRetention.toFixed(6),
+	),
+	catastrophicFailure: result.metrics.catastrophicFailure,
+});
+
 export const writeQualityBaselineImage = (
 	qualityCase: QualityImageCase,
 	outputPath: string,
@@ -307,118 +303,6 @@ export const writeQualityBaselineImage = (
 	const input = readPng(path.resolve(qualityCase.input));
 	const options = { ...effectiveCaseOptions(qualityCase), debug: false };
 	writePng(outputPath, processQualityCase(qualityCase, input, options).result);
-};
-
-const summarize = (cases: QualityCaseResult[]): QualityResults["summary"] => {
-	const count = cases.length;
-	const average = (select: (result: QualityCaseResult) => number): number => {
-		let total = 0;
-		for (const result of cases) total += select(result);
-		return count === 0 ? 0 : total / count;
-	};
-	const confidenceSamples = cases.flatMap((result) =>
-		result.gridCandidates.map((candidate) => ({
-			confidence: candidate.confidence,
-			correct: Number(
-				candidate.width === result.expectedWidth &&
-					candidate.height === result.expectedHeight,
-			),
-		})),
-	);
-	const sampleCount = confidenceSamples.length;
-	let confidenceTotal = 0;
-	let correctnessTotal = 0;
-	for (const sample of confidenceSamples) {
-		confidenceTotal += sample.confidence;
-		correctnessTotal += sample.correct;
-	}
-	const meanConfidence = sampleCount === 0 ? 0 : confidenceTotal / sampleCount;
-	const meanCorrectness =
-		sampleCount === 0 ? 0 : correctnessTotal / sampleCount;
-	let covariance = 0;
-	let confidenceVariance = 0;
-	let correctnessVariance = 0;
-	for (const sample of confidenceSamples) {
-		const confidenceDelta = sample.confidence - meanConfidence;
-		const correctnessDelta = sample.correct - meanCorrectness;
-		covariance += confidenceDelta * correctnessDelta;
-		confidenceVariance += confidenceDelta * confidenceDelta;
-		correctnessVariance += correctnessDelta * correctnessDelta;
-	}
-	const correlationDenominator = Math.sqrt(
-		confidenceVariance * correctnessVariance,
-	);
-	return {
-		caseCount: count,
-		passed: cases.filter((result) => result.status === "passed").length,
-		failed: cases.filter((result) => result.status === "failed").length,
-		changed: cases.filter((result) => result.changeStatus === "changed").length,
-		improved: cases.filter((result) => result.changeStatus === "improved")
-			.length,
-		regressed: cases.filter((result) => result.changeStatus === "regressed")
-			.length,
-		unchanged: cases.filter((result) => result.changeStatus === "unchanged")
-			.length,
-		newCases: cases.filter((result) => result.changeStatus === "new").length,
-		blockingFailures: cases.filter(
-			(result) =>
-				result.changeStatus === "regressed" ||
-				(result.changeStatus === "new" && result.status === "failed"),
-		).length,
-		explicitCases: cases.filter((result) => result.parameterMode === "explicit")
-			.length,
-		autoCases: cases.filter((result) => result.parameterMode === "auto").length,
-		top1SizeAccuracy: average((result) => Number(result.metrics.sizeCorrect)),
-		top3SizeAccuracy: average((result) =>
-			Number(result.metrics.top3SizeCorrect),
-		),
-		confidenceCorrectnessCorrelation:
-			correlationDenominator === 0 ? null : covariance / correlationDenominator,
-		byteIdentityRate: average((result) => Number(result.metrics.byteIdentical)),
-		catastrophicFailureRate: average((result) =>
-			Number(result.metrics.catastrophicFailure),
-		),
-		meanRgbaError: average((result) => result.metrics.meanRgbaError),
-		meanRuntimeMs: average((result) => result.metrics.runtimeMs),
-		approxPeakBytes: Math.max(
-			0,
-			...cases.map((result) => result.metrics.approxPeakBytes),
-		),
-	};
-};
-
-import {
-	renderCaseDetailHtml,
-	renderHtml,
-	renderMarkdown,
-} from "./report/render";
-
-export const generateQualityReport = (
-	cases: QualityImageCase[],
-): QualityResults => {
-	rmSync(REPORT_ROOT, { recursive: true, force: true });
-	mkdirSync(REPORT_ROOT, { recursive: true });
-	const caseResults = cases.map((qualityCase) =>
-		runQualityCase(qualityCase, true),
-	);
-	const results: QualityResults = {
-		metadata: metadataFromEnvironment(),
-		summary: summarize(caseResults),
-		cases: caseResults,
-	};
-	writeFileSync(
-		path.join(REPORT_ROOT, "results.json"),
-		`${JSON.stringify(results, null, 2)}\n`,
-	);
-	writeFileSync(path.join(REPORT_ROOT, "summary.md"), renderMarkdown(results));
-	writeFileSync(path.join(REPORT_ROOT, "index.html"), renderHtml(results));
-	for (const result of results.cases) {
-		writeFileSync(
-			path.join(REPORT_ROOT, "cases", result.id, "index.html"),
-			renderCaseDetailHtml(result),
-		);
-	}
-	return results;
 };
 
 export const reportRoot = REPORT_ROOT;

--- a/test/quality/cases.test.ts
+++ b/test/quality/cases.test.ts
@@ -1,130 +1,117 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
 	assertBaselineUpdateIsSafe,
 	baselineFile,
 	baselineRoot,
-	loadBaseline,
 } from "./baseline";
-import { runQualityCase, writeQualityBaselineImage } from "./benchmark";
-import { compareMetrics } from "./comparison";
 import {
-	caseParameterMode,
 	loadCases,
 	qualityProfileFromEnvironment,
 	selectCasesForProfile,
 	validateManifest,
 } from "./manifest";
+import { QUALITY_SHARD_COUNT, shardCases } from "./shard";
 import { QUALITY_BASELINE_VERSION, type QualityBaseline } from "./types";
+import {
+	readQualityUpdatePartials,
+	stagingBaselineImagePath,
+} from "./update/partial";
 
 const allCases = loadCases();
 const profile = qualityProfileFromEnvironment();
 const selectedCases = selectCasesForProfile(allCases, profile);
-// [Policy] 画像全体を対象とする品質ケースは、競合の激しい共有 CI ランナー上で
-// 実行される可能性があるため、正しさの検証には短い単体テストのタイムアウトを使用しない。
-const QUALITY_CASE_TIMEOUT_MS = 300_000;
-const resultCache = new Map<string, ReturnType<typeof runQualityCase>>();
-const getResult = (
-	qualityCase: (typeof selectedCases)[number],
-): ReturnType<typeof runQualityCase> => {
-	const cached = resultCache.get(qualityCase.id);
-	if (cached) return cached;
-	const result = runQualityCase(qualityCase);
-	resultCache.set(qualityCase.id, result);
-	return result;
-};
+const updateMode = process.env.UPDATE_QUALITY_BASELINE === "1";
+const SHARD_ROOT = path.resolve("test/quality/shards");
+const SHARD_ENTRY = /runCasesShard\((\d+)\)/;
+
+// [Policy] ここはベースライン更新の stage2（集約・書き込み専用）。ケース本体の実行は
+// test/quality/shards が並列に済ませ、tmp/quality-baseline-update へ結果を書き出す
+// （"pnpm run quality:update:generate"）。ここは集約と書き込みだけなので短い待機時間で足りる。
+const BASELINE_UPDATE_TIMEOUT_MS = 120_000;
 
 describe("quality case manifest", () => {
 	it("registers every fixture, degradation, and provenance record", () => {
 		expect(validateManifest(allCases)).toEqual([]);
 	});
 
-	it.each(selectedCases)(
-		"evaluates $id",
-		(qualityCase) => {
-			const result = getResult(qualityCase);
-			expect(result.metrics.byteIdentical).toBe(true);
-			// [Intended] 自動判定ケースには正解画像がなく、破綻や出力サイズは
-			// 「今の自動判定の実力」そのものなので絶対値では落とさない。悪化は
-			// ベースライン比較（catastrophicFailure の false→true や指標低下）で捕まえる。
-			if (caseParameterMode(qualityCase) === "auto") return;
-			expect(result.metrics.catastrophicFailure).toBe(false);
-			expect(result.failedAssertions).not.toContain("output-size");
-			expect(result.failedAssertions).not.toContain("expected-width");
-			expect(result.failedAssertions).not.toContain("expected-height");
-		},
-		QUALITY_CASE_TIMEOUT_MS,
-	);
+	// [Intended] ケース本体は test/quality/shards の各ファイルが並列に実行する。
+	// ここでは分配が全ケースをちょうど 1 度ずつ覆い、シャード数とファイル数が
+	// ずれていないことを検証する。ずれるとケースが黙って実行されなくなる。
+	it("splits every selected case into exactly one shard", () => {
+		const shardFiles = readdirSync(SHARD_ROOT)
+			.filter((fileName) => fileName.endsWith(".test.ts"))
+			.sort();
+		expect(shardFiles).toHaveLength(QUALITY_SHARD_COUNT);
+		const declaredIndexes = shardFiles.map(
+			(fileName) =>
+				SHARD_ENTRY.exec(
+					readFileSync(path.join(SHARD_ROOT, fileName), "utf8"),
+				)?.[1],
+		);
+		expect(declaredIndexes).toEqual(
+			Array.from({ length: QUALITY_SHARD_COUNT }, (_, index) =>
+				String(index + 1),
+			),
+		);
+		const buckets = shardCases(selectedCases, QUALITY_SHARD_COUNT);
+		const assignedIds = buckets.flat().map((qualityCase) => qualityCase.id);
+		expect([...assignedIds].sort()).toEqual(
+			selectedCases.map((qualityCase) => qualityCase.id).sort(),
+		);
+		for (const bucket of buckets) expect(bucket.length).toBeGreaterThan(0);
+	});
 
-	it("does not regress the stored quality baseline", () => {
-		const current: QualityBaseline = {
-			version: QUALITY_BASELINE_VERSION,
-			commit: process.env.QUALITY_HEAD_SHA ?? "working-tree",
-			cases: selectedCases.map((qualityCase) => {
-				const result = getResult(qualityCase);
-				return {
-					id: result.id,
-					status: result.status,
-					outputWidth: result.metrics.outputWidth,
-					outputHeight: result.metrics.outputHeight,
-					meanRgbaError: Number(result.metrics.meanRgbaError.toFixed(6)),
-					edgeF1: Number(result.metrics.edgeF1.toFixed(6)),
-					backgroundMaskIou: Number(
-						result.metrics.backgroundMaskIou.toFixed(6),
-					),
-					smallComponentRetention: Number(
-						result.metrics.smallComponentRetention.toFixed(6),
-					),
-					catastrophicFailure: result.metrics.catastrophicFailure,
-				};
-			}),
-		};
-		if (process.env.UPDATE_QUALITY_BASELINE === "1") {
+	it.runIf(updateMode)(
+		"updates the stored quality baseline",
+		() => {
 			assertBaselineUpdateIsSafe(profile);
-			writeFileSync(baselineFile(), `${JSON.stringify(current, null, 2)}\n`);
-			rmSync(baselineRoot(), { recursive: true, force: true });
-			mkdirSync(baselineRoot(), { recursive: true });
+			// [Intended] 自動判定ケースの指標は既存のベースライン画像を基準に測るため、
+			// stage1（並列生成）は画像を書き換える前の状態に対して全ケースを評価しきり、
+			// 結果をステージング領域へ書き出している。ここではそれを集約するだけ。
+			const entryById = new Map(
+				readQualityUpdatePartials().map((entry) => [entry.id, entry]),
+			);
+			const missingIds = selectedCases
+				.map((qualityCase) => qualityCase.id)
+				.filter((id) => !entryById.has(id));
+			if (missingIds.length > 0) {
+				throw new Error(
+					`Missing staged baseline update for ${missingIds.length} case(s): ` +
+						`${missingIds.join(", ")}. Run "pnpm run quality:update:generate" first.`,
+				);
+			}
+			const current: QualityBaseline = {
+				version: QUALITY_BASELINE_VERSION,
+				commit: process.env.QUALITY_HEAD_SHA ?? "working-tree",
+				cases: selectedCases.map((qualityCase) => {
+					const entry = entryById.get(qualityCase.id);
+					if (entry === undefined) {
+						throw new Error(`unreachable: missing entry for ${qualityCase.id}`);
+					}
+					return entry;
+				}),
+			};
+			const nextBaselineFile = baselineFile();
+			const nextBaselineRoot = baselineRoot();
+			writeFileSync(nextBaselineFile, `${JSON.stringify(current, null, 2)}\n`);
+			rmSync(nextBaselineRoot, { recursive: true, force: true });
+			mkdirSync(nextBaselineRoot, { recursive: true });
 			for (const qualityCase of selectedCases) {
-				writeQualityBaselineImage(
-					qualityCase,
-					path.join(baselineRoot(), `${qualityCase.id}.png`),
+				cpSync(
+					stagingBaselineImagePath(qualityCase.id),
+					path.join(nextBaselineRoot, `${qualityCase.id}.png`),
 				);
 			}
-			return;
-		}
-		const baseline = loadBaseline();
-		const baselineById = new Map(
-			baseline.cases.map((qualityCase) => [qualityCase.id, qualityCase]),
-		);
-		const autoCaseIds = new Set(
-			selectedCases
-				.filter((qualityCase) => caseParameterMode(qualityCase) === "auto")
-				.map((qualityCase) => qualityCase.id),
-		);
-		for (const currentCase of current.cases) {
-			const expected = baselineById.get(currentCase.id);
-			const isAutoCase = autoCaseIds.has(currentCase.id);
-			if (!expected) {
-				// [Intended] 自動判定ケースは正解画像を持たないため、初回は現状を記録する
-				// だけで合否は問わない。以降は下の compareMetrics が悪化を検出する。
-				if (isAutoCase) continue;
-				const result = resultCache.get(currentCase.id);
-				expect(result?.status, `${currentCase.id} is a failing new case`).toBe(
-					"passed",
-				);
-				continue;
-			}
-			if (!isAutoCase) expect(currentCase.catastrophicFailure).toBe(false);
-			const result = resultCache.get(currentCase.id);
-			expect(result).toBeDefined();
-			if (!result) continue;
-			expect(
-				compareMetrics(result.metrics, expected, currentCase.status).regressed,
-				`${currentCase.id} regressed against the stored quality baseline`,
-			).toEqual([]);
-		}
-		// [Policy] 自動判定ケースを含む全ケースを 1 テストで突き合わせるため、
-		// ベースライン更新時の再処理も入る想定で待機時間を確保する。
-	}, 900_000);
+		},
+		BASELINE_UPDATE_TIMEOUT_MS,
+	);
 });

--- a/test/quality/image.ts
+++ b/test/quality/image.ts
@@ -1,7 +1,16 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	closeSync,
+	mkdirSync,
+	openSync,
+	readFileSync,
+	readSync,
+	writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { PNG } from "pngjs";
 import type { RawImage } from "../../src/shared/types";
+
+const PNG_IHDR_HEADER_BYTES = 24;
 
 export const readPng = (filePath: string): RawImage => {
 	const png = PNG.sync.read(readFileSync(filePath));
@@ -10,6 +19,24 @@ export const readPng = (filePath: string): RawImage => {
 		height: png.height,
 		data: new Uint8ClampedArray(png.data),
 	};
+};
+
+/**
+ * PNG の画素数を IHDR だけ読んで求める。
+ * 全ケースの実行コストを見積もるために使うので、デコードは避ける。
+ */
+export const pngPixelCount = (filePath: string): number => {
+	const header = Buffer.alloc(PNG_IHDR_HEADER_BYTES);
+	const file = openSync(filePath, "r");
+	try {
+		const read = readSync(file, header, 0, PNG_IHDR_HEADER_BYTES, 0);
+		if (read < PNG_IHDR_HEADER_BYTES) {
+			throw new Error(`Truncated PNG header: ${filePath}`);
+		}
+	} finally {
+		closeSync(file);
+	}
+	return header.readUInt32BE(16) * header.readUInt32BE(20);
 };
 
 export const writePng = (filePath: string, image: RawImage): void => {

--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -2,17 +2,19 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { Script } from "node:vm";
 import { describe, expect, it } from "vitest";
-import { generateQualityReport, reportRoot } from "./benchmark";
+import { reportRoot } from "./benchmark";
 import { loadCases, selectCasesForProfile } from "./manifest";
+import { aggregateQualityReport } from "./report/aggregate";
 
 const enabled = process.env.QUALITY_REPORT === "1";
 
 describe.skipIf(!enabled)("quality report", () => {
-	// [Policy] 共有CIランナーでも全品質ケースの生成を完了できるよう、通常のテストより長く待機する。
+	// [Intended] ケースの実処理は test/quality/shards が済ませている。ここは部分結果を
+	// 集約して成果物を書くだけなので、画像処理ぶんの待機時間は要らない。
 	it("writes JSON, Markdown, HTML, and every case artifact", () => {
 		const allCases = loadCases();
 		const selectedCases = selectCasesForProfile(allCases);
-		const results = generateQualityReport(selectedCases);
+		const results = aggregateQualityReport(selectedCases);
 		expect(results.cases).toHaveLength(selectedCases.length);
 		expect(existsSync(path.join(reportRoot, "index.html"))).toBe(true);
 		expect(existsSync(path.join(reportRoot, "summary.md"))).toBe(true);
@@ -247,5 +249,5 @@ describe.skipIf(!enabled)("quality report", () => {
 				);
 			}
 		}
-	}, 1_200_000);
+	}, 120_000);
 });

--- a/test/quality/report/aggregate.ts
+++ b/test/quality/report/aggregate.ts
@@ -1,0 +1,159 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { loadBaseline } from "../baseline";
+import { reportRoot } from "../benchmark";
+import type {
+	QualityCaseResult,
+	QualityImageCase,
+	QualityMetadata,
+	QualityResults,
+} from "../types";
+import { QUALITY_BENCHMARK_VERSION, QUALITY_REPORT_VERSION } from "../types";
+import { readQualityReportPartials } from "./partial";
+import { renderCaseDetailHtml, renderHtml, renderMarkdown } from "./render";
+
+const metadataFromEnvironment = (): QualityMetadata => {
+	const repository =
+		process.env.GITHUB_REPOSITORY ?? "HappyOnigiri/PixelRefiner";
+	const server = process.env.GITHUB_SERVER_URL ?? "https://github.com";
+	const runId = process.env.GITHUB_RUN_ID ?? "";
+	const baseline = loadBaseline();
+	return {
+		repositoryUrl: `${server}/${repository}`,
+		prNumber: process.env.QUALITY_PR_NUMBER ?? "local",
+		headCommit:
+			process.env.QUALITY_HEAD_SHA ?? process.env.GITHUB_SHA ?? "local",
+		baseCommit: process.env.QUALITY_BASE_SHA ?? "local",
+		generatedAt: new Date().toISOString(),
+		workflowRunUrl:
+			runId === "" ? "local" : `${server}/${repository}/actions/runs/${runId}`,
+		benchmarkVersion: QUALITY_BENCHMARK_VERSION,
+		reportVersion: QUALITY_REPORT_VERSION,
+		baselineCommit: baseline.commit,
+	};
+};
+
+const summarize = (cases: QualityCaseResult[]): QualityResults["summary"] => {
+	const count = cases.length;
+	const average = (select: (result: QualityCaseResult) => number): number => {
+		let total = 0;
+		for (const result of cases) total += select(result);
+		return count === 0 ? 0 : total / count;
+	};
+	const confidenceSamples = cases.flatMap((result) =>
+		result.gridCandidates.map((candidate) => ({
+			confidence: candidate.confidence,
+			correct: Number(
+				candidate.width === result.expectedWidth &&
+					candidate.height === result.expectedHeight,
+			),
+		})),
+	);
+	const sampleCount = confidenceSamples.length;
+	let confidenceTotal = 0;
+	let correctnessTotal = 0;
+	for (const sample of confidenceSamples) {
+		confidenceTotal += sample.confidence;
+		correctnessTotal += sample.correct;
+	}
+	const meanConfidence = sampleCount === 0 ? 0 : confidenceTotal / sampleCount;
+	const meanCorrectness =
+		sampleCount === 0 ? 0 : correctnessTotal / sampleCount;
+	let covariance = 0;
+	let confidenceVariance = 0;
+	let correctnessVariance = 0;
+	for (const sample of confidenceSamples) {
+		const confidenceDelta = sample.confidence - meanConfidence;
+		const correctnessDelta = sample.correct - meanCorrectness;
+		covariance += confidenceDelta * correctnessDelta;
+		confidenceVariance += confidenceDelta * confidenceDelta;
+		correctnessVariance += correctnessDelta * correctnessDelta;
+	}
+	const correlationDenominator = Math.sqrt(
+		confidenceVariance * correctnessVariance,
+	);
+	return {
+		caseCount: count,
+		passed: cases.filter((result) => result.status === "passed").length,
+		failed: cases.filter((result) => result.status === "failed").length,
+		changed: cases.filter((result) => result.changeStatus === "changed").length,
+		improved: cases.filter((result) => result.changeStatus === "improved")
+			.length,
+		regressed: cases.filter((result) => result.changeStatus === "regressed")
+			.length,
+		unchanged: cases.filter((result) => result.changeStatus === "unchanged")
+			.length,
+		newCases: cases.filter((result) => result.changeStatus === "new").length,
+		blockingFailures: cases.filter(
+			(result) =>
+				result.changeStatus === "regressed" ||
+				(result.changeStatus === "new" && result.status === "failed"),
+		).length,
+		explicitCases: cases.filter((result) => result.parameterMode === "explicit")
+			.length,
+		autoCases: cases.filter((result) => result.parameterMode === "auto").length,
+		top1SizeAccuracy: average((result) => Number(result.metrics.sizeCorrect)),
+		top3SizeAccuracy: average((result) =>
+			Number(result.metrics.top3SizeCorrect),
+		),
+		confidenceCorrectnessCorrelation:
+			correlationDenominator === 0 ? null : covariance / correlationDenominator,
+		byteIdentityRate: average((result) => Number(result.metrics.byteIdentical)),
+		catastrophicFailureRate: average((result) =>
+			Number(result.metrics.catastrophicFailure),
+		),
+		meanRgbaError: average((result) => result.metrics.meanRgbaError),
+		meanRuntimeMs: average((result) => result.metrics.runtimeMs),
+		approxPeakBytes: Math.max(
+			0,
+			...cases.map((result) => result.metrics.approxPeakBytes),
+		),
+	};
+};
+
+/**
+ * シャードが書き出した部分結果を突き合わせ、results.json とレポート HTML を生成する。
+ * ケースの実処理は行わないので、シャード実行のあとに 1 プロセスで呼ぶ。
+ */
+export const aggregateQualityReport = (
+	cases: QualityImageCase[],
+): QualityResults => {
+	const collected = new Map(
+		readQualityReportPartials().map((result) => [result.id, result]),
+	);
+	// [Intended] 集めた結果はケース定義の順序へ戻す。シャードの完了順に並べると
+	// results.json とレポートの並びが実行ごとに変わり、差分比較ができなくなる。
+	const caseResults: QualityCaseResult[] = [];
+	const missing: string[] = [];
+	for (const qualityCase of cases) {
+		const result = collected.get(qualityCase.id);
+		if (result === undefined) missing.push(qualityCase.id);
+		else caseResults.push(result);
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`Quality shard results are missing ${missing.length} case(s): ${missing.join(", ")}`,
+		);
+	}
+	const results: QualityResults = {
+		metadata: metadataFromEnvironment(),
+		summary: summarize(caseResults),
+		cases: caseResults,
+	};
+	mkdirSync(reportRoot, { recursive: true });
+	writeFileSync(
+		path.join(reportRoot, "results.json"),
+		`${JSON.stringify(results, null, 2)}\n`,
+	);
+	writeFileSync(path.join(reportRoot, "summary.md"), renderMarkdown(results));
+	writeFileSync(path.join(reportRoot, "index.html"), renderHtml(results));
+	for (const result of results.cases) {
+		const caseDirectory = path.join(reportRoot, "cases", result.id);
+		mkdirSync(caseDirectory, { recursive: true });
+		writeFileSync(
+			path.join(caseDirectory, "index.html"),
+			renderCaseDetailHtml(result),
+		);
+	}
+	return results;
+};

--- a/test/quality/report/partial.ts
+++ b/test/quality/report/partial.ts
@@ -1,0 +1,47 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { QualityCaseResult } from "../types";
+
+// [Policy] 部分結果はレポート成果物と混ぜない。tmp/quality-report/latest は
+// そのまま CI のアップロード対象になるため、中間ファイルを含めない場所へ書く。
+const PARTIAL_ROOT = path.resolve("tmp/quality-report/partial");
+
+const partialFile = (shardIndex: number): string =>
+	path.join(PARTIAL_ROOT, `shard-${String(shardIndex).padStart(2, "0")}.json`);
+
+/** シャードが担当したケースの結果を、集約側が読める中間ファイルへ書き出す。 */
+export const writeQualityReportPartial = (
+	shardIndex: number,
+	cases: QualityCaseResult[],
+): void => {
+	mkdirSync(PARTIAL_ROOT, { recursive: true });
+	writeFileSync(
+		partialFile(shardIndex),
+		`${JSON.stringify({ shardIndex, cases })}\n`,
+	);
+};
+
+/**
+ * 全シャードの部分結果を読み出す。
+ * ケース順序は集約側でケース定義の順に並べ直すため、ここでは保証しない。
+ */
+export const readQualityReportPartials = (): QualityCaseResult[] => {
+	if (!existsSync(PARTIAL_ROOT)) return [];
+	const cases: QualityCaseResult[] = [];
+	for (const fileName of readdirSync(PARTIAL_ROOT).sort()) {
+		if (!fileName.endsWith(".json")) continue;
+		const partial = JSON.parse(
+			readFileSync(path.join(PARTIAL_ROOT, fileName), "utf8"),
+		) as { shardIndex: number; cases: QualityCaseResult[] };
+		cases.push(...partial.cases);
+	}
+	return cases;
+};
+
+export const qualityReportPartialRoot = PARTIAL_ROOT;

--- a/test/quality/shard.ts
+++ b/test/quality/shard.ts
@@ -1,0 +1,210 @@
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { assertBaselineUpdateIsSafe, loadBaseline } from "./baseline";
+import {
+	runQualityCase,
+	toBaselineCaseEntry,
+	writeQualityBaselineImage,
+} from "./benchmark";
+import { compareMetrics } from "./comparison";
+import { pngPixelCount } from "./image";
+import {
+	caseParameterMode,
+	loadCases,
+	qualityProfileFromEnvironment,
+	selectCasesForProfile,
+} from "./manifest";
+import { writeQualityReportPartial } from "./report/partial";
+import type {
+	QualityBaselineCase,
+	QualityCaseResult,
+	QualityImageCase,
+} from "./types";
+import {
+	stagingBaselineImagePath,
+	writeQualityUpdatePartial,
+} from "./update/partial";
+
+/**
+ * ケースを分配するシャード数。
+ * test/quality/shards のファイル数と一致させる（cases.test.ts が検証する）。
+ */
+export const QUALITY_SHARD_COUNT = 10;
+
+// [Policy] 画像全体を対象とする品質ケースは、競合の激しい共有 CI ランナー上で
+// 実行される可能性があるため、正しさの検証には短い単体テストのタイムアウトを使用しない。
+const QUALITY_CASE_TIMEOUT_MS = 300_000;
+
+const reportMode = process.env.QUALITY_REPORT === "1";
+const updateMode = process.env.UPDATE_QUALITY_BASELINE === "1";
+const profile = qualityProfileFromEnvironment();
+
+// [Intended] 実行コストは入力の画素数にほぼ比例するため、これを重みに使う。
+// 寸法は PNG の先頭 24 バイトに入っているので、全ケースをデコードせずに済む。
+const caseWeight = (qualityCase: QualityImageCase): number => {
+	let weight = 0;
+	for (const file of [
+		qualityCase.input,
+		...(qualityCase.sharedPalette?.inputs ?? []),
+	]) {
+		weight += pngPixelCount(path.resolve(file));
+	}
+	return weight;
+};
+
+/**
+ * ケースをシャード数ぶんのグループへ静的に分配する。
+ * 重い順に空いているシャードへ詰める（最長処理時間優先）。単純な index % N だと
+ * 最重量ケースが同じシャードに集まり、シャード間の実行時間が倍近く偏る。
+ */
+export const shardCases = (
+	cases: QualityImageCase[],
+	shardCount: number,
+): QualityImageCase[][] => {
+	const buckets: QualityImageCase[][] = Array.from(
+		{ length: shardCount },
+		() => [],
+	);
+	const loads = new Array<number>(shardCount).fill(0);
+	const order = new Map(
+		cases.map((qualityCase, index) => [qualityCase.id, index]),
+	);
+	const weighted = cases
+		.map((qualityCase) => ({ qualityCase, weight: caseWeight(qualityCase) }))
+		.sort(
+			(left, right) =>
+				right.weight - left.weight ||
+				left.qualityCase.id.localeCompare(right.qualityCase.id),
+		);
+	for (const entry of weighted) {
+		let target = 0;
+		for (let index = 1; index < shardCount; index += 1) {
+			if (loads[index] < loads[target]) target = index;
+		}
+		buckets[target].push(entry.qualityCase);
+		loads[target] += entry.weight;
+	}
+	for (const bucket of buckets) {
+		bucket.sort(
+			(left, right) => (order.get(left.id) ?? 0) - (order.get(right.id) ?? 0),
+		);
+	}
+	return buckets;
+};
+
+const registerGateShard = (cases: QualityImageCase[]): void => {
+	const baselineById = new Map(
+		loadBaseline().cases.map((baselineCase) => [baselineCase.id, baselineCase]),
+	);
+	it.each(cases)(
+		"evaluates $id",
+		(qualityCase) => {
+			const result = runQualityCase(qualityCase);
+			const isAutoCase = caseParameterMode(qualityCase) === "auto";
+			expect(result.metrics.byteIdentical).toBe(true);
+			// [Intended] 自動判定ケースには正解画像がなく、破綻や出力サイズは
+			// 「今の自動判定の実力」そのものなので絶対値では落とさない。悪化は
+			// ベースライン比較（catastrophicFailure の false→true や指標低下）で捕まえる。
+			if (!isAutoCase) {
+				expect(result.metrics.catastrophicFailure).toBe(false);
+				expect(result.failedAssertions).not.toContain("output-size");
+				expect(result.failedAssertions).not.toContain("expected-width");
+				expect(result.failedAssertions).not.toContain("expected-height");
+			}
+			const expected = baselineById.get(qualityCase.id);
+			if (expected === undefined) {
+				// [Intended] 自動判定ケースは正解画像を持たないため、初回は現状を記録する
+				// だけで合否は問わない。以降は compareMetrics が悪化を検出する。
+				if (isAutoCase) return;
+				expect(result.status, `${qualityCase.id} is a failing new case`).toBe(
+					"passed",
+				);
+				return;
+			}
+			expect(
+				compareMetrics(result.metrics, expected, result.status).regressed,
+				`${qualityCase.id} regressed against the stored quality baseline`,
+			).toEqual([]);
+		},
+		QUALITY_CASE_TIMEOUT_MS,
+	);
+};
+
+/**
+ * ベースライン更新の stage1（並列生成）。各ケースを書き換え前の既存ベースラインに
+ * 対して測定し、指標と新しい出力画像をステージング領域へ書き出す。全シャードが
+ * 読むのは同じ既存ベースラインだけなので、この段階は読み取り専用で並列安全。
+ * test/quality/baseline.json と baseline/ 本体の置き換えは stage2（cases.test.ts の
+ * 更新ブロック）が集約後に一括で行う。
+ */
+const registerUpdateShard = (
+	cases: QualityImageCase[],
+	shardIndex: number,
+): void => {
+	const entries: QualityBaselineCase[] = [];
+	it.each(cases)(
+		"stages baseline update for $id",
+		(qualityCase) => {
+			const result = runQualityCase(qualityCase);
+			entries.push(toBaselineCaseEntry(result));
+			writeQualityBaselineImage(
+				qualityCase,
+				stagingBaselineImagePath(qualityCase.id),
+			);
+		},
+		QUALITY_CASE_TIMEOUT_MS,
+	);
+	afterAll(() => {
+		writeQualityUpdatePartial(shardIndex, entries);
+	});
+};
+
+const registerReportShard = (
+	cases: QualityImageCase[],
+	shardIndex: number,
+): void => {
+	const results: QualityCaseResult[] = [];
+	it.each(cases)(
+		"reports $id",
+		(qualityCase) => {
+			results.push(runQualityCase(qualityCase, true));
+		},
+		QUALITY_CASE_TIMEOUT_MS,
+	);
+	// [Intended] 取れた分だけ書き出す。欠けたケースは集約側が ID 付きで報告する。
+	afterAll(() => {
+		writeQualityReportPartial(shardIndex, results);
+	});
+};
+
+/**
+ * シャードファイルから呼ぶ入口。1 始まりのシャード番号を受け取る。
+ * UPDATE_QUALITY_BASELINE=1 のときはベースライン更新の並列生成、
+ * QUALITY_REPORT=1 のときはレポート成果物の生成、それ以外は品質ゲートを担う。
+ */
+export const runCasesShard = (shardIndex: number): void => {
+	const selectedCases = selectCasesForProfile(loadCases());
+	const cases = shardCases(selectedCases, QUALITY_SHARD_COUNT)[shardIndex - 1];
+	const assignedCases = cases ?? [];
+	describe(`quality cases shard ${shardIndex}/${QUALITY_SHARD_COUNT}`, () => {
+		it(`owns ${assignedCases.length} of ${selectedCases.length} cases`, () => {
+			const selectedIds = new Set(
+				selectedCases.map((qualityCase) => qualityCase.id),
+			);
+			for (const qualityCase of assignedCases) {
+				expect(selectedIds.has(qualityCase.id)).toBe(true);
+			}
+		});
+		if (assignedCases.length === 0) return;
+		if (updateMode) {
+			assertBaselineUpdateIsSafe(profile);
+			registerUpdateShard(assignedCases, shardIndex);
+			return;
+		}
+		if (reportMode) {
+			registerReportShard(assignedCases, shardIndex);
+			return;
+		}
+		registerGateShard(assignedCases);
+	});
+};

--- a/test/quality/shards/shard-01.test.ts
+++ b/test/quality/shards/shard-01.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(1);

--- a/test/quality/shards/shard-02.test.ts
+++ b/test/quality/shards/shard-02.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(2);

--- a/test/quality/shards/shard-03.test.ts
+++ b/test/quality/shards/shard-03.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(3);

--- a/test/quality/shards/shard-04.test.ts
+++ b/test/quality/shards/shard-04.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(4);

--- a/test/quality/shards/shard-05.test.ts
+++ b/test/quality/shards/shard-05.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(5);

--- a/test/quality/shards/shard-06.test.ts
+++ b/test/quality/shards/shard-06.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(6);

--- a/test/quality/shards/shard-07.test.ts
+++ b/test/quality/shards/shard-07.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(7);

--- a/test/quality/shards/shard-08.test.ts
+++ b/test/quality/shards/shard-08.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(8);

--- a/test/quality/shards/shard-09.test.ts
+++ b/test/quality/shards/shard-09.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(9);

--- a/test/quality/shards/shard-10.test.ts
+++ b/test/quality/shards/shard-10.test.ts
@@ -1,0 +1,5 @@
+import { runCasesShard } from "../shard";
+
+// [Intended] シャードごとに別ファイルへ分けるのは、vitest がテストファイル単位で
+// プロセス並列化するため。1 ファイルにまとめると全ケースが直列実行になる。
+runCasesShard(10);

--- a/test/quality/update/partial.ts
+++ b/test/quality/update/partial.ts
@@ -1,0 +1,56 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { QualityBaselineCase } from "../types";
+
+// [Policy] ステージング領域はベースライン更新の中間生成物専用。集約側が読み終えたら
+// 使い捨てるので、成果物である test/quality/baseline* とは別に tmp 配下へ置く。
+const UPDATE_ROOT = path.resolve("tmp/quality-baseline-update");
+const PARTIAL_ROOT = path.join(UPDATE_ROOT, "partial");
+const IMAGE_ROOT = path.join(UPDATE_ROOT, "images");
+
+const partialFile = (shardIndex: number): string =>
+	path.join(PARTIAL_ROOT, `shard-${String(shardIndex).padStart(2, "0")}.json`);
+
+/** シャードが計算したベースライン更新分の指標を、集約側が読める中間ファイルへ書き出す。 */
+export const writeQualityUpdatePartial = (
+	shardIndex: number,
+	entries: QualityBaselineCase[],
+): void => {
+	mkdirSync(PARTIAL_ROOT, { recursive: true });
+	writeFileSync(
+		partialFile(shardIndex),
+		`${JSON.stringify({ shardIndex, entries })}\n`,
+	);
+};
+
+/**
+ * 全シャードの部分結果を読み出す。
+ * ケース順序は集約側で選択済みケースの定義順に並べ直すため、ここでは保証しない。
+ */
+export const readQualityUpdatePartials = (): QualityBaselineCase[] => {
+	if (!existsSync(PARTIAL_ROOT)) return [];
+	const entries: QualityBaselineCase[] = [];
+	for (const fileName of readdirSync(PARTIAL_ROOT).sort()) {
+		if (!fileName.endsWith(".json")) continue;
+		const partial = JSON.parse(
+			readFileSync(path.join(PARTIAL_ROOT, fileName), "utf8"),
+		) as { shardIndex: number; entries: QualityBaselineCase[] };
+		entries.push(...partial.entries);
+	}
+	return entries;
+};
+
+/**
+ * シャードが並列に書き出す、新しいベースライン画像のステージング先。
+ * ケース ID ごとにファイルが分かれるため、シャード間で書き込み先が衝突しない。
+ */
+export const stagingBaselineImagePath = (caseId: string): string =>
+	path.join(IMAGE_ROOT, `${caseId}.png`);
+
+export const qualityUpdateRoot = UPDATE_ROOT;


### PR DESCRIPTION
## 概要

品質ベンチマークとベースライン更新を複数シャードで実行できるようにし、大規模な品質検証の待ち時間を短縮する。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 品質ケースを10シャードに分配し、レポート生成とベースライン更新の計測を並列化する。
- レポートとベースライン更新の集約・書き込みを単一処理に分離し、並列実行時の競合を防ぐ。
- CIの品質ベンチマークに合わせてタイムアウトと実行コマンドを更新する。

### その他

- なし

## 動作確認

- なし
