### PR TITLE
fix: 品質レポートの絞り込み状態を保持

### DIFF
--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -103,9 +103,9 @@ describe.skipIf(!enabled)("quality report", () => {
 		expect(html).toContain('data-quality-filter="met"');
 		expect(html).toContain('data-quality-filter="missing"');
 		expect(html).toContain('id="active-quality-label"');
-		expect(html).toContain("pixel-refiner-quality-report-filters");
-		expect(html).toContain("storage.getItem(filterStorageKey)");
-		expect(html).toContain("storage.setItem(");
+		expect(html).toContain("new URLSearchParams(window.location.search)");
+		expect(html).toContain("window.history.replaceState(");
+		expect(html).toContain("url.searchParams.set");
 		expect(html).toContain('targetUnmet":"目標未達"');
 		// [Intended] 一覧のバッジと絞り込みの件数が同じ集計から出ていることを確かめる。
 		// 片方だけずれると、絞り込んだ結果と件数表示が食い違って読めなくなる。

--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -103,6 +103,9 @@ describe.skipIf(!enabled)("quality report", () => {
 		expect(html).toContain('data-quality-filter="met"');
 		expect(html).toContain('data-quality-filter="missing"');
 		expect(html).toContain('id="active-quality-label"');
+		expect(html).toContain("pixel-refiner-quality-report-filters");
+		expect(html).toContain("storage.getItem(filterStorageKey)");
+		expect(html).toContain("storage.setItem(");
 		expect(html).toContain('targetUnmet":"目標未達"');
 		// [Intended] 一覧のバッジと絞り込みの件数が同じ集計から出ていることを確かめる。
 		// 片方だけずれると、絞り込んだ結果と件数表示が食い違って読めなくなる。

--- a/test/quality/report/client.test.ts
+++ b/test/quality/report/client.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runQualityReportClient } from "./client";
+
+const FILTER_STORAGE_KEY = "pixel-refiner-quality-report-filters";
+
+type Listener = () => void;
+
+type MockElement = {
+	dataset: Record<string, string>;
+	hidden: boolean;
+	value: string;
+	textContent: string;
+	classList: { toggle: ReturnType<typeof vi.fn> };
+	setAttribute: ReturnType<typeof vi.fn>;
+	addEventListener: (type: string, listener: Listener) => void;
+	querySelector: (selector: string) => MockElement | null;
+	trigger: (type: string) => void;
+};
+
+const makeElement = (
+	dataset: Record<string, string> = {},
+	label?: string,
+): MockElement => {
+	const listeners = new Map<string, Listener[]>();
+	const labelElement =
+		label === undefined
+			? null
+			: ({
+					textContent: label,
+				} as MockElement);
+	const element: MockElement = {
+		dataset,
+		hidden: false,
+		value: "",
+		textContent: "",
+		classList: { toggle: vi.fn() },
+		setAttribute: vi.fn(),
+		addEventListener(type, listener) {
+			const entries = listeners.get(type) ?? [];
+			entries.push(listener);
+			listeners.set(type, entries);
+		},
+		querySelector: (selector) =>
+			selector === "[data-i18n]" ? labelElement : null,
+		trigger(type) {
+			for (const listener of listeners.get(type) ?? []) listener();
+		},
+	};
+	return element;
+};
+
+const makeButton = (name: string, value: string, label: string): MockElement =>
+	makeElement({ [`${name}Filter`]: value }, label);
+
+const createReportPage = (store: Map<string, string>) => {
+	const search = makeElement();
+	const visibleCount = makeElement();
+	const activeLabels = {
+		quality: makeElement(),
+		change: makeElement(),
+		parameter: makeElement(),
+	};
+	const qualityButtons = [
+		makeButton("quality", "", "All"),
+		makeButton("quality", "unmet", "Target unmet"),
+		makeButton("quality", "met", "Target met"),
+	];
+	const changeButtons = [
+		makeButton("change", "", "All"),
+		makeButton("change", "regressed", "Regressed"),
+	];
+	const parameterButtons = [
+		makeButton("parameter", "", "All"),
+		makeButton("parameter", "auto", "Auto"),
+	];
+	const cards = [
+		makeElement({
+			search: "auto target-unmet",
+			quality: "unmet",
+			change: "regressed",
+			parameter: "auto",
+		}),
+		makeElement({
+			search: "auto target-met",
+			quality: "met",
+			change: "regressed",
+			parameter: "auto",
+		}),
+		makeElement({
+			search: "manual target-unmet",
+			quality: "unmet",
+			change: "regressed",
+			parameter: "auto",
+		}),
+	];
+	const selectorGroups: Record<string, MockElement[]> = {
+		"[data-quality-filter]": qualityButtons,
+		"[data-change-filter]": changeButtons,
+		"[data-parameter-filter]": parameterButtons,
+	};
+	const selectorElements: Record<string, MockElement | null> = {
+		"#search": search,
+		"#visible-count": visibleCount,
+		"#active-quality-label": activeLabels.quality,
+		"#active-change-label": activeLabels.change,
+		"#active-parameter-label": activeLabels.parameter,
+		"#image-dialog": null,
+	};
+	const documentMock = {
+		documentElement: { lang: "" },
+		querySelectorAll(selector: string): MockElement[] {
+			if (selector === ".case") return cards;
+			if (selector === ".images img") return [];
+			if (selector === "[data-locale]") return [];
+			if (selector === "[data-i18n]" || selector === "[data-i18n-alt]") {
+				return [];
+			}
+			return selectorGroups[selector] ?? [];
+		},
+		querySelector(selector: string): MockElement | null {
+			return selectorElements[selector] ?? null;
+		},
+	} as unknown as Document;
+	const windowMock = {
+		__QUALITY_REPORT_TRANSLATIONS__: { en: {}, ja: {}, "zh-CN": {} },
+		localStorage: {
+			getItem: (key: string) => store.get(key) ?? null,
+			setItem: (key: string, value: string) => store.set(key, value),
+		},
+		addEventListener: vi.fn(),
+	} as unknown as Window;
+	return { cards, qualityButtons, search, documentMock, windowMock };
+};
+
+const runPage = (page: ReturnType<typeof createReportPage>): void => {
+	vi.stubGlobal("document", page.documentMock);
+	vi.stubGlobal("window", page.windowMock);
+	vi.stubGlobal("navigator", { languages: ["en"], language: "en" });
+	runQualityReportClient();
+};
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("quality report filter persistence", () => {
+	it("restores the selected filters and search text after reload", () => {
+		const store = new Map<string, string>();
+		const firstPage = createReportPage(store);
+		runPage(firstPage);
+
+		firstPage.qualityButtons[1].trigger("click");
+		firstPage.search.value = "auto";
+		firstPage.search.trigger("input");
+
+		expect(JSON.parse(store.get(FILTER_STORAGE_KEY) ?? "null")).toEqual({
+			search: "auto",
+			groups: { quality: "unmet", change: "", parameter: "" },
+		});
+
+		const secondPage = createReportPage(store);
+		runPage(secondPage);
+
+		expect(secondPage.search.value).toBe("auto");
+		expect(secondPage.qualityButtons[1].classList.toggle).toHaveBeenCalledWith(
+			"active",
+			true,
+		);
+		expect(secondPage.cards[0].hidden).toBe(false);
+		expect(secondPage.cards[1].hidden).toBe(true);
+		expect(secondPage.cards[2].hidden).toBe(true);
+	});
+});

--- a/test/quality/report/client.test.ts
+++ b/test/quality/report/client.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runQualityReportClient } from "./client";
 
-const FILTER_STORAGE_KEY = "pixel-refiner-quality-report-filters";
-
 type Listener = () => void;
 
 type MockElement = {
@@ -52,7 +50,7 @@ const makeElement = (
 const makeButton = (name: string, value: string, label: string): MockElement =>
 	makeElement({ [`${name}Filter`]: value }, label);
 
-const createReportPage = (store: Map<string, string>) => {
+const createReportPage = (query = "") => {
 	const search = makeElement();
 	const visibleCount = makeElement();
 	const activeLabels = {
@@ -121,15 +119,31 @@ const createReportPage = (store: Map<string, string>) => {
 			return selectorElements[selector] ?? null;
 		},
 	} as unknown as Document;
+	const location = new URL(`https://example.test/report/index.html${query}`);
+	const replaceState = vi.fn(
+		(_state: unknown, _title: string, nextUrl: string) => {
+			const nextLocation = new URL(nextUrl, location.href);
+			location.href = nextLocation.href;
+			location.search = nextLocation.search;
+			location.hash = nextLocation.hash;
+		},
+	);
 	const windowMock = {
 		__QUALITY_REPORT_TRANSLATIONS__: { en: {}, ja: {}, "zh-CN": {} },
-		localStorage: {
-			getItem: (key: string) => store.get(key) ?? null,
-			setItem: (key: string, value: string) => store.set(key, value),
+		location,
+		history: {
+			replaceState,
 		},
 		addEventListener: vi.fn(),
 	} as unknown as Window;
-	return { cards, qualityButtons, search, documentMock, windowMock };
+	return {
+		cards,
+		qualityButtons,
+		search,
+		documentMock,
+		windowMock,
+		replaceState,
+	};
 };
 
 const runPage = (page: ReturnType<typeof createReportPage>): void => {
@@ -143,22 +157,25 @@ afterEach(() => {
 	vi.unstubAllGlobals();
 });
 
-describe("quality report filter persistence", () => {
-	it("restores the selected filters and search text after reload", () => {
-		const store = new Map<string, string>();
-		const firstPage = createReportPage(store);
+describe("quality report filter query state", () => {
+	it("starts with all cases and restores query filters after reload", () => {
+		const firstPage = createReportPage();
 		runPage(firstPage);
+		expect(firstPage.search.value).toBe("");
+		expect(firstPage.cards.every((card) => !card.hidden)).toBe(true);
 
 		firstPage.qualityButtons[1].trigger("click");
 		firstPage.search.value = "auto";
 		firstPage.search.trigger("input");
 
-		expect(JSON.parse(store.get(FILTER_STORAGE_KEY) ?? "null")).toEqual({
-			search: "auto",
-			groups: { quality: "unmet", change: "", parameter: "" },
-		});
+		const params = new URL(firstPage.windowMock.location.href).searchParams;
+		expect(params.get("search")).toBe("auto");
+		expect(params.get("quality")).toBe("unmet");
+		expect(params.has("change")).toBe(false);
+		expect(params.has("parameter")).toBe(false);
+		expect(firstPage.replaceState).toHaveBeenCalledTimes(2);
 
-		const secondPage = createReportPage(store);
+		const secondPage = createReportPage(`?${params.toString()}`);
 		runPage(secondPage);
 
 		expect(secondPage.search.value).toBe("auto");

--- a/test/quality/report/client.ts
+++ b/test/quality/report/client.ts
@@ -123,49 +123,24 @@ export const runQualityReportClient = (): void => {
 			label: document.querySelector<HTMLElement>(`#active-${name}-label`),
 			active: "",
 		}));
-		const filterStorageKey = "pixel-refiner-quality-report-filters";
-		type SavedFilterState = {
+		type FilterState = {
 			search: string;
 			groups: Record<string, string>;
 		};
-		const isRecord = (value: unknown): value is Record<string, unknown> =>
-			typeof value === "object" && value !== null && !Array.isArray(value);
-		// [Workaround] file:// やプライベートブラウジングで保存領域が使えない場合も、
-		// レポートの絞り込み自体は継続できるように保存処理だけを無効化する。
-		const storage: Storage | null = (() => {
-			try {
-				return window.localStorage;
-			} catch {
-				return null;
+		const readFilterState = (): FilterState => {
+			const params = new URLSearchParams(window.location.search);
+			const savedGroups: Record<string, string> = {};
+			for (const group of groups) {
+				const active = params.get(group.name);
+				if (active !== null) savedGroups[group.name] = active;
 			}
-		})();
-		const emptyFilterState = (): SavedFilterState => ({
-			search: "",
-			groups: {},
-		});
-		const readFilterState = (): SavedFilterState => {
-			if (!storage) return emptyFilterState();
-			try {
-				const saved: unknown = JSON.parse(
-					storage.getItem(filterStorageKey) ?? "null",
-				);
-				if (!isRecord(saved)) return emptyFilterState();
-				const groups: Record<string, string> = {};
-				if (isRecord(saved.groups)) {
-					for (const [name, value] of Object.entries(saved.groups)) {
-						if (typeof value === "string") groups[name] = value;
-					}
-				}
-				return {
-					search: typeof saved.search === "string" ? saved.search : "",
-					groups,
-				};
-			} catch {
-				return emptyFilterState();
-			}
+			return {
+				search: params.get("search") ?? "",
+				groups: savedGroups,
+			};
 		};
-		const savedFilterState = readFilterState();
-		search.value = savedFilterState.search;
+		const initialFilterState = readFilterState();
+		search.value = initialFilterState.search;
 		const setGroupActive = (
 			group: (typeof groups)[number],
 			button: HTMLButtonElement,
@@ -178,7 +153,7 @@ export const runQualityReportClient = (): void => {
 			}
 		};
 		for (const group of groups) {
-			const savedActive = savedFilterState.groups[group.name];
+			const savedActive = initialFilterState.groups[group.name];
 			const button =
 				group.buttons.find(
 					(candidate) =>
@@ -190,16 +165,22 @@ export const runQualityReportClient = (): void => {
 			if (button) setGroupActive(group, button);
 		}
 		const saveFilterState = (): void => {
-			if (!storage) return;
 			try {
-				const savedGroups: Record<string, string> = {};
-				for (const group of groups) savedGroups[group.name] = group.active;
-				storage.setItem(
-					filterStorageKey,
-					JSON.stringify({ search: search.value, groups: savedGroups }),
+				const url = new URL(window.location.href);
+				url.searchParams.delete("search");
+				for (const group of groups) url.searchParams.delete(group.name);
+				if (search.value) url.searchParams.set("search", search.value);
+				for (const group of groups) {
+					if (group.active) url.searchParams.set(group.name, group.active);
+				}
+				// [Intended] URLに状態を残し、更新や共有リンクから同じ条件を復元する。
+				window.history.replaceState(
+					null,
+					"",
+					`${url.pathname}${url.search}${url.hash}`,
 				);
 			} catch {
-				// [Intended] 保存できない環境でも、画面上の絞り込みは妨げない。
+				// [Workaround] URLを更新できない環境でも、画面上の絞り込みは妨げない。
 			}
 		};
 

--- a/test/quality/report/client.ts
+++ b/test/quality/report/client.ts
@@ -123,6 +123,85 @@ export const runQualityReportClient = (): void => {
 			label: document.querySelector<HTMLElement>(`#active-${name}-label`),
 			active: "",
 		}));
+		const filterStorageKey = "pixel-refiner-quality-report-filters";
+		type SavedFilterState = {
+			search: string;
+			groups: Record<string, string>;
+		};
+		const isRecord = (value: unknown): value is Record<string, unknown> =>
+			typeof value === "object" && value !== null && !Array.isArray(value);
+		// [Workaround] file:// やプライベートブラウジングで保存領域が使えない場合も、
+		// レポートの絞り込み自体は継続できるように保存処理だけを無効化する。
+		const storage: Storage | null = (() => {
+			try {
+				return window.localStorage;
+			} catch {
+				return null;
+			}
+		})();
+		const emptyFilterState = (): SavedFilterState => ({
+			search: "",
+			groups: {},
+		});
+		const readFilterState = (): SavedFilterState => {
+			if (!storage) return emptyFilterState();
+			try {
+				const saved: unknown = JSON.parse(
+					storage.getItem(filterStorageKey) ?? "null",
+				);
+				if (!isRecord(saved)) return emptyFilterState();
+				const groups: Record<string, string> = {};
+				if (isRecord(saved.groups)) {
+					for (const [name, value] of Object.entries(saved.groups)) {
+						if (typeof value === "string") groups[name] = value;
+					}
+				}
+				return {
+					search: typeof saved.search === "string" ? saved.search : "",
+					groups,
+				};
+			} catch {
+				return emptyFilterState();
+			}
+		};
+		const savedFilterState = readFilterState();
+		search.value = savedFilterState.search;
+		const setGroupActive = (
+			group: (typeof groups)[number],
+			button: HTMLButtonElement,
+		): void => {
+			group.active = button.dataset[`${group.name}Filter`] ?? "";
+			for (const other of group.buttons) {
+				const active = other === button;
+				other.classList.toggle("active", active);
+				other.setAttribute("aria-pressed", String(active));
+			}
+		};
+		for (const group of groups) {
+			const savedActive = savedFilterState.groups[group.name];
+			const button =
+				group.buttons.find(
+					(candidate) =>
+						candidate.dataset[`${group.name}Filter`] === savedActive,
+				) ??
+				group.buttons.find(
+					(candidate) => candidate.dataset[`${group.name}Filter`] === "",
+				);
+			if (button) setGroupActive(group, button);
+		}
+		const saveFilterState = (): void => {
+			if (!storage) return;
+			try {
+				const savedGroups: Record<string, string> = {};
+				for (const group of groups) savedGroups[group.name] = group.active;
+				storage.setItem(
+					filterStorageKey,
+					JSON.stringify({ search: search.value, groups: savedGroups }),
+				);
+			} catch {
+				// [Intended] 保存できない環境でも、画面上の絞り込みは妨げない。
+			}
+		};
 
 		refreshFilter = (): void => {
 			const text = search.value.toLowerCase();
@@ -149,16 +228,15 @@ export const runQualityReportClient = (): void => {
 			}
 			if (visibleCount) visibleCount.textContent = String(visible);
 		};
-		search.addEventListener("input", refreshFilter);
+		search.addEventListener("input", () => {
+			saveFilterState();
+			refreshFilter();
+		});
 		for (const group of groups) {
 			for (const button of group.buttons) {
 				button.addEventListener("click", () => {
-					group.active = button.dataset[`${group.name}Filter`] ?? "";
-					for (const other of group.buttons) {
-						const active = other === button;
-						other.classList.toggle("active", active);
-						other.setAttribute("aria-pressed", String(active));
-					}
+					setGroupActive(group, button);
+					saveFilterState();
 					refreshFilter();
 				});
 			}


### PR DESCRIPTION
## 概要

品質レポートで選択した絞り込み条件と検索語を、ページ更新後も復元できるようにする。

## 変更内容

### UI/UX

- 品質レポートで選択した品質状態・前回比較・パラメータ種別の絞り込みと検索語を、画面更新後も維持できるようにする。

### ロジック

- 現在のレポートで利用できない保存済み条件は既定値へ戻し、URLを更新できない環境でも絞り込み操作を継続できるようにする。

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
