### PR TITLE
fix: 品質レポート画像の初期表示崩れを修正

### DIFF
--- a/test/quality/report/styles.test.ts
+++ b/test/quality/report/styles.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { DETAIL_REPORT_STYLES, INDEX_REPORT_STYLES } from "./styles";
+
+describe("quality report image styles", () => {
+	it("constrains images before their load handler sets dimensions", () => {
+		for (const styles of [INDEX_REPORT_STYLES, DETAIL_REPORT_STYLES]) {
+			expect(styles).toMatch(
+				/\.image-stage img \{[^}]*max-width: 100%;[^}]*max-height: 100%;/,
+			);
+		}
+	});
+});

--- a/test/quality/report/styles.ts
+++ b/test/quality/report/styles.ts
@@ -71,7 +71,14 @@ a { color: #b9a7ff; }
 .images { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
 .images figure { margin: 0; }
 .image-stage { display: flex; align-items: center; justify-content: center; width: 100%; height: 220px; }
-.image-stage img { display: block; cursor: zoom-in; image-rendering: pixelated; background: repeating-conic-gradient(#777 0 25%, #aaa 0 50%) 50% / 16px 16px; }
+.image-stage img {
+	display: block;
+	max-width: 100%;
+	max-height: 100%;
+	cursor: zoom-in;
+	image-rendering: pixelated;
+	background: repeating-conic-gradient(#777 0 25%, #aaa 0 50%) 50% / 16px 16px;
+}
 .table-scroll { overflow-x: auto; }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 7px; text-align: right; border-bottom: 1px solid #494151; }
@@ -120,7 +127,14 @@ a { color: #b9a7ff; }
 .images { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
 .images figure { margin: 0; }
 .image-stage { display: flex; align-items: center; justify-content: center; width: 100%; height: 280px; }
-.image-stage img { display: block; cursor: zoom-in; image-rendering: pixelated; background: repeating-conic-gradient(#777 0 25%, #aaa 0 50%) 50% / 16px 16px; }
+.image-stage img {
+	display: block;
+	max-width: 100%;
+	max-height: 100%;
+	cursor: zoom-in;
+	image-rendering: pixelated;
+	background: repeating-conic-gradient(#777 0 25%, #aaa 0 50%) 50% / 16px 16px;
+}
 .table-scroll { overflow-x: auto; }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 8px; text-align: right; border-bottom: 1px solid #494151; }


### PR DESCRIPTION
## 概要

品質レポートを開いた直後も画像が表示領域内に収まり、緑色や透明チェック柄が画面全体を覆わないようにする。

## 変更内容

### UI/UX

- 品質レポートの一覧・詳細画面で画像を表示領域内に収め、読み込み完了前の一時的な画面崩れを防ぐ。

### ロジック

- なし

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
