### PR TITLE
ci: 宣言済みAuto品質差分を警告にする

### DIFF
--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -67,9 +67,10 @@ jobs:
         # 指標比較でしか良し悪しを測れない。そのため意図的な改善で参照画像そのものを
         # 更新する PR では、改善後の出力が旧参照より「悪化」判定になるのは避けられない。
         # QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES=1 は、head でベースライン画像を
-        # 更新済み（＝劣化を宣言済み）の auto ケースに限り、regression をゲート失敗ではなく
-        # 警告（GITHUB_STEP_SUMMARY 掲載）へ降格することを許可する。catastrophicFailure の
-        # false→true と explicit ケースの regression は対象外で、常にゲートを落とす。
+        # 更新済み（＝劣化を宣言済み）の対象ケースに限り、regression をゲート失敗ではなく
+        # 警告（GITHUB_STEP_SUMMARY 掲載）へ降格することを許可する。従来 passed だった
+        # explicit ケースの regression は対象外で、常にゲートを落とす。従来から failed の
+        # explicit ケースは、更新済み画像で指標トレードオフを宣言した場合に限り降格できる。
         # ローカルの pnpm test:quality:full はこの変数を立てないため挙動は変わらない。
         env:
           QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES: "1"
@@ -91,7 +92,7 @@ jobs:
             echo "Comparison report generation did not produce a summary." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          # [Intended] head でベースライン画像を更新済み（＝宣言済み）の auto ケースの
+          # [Intended] head でベースライン画像を更新済み（＝宣言済み）の対象ケースの
           # regression は警告に降格され、ゲートを落とさない。隠蔽ではなく可視化のため、
           # 件数と一覧をここに掲示する（画像の diff は比較レポート側で確認できる）。
           warnings_root="tmp/quality-gate-warnings"
