### PR TITLE
refactor: coreのVite実行環境依存を分離

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: ci fix build quality report ts-check-diff ts-fix-diff html-check-diff html-fix-diff repomix test test-unit test-debug type-check check-ts-rules check-ts-line-length check-file-line-count check-file-line-count-all setup
+.PHONY: ci fix build quality report ts-check-diff ts-fix-diff html-check-diff html-fix-diff repomix test test-unit test-debug type-check check-ts-rules check-ts-line-length check-file-line-count check-file-line-count-all check-architecture setup
 
 # repomix を実行してファイルを tmp/repomix/ にまとめる
 repomix:
@@ -46,6 +46,9 @@ type-check:
 
 check-ts-rules:
 	python3 scripts/check_ts_rules.py
+
+check-architecture:
+	python3 scripts/check_architecture.py
 
 check-ts-line-length:
 	python3 scripts/check_ts_line_length.py

--- a/scripts/check_architecture.py
+++ b/scripts/check_architecture.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+# [Policy] 低レイヤーは browser の実行環境と画像表示 API に依存しない。
+DOM_CANVAS_RE = re.compile(
+    r"\b(?:document|window|navigator|HTMLElement|HTMLCanvasElement|"
+    r"HTMLImageElement|CanvasRenderingContext2D|OffscreenCanvas|ImageData|"
+    r"ImageBitmap|createImageBitmap|DOMParser|MutationObserver|File|Blob|"
+    r"Worker)\b"
+)
+IMPORT_META_ENV_RE = re.compile(r"\bimport\.meta\.env\b")
+IMPORT_FROM_RE = re.compile(r"\bfrom\s*[\"']([^\"']+)[\"']")
+SIDE_EFFECT_IMPORT_RE = re.compile(r"\bimport\s*[\"']([^\"']+)[\"']")
+FORBIDDEN_IMPORTS = {
+    "shared": {"core", "browser"},
+    "core": {"browser"},
+}
+
+
+def source_files(src_root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in src_root.rglob("*")
+        if path.is_file() and path.suffix in {".ts", ".tsx"}
+    )
+
+
+def source_layer(path: Path, src_root: Path) -> str | None:
+    try:
+        relative = path.resolve().relative_to(src_root.resolve())
+    except ValueError:
+        return None
+    return relative.parts[0] if relative.parts else None
+
+
+def imported_layer(
+    source_path: Path, specifier: str, src_root: Path
+) -> str | None:
+    if not specifier.startswith("."):
+        return None
+    imported_path = (source_path.parent / specifier).resolve()
+    return source_layer(imported_path, src_root)
+
+
+def line_number(content: str, offset: int) -> int:
+    return content.count("\n", 0, offset) + 1
+
+
+def check_file(path: Path, src_root: Path, repository_root: Path) -> list[str]:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as error:
+        return [f"{path}: ファイルを読み込めません: {error}"]
+
+    errors: list[str] = []
+    layer = source_layer(path, src_root)
+    display_path = path.relative_to(repository_root)
+
+    if layer in {"core", "shared"}:
+        for match in IMPORT_META_ENV_RE.finditer(content):
+            errors.append(
+                f"{display_path}:{line_number(content, match.start())}: "
+                "core/shared から import.meta.env を参照できません"
+            )
+        for match in DOM_CANVAS_RE.finditer(content):
+            errors.append(
+                f"{display_path}:{line_number(content, match.start())}: "
+                f"{layer} から DOM/Canvas API ({match.group(0)}) を参照できません"
+            )
+
+    if layer in FORBIDDEN_IMPORTS:
+        import_matches = list(IMPORT_FROM_RE.finditer(content))
+        import_matches.extend(SIDE_EFFECT_IMPORT_RE.finditer(content))
+        for match in import_matches:
+            imported = imported_layer(path, match.group(1), src_root)
+            if imported not in FORBIDDEN_IMPORTS[layer]:
+                continue
+            errors.append(
+                f"{display_path}:{line_number(content, match.start())}: "
+                f"{layer} から src/{imported} へ依存できません"
+            )
+
+    return errors
+
+
+def check_architecture(repository_root: Path) -> list[str]:
+    src_root = repository_root / "src"
+    if not src_root.is_dir():
+        return [f"{src_root}: src ディレクトリがありません"]
+
+    errors: list[str] = []
+    for path in source_files(src_root):
+        errors.extend(check_file(path, src_root, repository_root))
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Pixel Refiner の依存方向を検査する")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("."),
+        help="リポジトリのルート（既定: カレントディレクトリ）",
+    )
+    args = parser.parse_args()
+    repository_root = args.root.resolve()
+    errors = check_architecture(repository_root)
+
+    if errors:
+        print("\n".join(errors))
+        print(f"\nTotal architecture violations: {len(errors)}")
+        return 1
+
+    print("No architecture violations found.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_ci.py
+++ b/scripts/run_ci.py
@@ -78,6 +78,7 @@ def main():
         ("HTML Check", ["make", "html-check-diff"], False),
         ("Type Check", ["make", "type-check"], False),
         ("Custom Rules", ["make", "check-ts-rules"], False),
+        ("Architecture Check", ["make", "check-architecture"], False),
         ("TS Line Length", ["make", "check-ts-line-length"], False),
         ("File Line Count", ["make", "check-file-line-count"], True),
         ("Unit Tests", ["make", "test-unit"], False),

--- a/scripts/run_ci.test.ts
+++ b/scripts/run_ci.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, it } from "vitest";
 const RUN_CI_PATH = fileURLToPath(new URL("./run_ci.py", import.meta.url));
 const CHECK_TASKS = [
 	"build",
+	"check-architecture",
 	"check-file-line-count",
 	"check-ts-line-length",
 	"check-ts-rules",

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -29,6 +29,7 @@ import {
 	type QuickDithering,
 } from "./quick-settings";
 import type { ResultViewer } from "./result-viewer";
+import { BROWSER_RUNTIME_CONFIG } from "./runtime-config";
 import type { ImageSession } from "./session";
 
 const workerInstance = new Worker(
@@ -112,6 +113,7 @@ export const createProcessOptions = (
 	const usePixels = pixelsW !== undefined && pixelsH !== undefined;
 
 	const advancedOptions: ProcessOptions = {
+		debug: BROWSER_RUNTIME_CONFIG.debug,
 		detectionQuantStep,
 		forcePixelsW: gridMode === "force" && usePixels ? pixelsW : undefined,
 		forcePixelsH: gridMode === "force" && usePixels ? pixelsH : undefined,

--- a/src/browser/runtime-config.ts
+++ b/src/browser/runtime-config.ts
@@ -1,0 +1,3 @@
+export const BROWSER_RUNTIME_CONFIG = {
+	debug: import.meta.env.DEV,
+} as const;

--- a/src/core/processor-options.test.ts
+++ b/src/core/processor-options.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import { normalizeProcessOptions } from "./processor-options";
 
 describe("small-component options", () => {
+	it("uses an environment-independent debug default", () => {
+		const options = normalizeProcessOptions({});
+
+		expect(options.debug).toBe(false);
+	});
+
 	it("disables alpha-aware medoid sampling for new callers", () => {
 		const options = normalizeProcessOptions({});
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -609,7 +609,8 @@ export const PROCESS_DEFAULTS = {
 	outlineColor: PROCESS_RANGES.outlineColor,
 	sharedPalette: false,
 	includeDiagnosticSummary: false,
-	debug: import.meta.env.DEV,
+	// [Policy] core/shared は実行環境に依存せず、開発時の値は browser 側から明示的に渡す。
+	debug: false,
 } as const;
 
 export const clampInt = (value: number, range: IntRange): number => {


### PR DESCRIPTION
## 概要

core/shared を Vite 実行環境から切り離し、Node から画像処理 core を直接診断できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- core/shared の既定値を実行環境に依存しない形へ整理し、browser の開発時デバッグ設定を明示的に渡せるようにした。
- CI で依存方向と core/shared の DOM・Canvas API および Vite 環境参照を検査し、層の境界を継続的に検証できるようにした。

### その他

- なし

## 動作確認

- なし