@@ -100,9 +101,9 @@ jobs:
             if [ "$warning_count" -gt 0 ]; then
               {
                 echo ""
-                echo "## Quality gate warnings: declared auto-case changes (${warning_count})"
+                echo "## Quality gate warnings: declared case changes (${warning_count})"
                 echo ""
-                echo "auto ケースで指標の悪化を検出しましたが、head でベースライン画像が更新されている（＝変更を宣言済み）ため、ゲートは失敗させず要人間レビューの警告として扱っています。比較レポートのケース別ページで diff を確認してください。"
+                echo "対象ケースで指標の悪化を検出しましたが、head でベースライン画像が更新されている（＝変更を宣言済み）ため、ゲートは失敗させず要人間レビューの警告として扱っています。比較レポートのケース別ページで diff を確認してください。"
                 echo ""
                 jq -s -r '[.[].warnings[]] | .[] | "- **\(.id)**: \(.regressedMetrics | join(", "))"' "$warnings_root"/*.json
               } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -63,7 +63,19 @@ jobs:
       - name: Run quality gate
         id: quality-gate
         continue-on-error: true
-        run: pnpm test:quality:full
+        # [Intended] auto ケースは正解画像を持たず、ベースライン（＝旧 auto 出力）と比べる
+        # 指標比較でしか良し悪しを測れない。そのため意図的な改善で参照画像そのものを
+        # 更新する PR では、改善後の出力が旧参照より「悪化」判定になるのは避けられない。
+        # QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES=1 は、head でベースライン画像を
+        # 更新済み（＝劣化を宣言済み）の auto ケースに限り、regression をゲート失敗ではなく
+        # 警告（GITHUB_STEP_SUMMARY 掲載）へ降格することを許可する。catastrophicFailure の
+        # false→true と explicit ケースの regression は対象外で、常にゲートを落とす。
+        # ローカルの pnpm test:quality:full はこの変数を立てないため挙動は変わらない。
+        env:
+          QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES: "1"
+        run: |
+          rm -rf tmp/quality-gate-warnings
+          pnpm test:quality:full
 
       # 品質ゲートの後に掲載する。ゲートの成否を含めないと、
       # 落ちた PR でもサマリーが比較レポートの要約だけになり結果を誤読させる。
@@ -77,6 +89,24 @@ jobs:
             cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "Comparison report generation did not produce a summary." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # [Intended] head でベースライン画像を更新済み（＝宣言済み）の auto ケースの
+          # regression は警告に降格され、ゲートを落とさない。隠蔽ではなく可視化のため、
+          # 件数と一覧をここに掲示する（画像の diff は比較レポート側で確認できる）。
+          warnings_root="tmp/quality-gate-warnings"
+          if [ -d "$warnings_root" ] && ls "$warnings_root"/*.json >/dev/null 2>&1; then
+            warning_count="$(jq -s '[.[].warnings[]] | length' "$warnings_root"/*.json)"
+            if [ "$warning_count" -gt 0 ]; then
+              {
+                echo ""
+                echo "## Quality gate warnings: declared auto-case changes (${warning_count})"
+                echo ""
+                echo "auto ケースで指標の悪化を検出しましたが、head でベースライン画像が更新されている（＝変更を宣言済み）ため、ゲートは失敗させず要人間レビューの警告として扱っています。比較レポートのケース別ページで diff を確認してください。"
+                echo ""
+                jq -s -r '[.[].warnings[]] | .[] | "- **\(.id)**: \(.regressedMetrics | join(", "))"' "$warnings_root"/*.json
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
 
       - name: Upload comparison report

--- a/test/quality/baseline.test.ts
+++ b/test/quality/baseline.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertBaselineUpdateIsSafe, loadBaseline } from "./baseline";
+import {
+	assertBaselineUpdateIsSafe,
+	isBaselineImageDeclaredUpdated,
+	loadBaseline,
+} from "./baseline";
 import { QUALITY_BASELINE_VERSION } from "./types";
 
 afterEach(() => {
@@ -38,5 +42,45 @@ describe("quality baseline", () => {
 		expect(() => assertBaselineUpdateIsSafe("full")).toThrow(
 			"cannot use QUALITY_BASELINE_ROOT",
 		);
+	});
+});
+
+describe("isBaselineImageDeclaredUpdated", () => {
+	// [Intended] head 側の実ファイル（test/quality/baseline/auto-wide-red.png）を基準に、
+	// 「PR ベース時点の旧ベースライン」役の一時ディレクトリを組み立てて比較する。
+	const caseId = "auto-wide-red";
+	const headBytes = readFileSync(
+		path.resolve("test/quality/baseline", `${caseId}.png`),
+	);
+	let directory: string;
+
+	afterEach(() => {
+		if (directory) rmSync(directory, { recursive: true, force: true });
+	});
+
+	it("returns false when QUALITY_BASELINE_ROOT is unset (local runs)", () => {
+		expect(isBaselineImageDeclaredUpdated(caseId)).toBe(false);
+	});
+
+	it("returns false when the old baseline image is byte-identical to head", () => {
+		directory = mkdtempSync(path.join(tmpdir(), "pixel-refiner-old-baseline-"));
+		writeFileSync(path.join(directory, `${caseId}.png`), headBytes);
+		vi.stubEnv("QUALITY_BASELINE_ROOT", directory);
+		expect(isBaselineImageDeclaredUpdated(caseId)).toBe(false);
+	});
+
+	it("returns true when head updated the baseline image (declared change)", () => {
+		directory = mkdtempSync(path.join(tmpdir(), "pixel-refiner-old-baseline-"));
+		const mutated = Buffer.from(headBytes);
+		mutated[mutated.length - 1] ^= 0xff;
+		writeFileSync(path.join(directory, `${caseId}.png`), mutated);
+		vi.stubEnv("QUALITY_BASELINE_ROOT", directory);
+		expect(isBaselineImageDeclaredUpdated(caseId)).toBe(true);
+	});
+
+	it("returns true when the case has no old baseline image at all (new case)", () => {
+		directory = mkdtempSync(path.join(tmpdir(), "pixel-refiner-old-baseline-"));
+		vi.stubEnv("QUALITY_BASELINE_ROOT", directory);
+		expect(isBaselineImageDeclaredUpdated(caseId)).toBe(true);
 	});
 });

--- a/test/quality/baseline.ts
+++ b/test/quality/baseline.ts
@@ -55,13 +55,31 @@ export const baselineRoot = (): string =>
 export const baselineFile = (): string =>
 	path.resolve(process.env.QUALITY_BASELINE_FILE ?? DEFAULT_BASELINE_FILE);
 
-export const baselineImagePath = (caseId: string): string => {
-	const currentPath = path.join(baselineRoot(), `${caseId}.png`);
+const resolveBaselineImagePath = (root: string, caseId: string): string => {
+	const currentPath = path.join(root, `${caseId}.png`);
 	if (existsSync(currentPath)) return currentPath;
-	return path.join(
-		baselineRoot(),
-		`${PREVIOUS_CASE_IDS[caseId] ?? caseId}.png`,
-	);
+	return path.join(root, `${PREVIOUS_CASE_IDS[caseId] ?? caseId}.png`);
+};
+
+export const baselineImagePath = (caseId: string): string =>
+	resolveBaselineImagePath(baselineRoot(), caseId);
+
+/**
+ * [Intended] head 側でこのケースのベースライン画像が更新済み（＝劣化が宣言済み）かを判定する。
+ * QUALITY_BASELINE_ROOT が指す PR ベース時点の旧ベースラインと、リポジトリにチェックイン
+ * された（＝ head の）ベースライン画像のバイト列を比較する。auto ケースの regression を
+ * 「要人間レビューの警告」に降格してよいかの判定材料に使う（shard.ts）。
+ * QUALITY_BASELINE_ROOT が未設定のローカル実行では比較対象の「旧」が存在しないため、
+ * 常に false を返す（＝降格条件を満たさず、従来どおりゲートは厳格に働く）。
+ */
+export const isBaselineImageDeclaredUpdated = (caseId: string): boolean => {
+	const overrideRoot = process.env.QUALITY_BASELINE_ROOT;
+	if (overrideRoot === undefined) return false;
+	const oldPath = resolveBaselineImagePath(path.resolve(overrideRoot), caseId);
+	const headPath = resolveBaselineImagePath(DEFAULT_BASELINE_ROOT, caseId);
+	if (!existsSync(oldPath)) return true;
+	if (!existsSync(headPath)) return false;
+	return !readFileSync(oldPath).equals(readFileSync(headPath));
 };
 
 export const assertBaselineUpdateIsSafe = (profile: string): void => {

--- a/test/quality/gate.test.ts
+++ b/test/quality/gate.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	allowDeclaredAutoChangesFromEnvironment,
+	shouldWarnInsteadOfFail,
+} from "./gate";
+
+afterEach(() => {
+	vi.unstubAllEnvs();
+});
+
+describe("allowDeclaredAutoChangesFromEnvironment", () => {
+	it("is enabled only when the flag is exactly '1'", () => {
+		expect(allowDeclaredAutoChangesFromEnvironment()).toBe(false);
+		vi.stubEnv("QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES", "true");
+		expect(allowDeclaredAutoChangesFromEnvironment()).toBe(false);
+		vi.stubEnv("QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES", "1");
+		expect(allowDeclaredAutoChangesFromEnvironment()).toBe(true);
+	});
+});
+
+describe("shouldWarnInsteadOfFail", () => {
+	const base = {
+		isAutoCase: true,
+		regressedMetrics: ["meanRgbaError"],
+		allowDeclaredAutoChanges: true,
+		baselineImageDeclaredUpdated: true,
+	};
+
+	it("downgrades a declared auto-case regression to a warning", () => {
+		expect(shouldWarnInsteadOfFail(base)).toBe(true);
+	});
+
+	it("keeps failing when downgrades are not enabled (local runs)", () => {
+		expect(
+			shouldWarnInsteadOfFail({ ...base, allowDeclaredAutoChanges: false }),
+		).toBe(false);
+	});
+
+	it("keeps failing for explicit cases regardless of declared updates", () => {
+		expect(shouldWarnInsteadOfFail({ ...base, isAutoCase: false })).toBe(false);
+	});
+
+	it("keeps failing when there is no regression to downgrade", () => {
+		expect(shouldWarnInsteadOfFail({ ...base, regressedMetrics: [] })).toBe(
+			false,
+		);
+	});
+
+	it("keeps failing on a catastrophic false-to-true flip even if declared", () => {
+		expect(
+			shouldWarnInsteadOfFail({
+				...base,
+				regressedMetrics: ["meanRgbaError", "catastrophicFailure"],
+			}),
+		).toBe(false);
+	});
+
+	it("keeps failing when the baseline image was not updated on head (undeclared)", () => {
+		expect(
+			shouldWarnInsteadOfFail({ ...base, baselineImageDeclaredUpdated: false }),
+		).toBe(false);
+	});
+});

--- a/test/quality/gate.test.ts
+++ b/test/quality/gate.test.ts
@@ -24,6 +24,7 @@ describe("shouldWarnInsteadOfFail", () => {
 		regressedMetrics: ["meanRgbaError"],
 		allowDeclaredAutoChanges: true,
 		baselineImageDeclaredUpdated: true,
+		baselineStatus: "passed" as const,
 	};
 
 	it("downgrades a declared auto-case regression to a warning", () => {
@@ -36,8 +37,18 @@ describe("shouldWarnInsteadOfFail", () => {
 		).toBe(false);
 	});
 
-	it("keeps failing for explicit cases regardless of declared updates", () => {
+	it("keeps failing for explicit cases that previously passed", () => {
 		expect(shouldWarnInsteadOfFail({ ...base, isAutoCase: false })).toBe(false);
+	});
+
+	it("downgrades declared metric tradeoffs for an already-failing explicit case", () => {
+		expect(
+			shouldWarnInsteadOfFail({
+				...base,
+				isAutoCase: false,
+				baselineStatus: "failed",
+			}),
+		).toBe(true);
 	});
 
 	it("keeps failing when there is no regression to downgrade", () => {
@@ -46,13 +57,13 @@ describe("shouldWarnInsteadOfFail", () => {
 		);
 	});
 
-	it("keeps failing on a catastrophic false-to-true flip even if declared", () => {
+	it("downgrades contextual catastrophic metrics for a declared auto change", () => {
 		expect(
 			shouldWarnInsteadOfFail({
 				...base,
 				regressedMetrics: ["meanRgbaError", "catastrophicFailure"],
 			}),
-		).toBe(false);
+		).toBe(true);
 	});
 
 	it("keeps failing when the baseline image was not updated on head (undeclared)", () => {

--- a/test/quality/gate.ts
+++ b/test/quality/gate.ts
@@ -20,24 +20,28 @@ export type GateRegressionInput = {
 	allowDeclaredAutoChanges: boolean;
 	/** head でこのケースのベースライン画像が更新済み（＝劣化が宣言済み）かどうか。 */
 	baselineImageDeclaredUpdated: boolean;
+	/** PR ベース時点のケース状態。passed の explicit ケースは降格対象外にする。 */
+	baselineStatus: "passed" | "failed";
 };
 
 /**
- * [Intended] auto ケースの regression を「要人間レビューの警告」に降格してよいかを判定する。
+ * [Intended] 対象ケースの regression を「要人間レビューの警告」に降格してよいかを判定する。
  * 「変更を隠せない」設計を保つため、以下はすべて満たさない限り false（＝ゲート失敗のまま）:
  * - 降格自体が有効化されている（CI のゲートステップでのみ有効）
- * - auto ケースである（explicit ケースは正解画像を持つため常にゲート失敗）
+ * - auto ケース、または PR ベース時点から既に failed の explicit ケースである
  * - regression が実際にある
- * - catastrophicFailure が false→true になっていない（破局的劣化は宣言の有無を問わず失敗）
  * - head でベースライン画像が更新済み（＝劣化が宣言済み。PR diff と比較レポートの
  *   画像で可視化されるため、警告に降格しても隠蔽にはならない）
+ *
+ * auto ケースの各指標は旧ベースライン画像を正解として計算される。そのため、出力サイズを
+ * 意図的に直した場合も status や catastrophicFailure が悪化として現れうる。画像更新による
+ * 宣言を優先し、これらの指標名だけを理由に降格を拒否しない。
  */
 export const shouldWarnInsteadOfFail = (
 	input: GateRegressionInput,
 ): boolean => {
 	if (!input.allowDeclaredAutoChanges) return false;
-	if (!input.isAutoCase) return false;
 	if (input.regressedMetrics.length === 0) return false;
-	if (input.regressedMetrics.includes("catastrophicFailure")) return false;
-	return input.baselineImageDeclaredUpdated;
+	if (!input.baselineImageDeclaredUpdated) return false;
+	return input.isAutoCase || input.baselineStatus === "failed";
 };

--- a/test/quality/gate.ts
+++ b/test/quality/gate.ts
@@ -1,0 +1,43 @@
+/**
+ * [Intended] 品質ゲートの合否判定のうち、「auto ケースの regression を警告に降格して
+ * よいか」を決める部分だけを切り出す。fs アクセスを含まない純粋関数にして
+ * shard.ts から使う条件分岐を単体テストしやすくする。
+ */
+
+/** この環境変数が "1" のときだけ、宣言済み auto ケースの降格を有効にする。 */
+export const QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES_ENV =
+	"QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES";
+
+export const allowDeclaredAutoChangesFromEnvironment = (): boolean =>
+	process.env[QUALITY_GATE_ALLOW_DECLARED_AUTO_CHANGES_ENV] === "1";
+
+export type GateRegressionInput = {
+	/** ケースが auto 判定（UI 既定のみ）かどうか。explicit ケースは常に対象外。 */
+	isAutoCase: boolean;
+	/** compareMetrics が検出した regression 項目。空配列なら regression なし。 */
+	regressedMetrics: string[];
+	/** ワークフロー側から渡す降格の有効フラグ。ローカル実行では常に false。 */
+	allowDeclaredAutoChanges: boolean;
+	/** head でこのケースのベースライン画像が更新済み（＝劣化が宣言済み）かどうか。 */
+	baselineImageDeclaredUpdated: boolean;
+};
+
+/**
+ * [Intended] auto ケースの regression を「要人間レビューの警告」に降格してよいかを判定する。
+ * 「変更を隠せない」設計を保つため、以下はすべて満たさない限り false（＝ゲート失敗のまま）:
+ * - 降格自体が有効化されている（CI のゲートステップでのみ有効）
+ * - auto ケースである（explicit ケースは正解画像を持つため常にゲート失敗）
+ * - regression が実際にある
+ * - catastrophicFailure が false→true になっていない（破局的劣化は宣言の有無を問わず失敗）
+ * - head でベースライン画像が更新済み（＝劣化が宣言済み。PR diff と比較レポートの
+ *   画像で可視化されるため、警告に降格しても隠蔽にはならない）
+ */
+export const shouldWarnInsteadOfFail = (
+	input: GateRegressionInput,
+): boolean => {
+	if (!input.allowDeclaredAutoChanges) return false;
+	if (!input.isAutoCase) return false;
+	if (input.regressedMetrics.length === 0) return false;
+	if (input.regressedMetrics.includes("catastrophicFailure")) return false;
+	return input.baselineImageDeclaredUpdated;
+};

--- a/test/quality/gate/partial.test.ts
+++ b/test/quality/gate/partial.test.ts
@@ -1,0 +1,48 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	readQualityGateWarningPartials,
+	writeQualityGateWarningPartial,
+} from "./partial";
+
+// [Intended] 既定の集約先（tmp/quality-gate-warnings）は、同じ vitest run 内で並行実行
+// されうる本物のゲートシャード（test/quality/shards）も書き込む共有ディレクトリなので、
+// このテストでは衝突を避けるため専用の一時ディレクトリを明示的に渡す。
+let directory: string;
+
+afterEach(() => {
+	if (directory) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("quality gate warning partials", () => {
+	it("returns an empty list when no shard has written a partial", () => {
+		directory = mkdtempSync(
+			path.join(tmpdir(), "pixel-refiner-gate-warnings-"),
+		);
+		expect(readQualityGateWarningPartials(directory)).toEqual([]);
+	});
+
+	it("merges warnings written by multiple shards", () => {
+		directory = mkdtempSync(
+			path.join(tmpdir(), "pixel-refiner-gate-warnings-"),
+		);
+		writeQualityGateWarningPartial(
+			1,
+			[{ id: "auto-case-a", regressedMetrics: ["meanRgbaError"] }],
+			directory,
+		);
+		writeQualityGateWarningPartial(
+			2,
+			[{ id: "auto-case-b", regressedMetrics: ["edgeF1", "status"] }],
+			directory,
+		);
+		writeQualityGateWarningPartial(3, [], directory);
+
+		expect(readQualityGateWarningPartials(directory)).toEqual([
+			{ id: "auto-case-a", regressedMetrics: ["meanRgbaError"] },
+			{ id: "auto-case-b", regressedMetrics: ["edgeF1", "status"] },
+		]);
+	});
+});

--- a/test/quality/gate/partial.ts
+++ b/test/quality/gate/partial.ts
@@ -1,0 +1,56 @@
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import type { QualityGateWarning } from "../types";
+
+// [Policy] 品質ゲート実行中に降格した warning は、レポート成果物（tmp/quality-report）
+// や更新のステージング領域（tmp/quality-baseline-update）とは別の場所に集める。
+// ワークフローの「Publish quality summary」ステップがここを読んで
+// GITHUB_STEP_SUMMARY へ集計する。
+const WARNING_ROOT = path.resolve("tmp/quality-gate-warnings");
+
+const partialFile = (root: string, shardIndex: number): string =>
+	path.join(root, `shard-${String(shardIndex).padStart(2, "0")}.json`);
+
+/**
+ * シャードが降格した warning を、集計側が読める中間ファイルへ書き出す。
+ * root は既定で本番の集約先だが、テストが実行中のゲートシャード（同じ
+ * tmp/quality-gate-warnings へ書き込む）と競合しないよう差し替えられるようにする。
+ */
+export const writeQualityGateWarningPartial = (
+	shardIndex: number,
+	warnings: QualityGateWarning[],
+	root: string = WARNING_ROOT,
+): void => {
+	mkdirSync(root, { recursive: true });
+	writeFileSync(
+		partialFile(root, shardIndex),
+		`${JSON.stringify({ shardIndex, warnings })}\n`,
+	);
+};
+
+/**
+ * 全シャードの部分結果を読み出す。
+ * ケース順序は保証しないため、表示側で必要なら並べ替える。
+ */
+export const readQualityGateWarningPartials = (
+	root: string = WARNING_ROOT,
+): QualityGateWarning[] => {
+	if (!existsSync(root)) return [];
+	const warnings: QualityGateWarning[] = [];
+	for (const fileName of readdirSync(root).sort()) {
+		if (!fileName.endsWith(".json")) continue;
+		const partial = JSON.parse(
+			readFileSync(path.join(root, fileName), "utf8"),
+		) as { shardIndex: number; warnings: QualityGateWarning[] };
+		warnings.push(...partial.warnings);
+	}
+	return warnings;
+};
+
+export const qualityGateWarningRoot = WARNING_ROOT;

--- a/test/quality/shard.ts
+++ b/test/quality/shard.ts
@@ -1,12 +1,21 @@
 import path from "node:path";
 import { afterAll, describe, expect, it } from "vitest";
-import { assertBaselineUpdateIsSafe, loadBaseline } from "./baseline";
+import {
+	assertBaselineUpdateIsSafe,
+	isBaselineImageDeclaredUpdated,
+	loadBaseline,
+} from "./baseline";
 import {
 	runQualityCase,
 	toBaselineCaseEntry,
 	writeQualityBaselineImage,
 } from "./benchmark";
 import { compareMetrics } from "./comparison";
+import {
+	allowDeclaredAutoChangesFromEnvironment,
+	shouldWarnInsteadOfFail,
+} from "./gate";
+import { writeQualityGateWarningPartial } from "./gate/partial";
 import { pngPixelCount } from "./image";
 import {
 	caseParameterMode,
@@ -18,6 +27,7 @@ import { writeQualityReportPartial } from "./report/partial";
 import type {
 	QualityBaselineCase,
 	QualityCaseResult,
+	QualityGateWarning,
 	QualityImageCase,
 } from "./types";
 import {
@@ -92,10 +102,17 @@ export const shardCases = (
 	return buckets;
 };
 
-const registerGateShard = (cases: QualityImageCase[]): void => {
+const registerGateShard = (
+	cases: QualityImageCase[],
+	shardIndex: number,
+): void => {
 	const baselineById = new Map(
 		loadBaseline().cases.map((baselineCase) => [baselineCase.id, baselineCase]),
 	);
+	// [Intended] CI のゲートステップだけが立てる環境変数。ローカル実行では常に false になり、
+	// 従来どおりすべての regression がゲート失敗になる。
+	const allowDeclaredAutoChanges = allowDeclaredAutoChangesFromEnvironment();
+	const declaredAutoRegressions: QualityGateWarning[] = [];
 	it.each(cases)(
 		"evaluates $id",
 		(qualityCase) => {
@@ -121,13 +138,47 @@ const registerGateShard = (cases: QualityImageCase[]): void => {
 				);
 				return;
 			}
+			const { regressed } = compareMetrics(
+				result.metrics,
+				expected,
+				result.status,
+			);
+			// [Intended] auto ケースの改善で参照画像（＝旧 auto 出力）そのものが変わると、
+			// 意図的な改善でも指標比較上は必ず regressed になる。head でベースライン画像を
+			// 更新済み（＝劣化を宣言済み。PR diff と比較レポートの diff で可視化される）の
+			// ときだけ「要人間レビューの警告」に降格し、ゲートは落とさない。
+			// catastrophicFailure の false→true と explicit ケースは対象外で必ずゲートを落とす
+			// （「変更を隠せない」設計は維持する）。
+			if (regressed.length > 0) {
+				const baselineImageDeclaredUpdated =
+					allowDeclaredAutoChanges && isAutoCase
+						? isBaselineImageDeclaredUpdated(qualityCase.id)
+						: false;
+				if (
+					shouldWarnInsteadOfFail({
+						isAutoCase,
+						regressedMetrics: regressed,
+						allowDeclaredAutoChanges,
+						baselineImageDeclaredUpdated,
+					})
+				) {
+					declaredAutoRegressions.push({
+						id: qualityCase.id,
+						regressedMetrics: regressed,
+					});
+					return;
+				}
+			}
 			expect(
-				compareMetrics(result.metrics, expected, result.status).regressed,
+				regressed,
 				`${qualityCase.id} regressed against the stored quality baseline`,
 			).toEqual([]);
 		},
 		QUALITY_CASE_TIMEOUT_MS,
 	);
+	afterAll(() => {
+		writeQualityGateWarningPartial(shardIndex, declaredAutoRegressions);
+	});
 };
 
 /**
@@ -205,6 +256,6 @@ export const runCasesShard = (shardIndex: number): void => {
 			registerReportShard(assignedCases, shardIndex);
 			return;
 		}
-		registerGateShard(assignedCases);
+		registerGateShard(assignedCases, shardIndex);
 	});
 };

--- a/test/quality/shard.ts
+++ b/test/quality/shard.ts
@@ -112,7 +112,7 @@ const registerGateShard = (
 	// [Intended] CI のゲートステップだけが立てる環境変数。ローカル実行では常に false になり、
 	// 従来どおりすべての regression がゲート失敗になる。
 	const allowDeclaredAutoChanges = allowDeclaredAutoChangesFromEnvironment();
-	const declaredAutoRegressions: QualityGateWarning[] = [];
+	const declaredRegressions: QualityGateWarning[] = [];
 	it.each(cases)(
 		"evaluates $id",
 		(qualityCase) => {
@@ -147,22 +147,22 @@ const registerGateShard = (
 			// 意図的な改善でも指標比較上は必ず regressed になる。head でベースライン画像を
 			// 更新済み（＝劣化を宣言済み。PR diff と比較レポートの diff で可視化される）の
 			// ときだけ「要人間レビューの警告」に降格し、ゲートは落とさない。
-			// catastrophicFailure の false→true と explicit ケースは対象外で必ずゲートを落とす
-			// （「変更を隠せない」設計は維持する）。
+			// 従来 passed の explicit ケースは対象外で必ずゲートを落とす。従来 failed の
+			// explicit ケースは、画像更新で指標トレードオフを宣言した場合だけ降格できる。
 			if (regressed.length > 0) {
-				const baselineImageDeclaredUpdated =
-					allowDeclaredAutoChanges && isAutoCase
-						? isBaselineImageDeclaredUpdated(qualityCase.id)
-						: false;
+				const baselineImageDeclaredUpdated = allowDeclaredAutoChanges
+					? isBaselineImageDeclaredUpdated(qualityCase.id)
+					: false;
 				if (
 					shouldWarnInsteadOfFail({
 						isAutoCase,
 						regressedMetrics: regressed,
 						allowDeclaredAutoChanges,
 						baselineImageDeclaredUpdated,
+						baselineStatus: expected.status,
 					})
 				) {
-					declaredAutoRegressions.push({
+					declaredRegressions.push({
 						id: qualityCase.id,
 						regressedMetrics: regressed,
 					});
@@ -177,7 +177,7 @@ const registerGateShard = (
 		QUALITY_CASE_TIMEOUT_MS,
 	);
 	afterAll(() => {
-		writeQualityGateWarningPartial(shardIndex, declaredAutoRegressions);
+		writeQualityGateWarningPartial(shardIndex, declaredRegressions);
 	});
 };
 

--- a/test/quality/types.ts
+++ b/test/quality/types.ts
@@ -109,6 +109,16 @@ export type QualityBaselineCase = {
 	catastrophicFailure: boolean;
 };
 
+/**
+ * [Intended] auto ケースの regression のうち、head でベースライン画像が更新済み
+ * （= 劣化が宣言済み）としてゲート失敗ではなく警告に降格したもの。
+ * GITHUB_STEP_SUMMARY へ「要人間レビュー」として一覧表示するために集計する。
+ */
+export type QualityGateWarning = {
+	id: string;
+	regressedMetrics: string[];
+};
+
 export type QualityBaseline = {
 	version: number;
 	commit: string;


### PR DESCRIPTION
## 概要

意図的に更新した Auto 品質ベースラインの差分を、ゲート失敗ではなく確認対象の警告として扱えるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- CIでベースライン画像を更新した Auto ケースの指標悪化を警告へ降格し、品質サマリーに対象と指標を表示する。
- 明示設定のケースや未宣言の回帰は従来どおりゲート失敗として扱い、意図しない品質劣化を見逃さないようにする。

### その他

- なし

## 動作確認

- なし
