### PR TITLE
refactor: UI初期オプションの生成経路を統合

### DIFF
--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -1,5 +1,6 @@
 import { wrap } from "comlink";
 import type { ProcessOptions } from "../core/processor";
+import { createDefaultProcessOptions } from "../core/processor-options";
 import type { ProcessorWorker } from "../core/worker";
 import { clampInt, PROCESS_RANGES } from "../shared/config";
 import type {
@@ -24,7 +25,6 @@ import {
 } from "./processing-warnings";
 import {
 	applyQuickSettingsToOptions,
-	createUiInitialProcessOptions,
 	type QuickBackground,
 	type QuickColors,
 	type QuickDithering,
@@ -113,8 +113,10 @@ export const createProcessOptions = (
 	const gridMode = els.gridDetectionModeSelect.value as GridDetectionMode;
 	const usePixels = pixelsW !== undefined && pixelsH !== undefined;
 
+	// [Intended] 土台は Quick 設定を適用していない詳細設定の既定値にする。
+	// Quick 設定は DOM の実値で最後に一度だけ適用する。
 	const advancedOptions: ProcessOptions = {
-		...createUiInitialProcessOptions(),
+		...createDefaultProcessOptions(),
 		debug: BROWSER_RUNTIME_CONFIG.debug,
 		detectionQuantStep,
 		forcePixelsW: gridMode === "force" && usePixels ? pixelsW : undefined,

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -24,6 +24,7 @@ import {
 } from "./processing-warnings";
 import {
 	applyQuickSettingsToOptions,
+	createUiInitialProcessOptions,
 	type QuickBackground,
 	type QuickColors,
 	type QuickDithering,
@@ -113,6 +114,7 @@ export const createProcessOptions = (
 	const usePixels = pixelsW !== undefined && pixelsH !== undefined;
 
 	const advancedOptions: ProcessOptions = {
+		...createUiInitialProcessOptions(),
 		debug: BROWSER_RUNTIME_CONFIG.debug,
 		detectionQuantStep,
 		forcePixelsW: gridMode === "force" && usePixels ? pixelsW : undefined,

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -1,3 +1,4 @@
+import { rgbToHex } from "../core/colorUtils";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS } from "../shared/config";
 import type {
@@ -120,13 +121,7 @@ export const setupQuickSettingsControls = ({
 				defaults.fastAutoGridFromTrimmed;
 			els.makeSquareCheck.checked = defaults.makeSquare;
 			els.keepAspectRatioCheck.checked = defaults.keepAspectRatio;
-			els.outlineColorInput.value = `#${[
-				defaults.outlineColor.r,
-				defaults.outlineColor.g,
-				defaults.outlineColor.b,
-			]
-				.map((value) => value.toString(16).padStart(2, "0"))
-				.join("")}`;
+			els.outlineColorInput.value = rgbToHex(defaults.outlineColor);
 			processingState.currentFixedPalette = undefined;
 		}
 		els.quickProcessingModeSelect.value = settings.processingMode;

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -1,4 +1,5 @@
-import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import { createDefaultProcessOptions } from "../core/processor-options";
+import { PROCESS_DEFAULTS } from "../shared/config";
 import type {
 	DetailLevel,
 	OutlineStyle,
@@ -97,31 +98,35 @@ export const setupQuickSettingsControls = ({
 	) => {
 		clearCandidateSelections();
 		if (presetId !== "custom") {
-			els.quantStepInput.value = String(
-				PROCESS_RANGES.detectionQuantStep.default,
-			);
+			const defaults = createDefaultProcessOptions();
+			els.quantStepInput.value = String(defaults.detectionQuantStep);
 			els.quantStepSlider.value = els.quantStepInput.value;
-			els.sampleWindowInput.value = String(PROCESS_RANGES.sampleWindow.default);
+			els.sampleWindowInput.value = String(defaults.sampleWindow);
 			els.sampleWindowSlider.value = els.sampleWindowInput.value;
-			els.toleranceInput.value = String(
-				PROCESS_RANGES.backgroundTolerance.default,
-			);
+			els.toleranceInput.value = String(defaults.backgroundTolerance);
 			els.toleranceSlider.value = els.toleranceInput.value;
 			els.forcePixelsWInput.value = "";
 			els.forcePixelsHInput.value = "";
-			els.gridDetectionModeSelect.value = "auto";
-			els.preRemoveCheck.checked = PROCESS_DEFAULTS.preRemoveBackground;
-			els.postRemoveCheck.checked = PROCESS_DEFAULTS.postRemoveBackground;
-			els.bgRemovalScopeSelect.value = PROCESS_DEFAULTS.bgRemovalScope;
-			els.bgConnectivitySelect.value = PROCESS_DEFAULTS.bgConnectivity;
-			els.smallComponentModeSelect.value = PROCESS_DEFAULTS.smallComponentMode;
+			els.gridDetectionModeSelect.value =
+				PROCESS_DEFAULTS.gridDetectionMode ?? "auto";
+			els.preRemoveCheck.checked = defaults.preRemoveBackground;
+			els.postRemoveCheck.checked = defaults.postRemoveBackground;
+			els.bgRemovalScopeSelect.value = defaults.bgRemovalScope;
+			els.bgConnectivitySelect.value = defaults.bgConnectivity;
+			els.smallComponentModeSelect.value = defaults.smallComponentMode;
 			els.alphaAwareMedoidCheck.checked =
-				(PROCESS_DEFAULTS.cellSamplingMode as string) === "alpha-aware-medoid";
+				(defaults.cellSamplingMode as string) === "alpha-aware-medoid";
 			els.fastAutoGridFromTrimmedCheck.checked =
-				PROCESS_DEFAULTS.fastAutoGridFromTrimmed;
-			els.makeSquareCheck.checked = PROCESS_DEFAULTS.makeSquare;
-			els.keepAspectRatioCheck.checked = PROCESS_DEFAULTS.keepAspectRatio;
-			els.outlineColorInput.value = "#ffffff";
+				defaults.fastAutoGridFromTrimmed;
+			els.makeSquareCheck.checked = defaults.makeSquare;
+			els.keepAspectRatioCheck.checked = defaults.keepAspectRatio;
+			els.outlineColorInput.value = `#${[
+				defaults.outlineColor.r,
+				defaults.outlineColor.g,
+				defaults.outlineColor.b,
+			]
+				.map((value) => value.toString(16).padStart(2, "0"))
+				.join("")}`;
 			processingState.currentFixedPalette = undefined;
 		}
 		els.quickProcessingModeSelect.value = settings.processingMode;

--- a/src/browser/quick-settings.test.ts
+++ b/src/browser/quick-settings.test.ts
@@ -3,6 +3,7 @@ import { PROCESS_DEFAULTS } from "../shared/config";
 import {
 	applyQuickSettingsToOptions,
 	BUILT_IN_PRESETS,
+	createUiInitialProcessOptions,
 	QUICK_SETTINGS_DEFAULTS,
 } from "./quick-settings";
 
@@ -14,6 +15,25 @@ describe("quick settings", () => {
 			outlineStyle: PROCESS_DEFAULTS.outlineStyle,
 			trimToContent: PROCESS_DEFAULTS.trimToContent,
 		});
+	});
+
+	it("builds UI initial options from processing defaults and Auto settings", () => {
+		const options = createUiInitialProcessOptions();
+
+		expect(options).toMatchObject({
+			processingMode: PROCESS_DEFAULTS.processingMode,
+			detailLevel: PROCESS_DEFAULTS.detailLevel,
+			preRemoveBackground: true,
+			postRemoveBackground: true,
+			bgExtractionMethod: "auto",
+			bgRemovalScope: "outer",
+			trimToContent: PROCESS_DEFAULTS.trimToContent,
+			ditherMode: "none",
+			ditherStrength: 0,
+		});
+		expect(options.reduceColors).toBeUndefined();
+		expect(options.reduceColorMode).toBeUndefined();
+		expect(options.colorCount).toBeUndefined();
 	});
 
 	it("delegates automatic color selection to the processing route", () => {

--- a/src/browser/quick-settings.ts
+++ b/src/browser/quick-settings.ts
@@ -146,7 +146,8 @@ export const applyQuickSettingsToOptions = (
 /**
  * UI の初期状態（詳細設定の既定値と Auto プリセット）を処理オプションへ変換する。
  *
- * [Intended] Auto 品質ケースもこの関数を使い、DOM の初期化経路と同じ設定を測る。
+ * [Intended] UI に表示していない詳細設定も既定値から取り込むため、DOM の
+ * 初期化経路と同じ設定になる。Auto 品質ケースもこの関数を使って同じ状態を測る。
  */
 export const createUiInitialProcessOptions = (): ProcessOptions =>
 	applyQuickSettingsToOptions(

--- a/src/browser/quick-settings.ts
+++ b/src/browser/quick-settings.ts
@@ -1,4 +1,5 @@
 import type { ProcessOptions } from "../core/processor";
+import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS } from "../shared/config";
 import type {
 	DetailLevel,
@@ -141,3 +142,14 @@ export const applyQuickSettingsToOptions = (
 
 	return options;
 };
+
+/**
+ * UI の初期状態（詳細設定の既定値と Auto プリセット）を処理オプションへ変換する。
+ *
+ * [Intended] Auto 品質ケースもこの関数を使い、DOM の初期化経路と同じ設定を測る。
+ */
+export const createUiInitialProcessOptions = (): ProcessOptions =>
+	applyQuickSettingsToOptions(
+		createDefaultProcessOptions(),
+		QUICK_SETTINGS_DEFAULTS,
+	);

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -1,3 +1,4 @@
+import { rgbToHex } from "../core/colorUtils";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
 import type { Elements } from "./app-elements";
@@ -231,6 +232,7 @@ export const setupSettingsControls = ({
 			PROCESS_DEFAULTS.gridDetectionMode ?? "auto";
 		els.reduceColorModeSelect.value = defaults.reduceColorMode;
 		els.ditherModeSelect.value = defaults.ditherMode;
+		els.outlineColorInput.value = rgbToHex(defaults.outlineColor);
 
 		els.bgExtractionMethod.value = defaults.bgExtractionMethod;
 		els.quickProcessingModeSelect.value =

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -1,3 +1,4 @@
+import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
@@ -6,7 +7,10 @@ import { i18n, type Language } from "./i18n";
 import { drawRawImageToCanvas } from "./io";
 import { showError } from "./notifications";
 import type { RunProcessingOptions } from "./processing-controller";
-import type { QuickSettingsState } from "./quick-settings";
+import {
+	QUICK_SETTINGS_DEFAULTS,
+	type QuickSettingsState,
+} from "./quick-settings";
 import { setupQuickSettingsControls } from "./quick-settings-controls";
 import type { ImageSession } from "./session";
 
@@ -159,18 +163,20 @@ export const setupSettingsControls = ({
 
 	// 設定ファイルの既定値・範囲を UI に適用
 	const applyConfigToUi = () => {
+		const defaults = createDefaultProcessOptions();
 		const setNumberInput = (
 			input: HTMLInputElement,
 			slider: HTMLInputElement | null,
 			range: { min: number; max: number; default: number },
+			defaultValue: number,
 		) => {
 			input.min = String(range.min);
 			input.max = String(range.max);
-			input.value = String(range.default);
+			input.value = String(defaultValue);
 			if (slider) {
 				slider.min = String(range.min);
 				slider.max = String(range.max);
-				slider.value = String(range.default);
+				slider.value = String(defaultValue);
 			}
 		};
 
@@ -178,26 +184,31 @@ export const setupSettingsControls = ({
 			els.quantStepInput,
 			els.quantStepSlider,
 			PROCESS_RANGES.detectionQuantStep,
+			defaults.detectionQuantStep,
 		);
 		setNumberInput(
 			els.sampleWindowInput,
 			els.sampleWindowSlider,
 			PROCESS_RANGES.sampleWindow,
+			defaults.sampleWindow,
 		);
 		setNumberInput(
 			els.toleranceInput,
 			els.toleranceSlider,
 			PROCESS_RANGES.backgroundTolerance,
+			defaults.backgroundTolerance,
 		);
 		setNumberInput(
 			els.colorCountInput,
 			els.colorCountSlider,
 			PROCESS_RANGES.colorCount,
+			defaults.colorCount,
 		);
 		setNumberInput(
 			els.ditherStrengthInput,
 			els.ditherStrengthSlider,
 			PROCESS_RANGES.ditherStrength,
+			defaults.ditherStrength,
 		);
 
 		els.forcePixelsWInput.min = String(PROCESS_RANGES.forcePixelsW.min);
@@ -205,31 +216,31 @@ export const setupSettingsControls = ({
 		els.forcePixelsHInput.min = String(PROCESS_RANGES.forcePixelsH.min);
 		els.forcePixelsHInput.max = String(PROCESS_RANGES.forcePixelsH.max);
 
-		els.preRemoveCheck.checked = PROCESS_DEFAULTS.preRemoveBackground;
-		els.postRemoveCheck.checked = PROCESS_DEFAULTS.postRemoveBackground;
-		els.bgRemovalScopeSelect.value = PROCESS_DEFAULTS.bgRemovalScope;
-		els.bgConnectivitySelect.value = PROCESS_DEFAULTS.bgConnectivity;
-		els.smallComponentModeSelect.value = PROCESS_DEFAULTS.smallComponentMode;
+		els.preRemoveCheck.checked = defaults.preRemoveBackground;
+		els.postRemoveCheck.checked = defaults.postRemoveBackground;
+		els.bgRemovalScopeSelect.value = defaults.bgRemovalScope;
+		els.bgConnectivitySelect.value = defaults.bgConnectivity;
+		els.smallComponentModeSelect.value = defaults.smallComponentMode;
 		els.alphaAwareMedoidCheck.checked =
-			(PROCESS_DEFAULTS.cellSamplingMode as string) === "alpha-aware-medoid";
-		els.trimToContentCheck.checked = PROCESS_DEFAULTS.trimToContent;
-		els.fastAutoGridFromTrimmedCheck.checked =
-			PROCESS_DEFAULTS.fastAutoGridFromTrimmed;
-		els.makeSquareCheck.checked = PROCESS_DEFAULTS.makeSquare;
-		els.keepAspectRatioCheck.checked = PROCESS_DEFAULTS.keepAspectRatio;
+			(defaults.cellSamplingMode as string) === "alpha-aware-medoid";
+		els.trimToContentCheck.checked = defaults.trimToContent;
+		els.fastAutoGridFromTrimmedCheck.checked = defaults.fastAutoGridFromTrimmed;
+		els.makeSquareCheck.checked = defaults.makeSquare;
+		els.keepAspectRatioCheck.checked = defaults.keepAspectRatio;
 		els.gridDetectionModeSelect.value =
 			PROCESS_DEFAULTS.gridDetectionMode ?? "auto";
-		els.reduceColorModeSelect.value = PROCESS_DEFAULTS.reduceColorMode;
-		els.ditherModeSelect.value = PROCESS_DEFAULTS.ditherMode;
+		els.reduceColorModeSelect.value = defaults.reduceColorMode;
+		els.ditherModeSelect.value = defaults.ditherMode;
 
-		els.bgExtractionMethod.value = PROCESS_DEFAULTS.bgExtractionMethod;
-		els.quickProcessingModeSelect.value = PROCESS_DEFAULTS.processingMode;
-		els.quickDetailLevelSelect.value = PROCESS_DEFAULTS.detailLevel;
-		els.quickColorsSelect.value = "auto";
-		els.quickBackgroundSelect.value = "auto";
-		els.quickDitheringSelect.value = "off";
-		els.quickOutlineStyleSelect.value = PROCESS_DEFAULTS.outlineStyle;
-		els.quickAutoTrimCheck.checked = PROCESS_DEFAULTS.trimToContent;
+		els.bgExtractionMethod.value = defaults.bgExtractionMethod;
+		els.quickProcessingModeSelect.value =
+			QUICK_SETTINGS_DEFAULTS.processingMode;
+		els.quickDetailLevelSelect.value = QUICK_SETTINGS_DEFAULTS.detailLevel;
+		els.quickColorsSelect.value = QUICK_SETTINGS_DEFAULTS.colors;
+		els.quickBackgroundSelect.value = QUICK_SETTINGS_DEFAULTS.background;
+		els.quickDitheringSelect.value = QUICK_SETTINGS_DEFAULTS.dithering;
+		els.quickOutlineStyleSelect.value = QUICK_SETTINGS_DEFAULTS.outlineStyle;
+		els.quickAutoTrimCheck.checked = QUICK_SETTINGS_DEFAULTS.trimToContent;
 		els.builtInPresetSelect.value = "auto";
 		syncQuickSettingsToAdvanced();
 

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -168,7 +168,7 @@ export const setupSettingsControls = ({
 		const setNumberInput = (
 			input: HTMLInputElement,
 			slider: HTMLInputElement | null,
-			range: { min: number; max: number; default: number },
+			range: { min: number; max: number },
 			defaultValue: number,
 		) => {
 			input.min = String(range.min);

--- a/src/core/colorUtils.ts
+++ b/src/core/colorUtils.ts
@@ -17,6 +17,15 @@ function linearToSrgb(c: number): number {
 }
 
 /**
+ * RGB を `#rrggbb` 形式の文字列へ変換する。
+ */
+export function rgbToHex(rgb: RGB): string {
+	return `#${[rgb.r, rgb.g, rgb.b]
+		.map((value) => value.toString(16).padStart(2, "0"))
+		.join("")}`;
+}
+
+/**
  * RGB から Oklab への変換
  */
 export function rgbToOklab(rgb: RGB): Oklab {

--- a/src/core/processor-options.test.ts
+++ b/src/core/processor-options.test.ts
@@ -5,7 +5,33 @@ import {
 	normalizeProcessOptions,
 } from "./processor-options";
 
+/**
+ * createDefaultProcessOptions が意図的に含めない PROCESS_DEFAULTS のキー。
+ *
+ * [Intended] ここに挙げていない既定値の取りこぼしはテストで落とす。
+ * 新しい既定値を除外する場合は理由とともに追加する。
+ */
+const EXCLUDED_DEFAULT_KEYS = new Set<string>([
+	// UI のグリッド検出モード。ProcessOptions には対応する項目がない。
+	"gridDetectionMode",
+	// バッチ処理の設定。単体処理の既定には含めない。
+	"sharedPalette",
+	// 診断出力の設定。呼び出し側が必要なときだけ指定する。
+	"includeDiagnosticSummary",
+	// 非推奨の旧オプション。normalizeProcessOptions が既定 0 を与える。
+	"floatingMaxPixels",
+]);
+
 describe("default process options", () => {
+	it("covers every shared process default that is not excluded", () => {
+		const options = createDefaultProcessOptions() as Record<string, unknown>;
+
+		for (const [key, value] of Object.entries(PROCESS_DEFAULTS)) {
+			if (EXCLUDED_DEFAULT_KEYS.has(key)) continue;
+			expect(options[key]).toEqual(value);
+		}
+	});
+
 	it("builds complete defaults from the shared configuration", () => {
 		const options = createDefaultProcessOptions();
 

--- a/src/core/processor-options.test.ts
+++ b/src/core/processor-options.test.ts
@@ -34,7 +34,6 @@ describe("default process options", () => {
 			preserveThinFeatures: PROCESS_DEFAULTS.preserveThinFeatures,
 			enableDeskew: PROCESS_DEFAULTS.enableDeskew,
 			smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
-			floatingMaxPixels: PROCESS_DEFAULTS.floatingMaxPixels,
 			reduceColors: PROCESS_DEFAULTS.reduceColors,
 			reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
 			ditherMode: PROCESS_DEFAULTS.ditherMode,

--- a/src/core/processor-options.test.ts
+++ b/src/core/processor-options.test.ts
@@ -1,5 +1,51 @@
 import { describe, expect, it } from "vitest";
-import { normalizeProcessOptions } from "./processor-options";
+import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import {
+	createDefaultProcessOptions,
+	normalizeProcessOptions,
+} from "./processor-options";
+
+describe("default process options", () => {
+	it("builds complete defaults from the shared configuration", () => {
+		const options = createDefaultProcessOptions();
+
+		expect(options).toMatchObject({
+			detectionQuantStep: PROCESS_RANGES.detectionQuantStep.default,
+			backgroundMaskTolerance: PROCESS_RANGES.backgroundMaskTolerance.default,
+			backgroundTolerance: PROCESS_RANGES.backgroundTolerance.default,
+			sampleWindow: PROCESS_RANGES.sampleWindow.default,
+			maxSamplesPerCell: PROCESS_RANGES.maxSamplesPerCell.default,
+			cellAlphaThreshold: PROCESS_RANGES.cellAlphaThreshold.default,
+			trimAlphaThreshold: PROCESS_RANGES.trimAlphaThreshold.default,
+			processingMode: PROCESS_DEFAULTS.processingMode,
+			detailLevel: PROCESS_DEFAULTS.detailLevel,
+			preRemoveBackground: PROCESS_DEFAULTS.preRemoveBackground,
+			postRemoveBackground: PROCESS_DEFAULTS.postRemoveBackground,
+			bgExtractionMethod: PROCESS_DEFAULTS.bgExtractionMethod,
+			bgRemovalScope: PROCESS_DEFAULTS.bgRemovalScope,
+			bgConnectivity: PROCESS_DEFAULTS.bgConnectivity,
+			trimToContent: PROCESS_DEFAULTS.trimToContent,
+			autoGridFromTrimmed: PROCESS_DEFAULTS.autoGridFromTrimmed,
+			fastAutoGridFromTrimmed: PROCESS_DEFAULTS.fastAutoGridFromTrimmed,
+			enableGridDetection: PROCESS_DEFAULTS.enableGridDetection,
+			makeSquare: PROCESS_DEFAULTS.makeSquare,
+			keepAspectRatio: PROCESS_DEFAULTS.keepAspectRatio,
+			cellSamplingMode: PROCESS_DEFAULTS.cellSamplingMode,
+			preserveThinFeatures: PROCESS_DEFAULTS.preserveThinFeatures,
+			enableDeskew: PROCESS_DEFAULTS.enableDeskew,
+			smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
+			floatingMaxPixels: PROCESS_DEFAULTS.floatingMaxPixels,
+			reduceColors: PROCESS_DEFAULTS.reduceColors,
+			reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
+			ditherMode: PROCESS_DEFAULTS.ditherMode,
+			colorCount: PROCESS_DEFAULTS.colorCount,
+			ditherStrength: PROCESS_DEFAULTS.ditherStrength,
+			outlineStyle: PROCESS_DEFAULTS.outlineStyle,
+			outlineColor: PROCESS_DEFAULTS.outlineColor,
+			debug: PROCESS_DEFAULTS.debug,
+		});
+	});
+});
 
 describe("small-component options", () => {
 	it("uses an environment-independent debug default", () => {

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -165,10 +165,11 @@ export type ProcessOptions = DetectOptions & {
 };
 
 /**
- * 処理設定の既定値から、UI が処理器へ渡す詳細設定を構築する。
+ * 共有設定から ProcessOptions の既定値一式を組み立てる。
  *
- * [Intended] UI に表示していない設定もここへ含め、browser と品質テストが
- * 同じ初期オプションを使う。新しい既定値を追加するときはこの関数にも反映する。
+ * [Intended] PROCESS_DEFAULTS のうち ProcessOptions に対応する項目はすべて
+ * ここへ含める。新しい既定値を追加するときはこの関数にも反映する
+ * （網羅性は processor-options.test.ts が検証する）。
  */
 export const createDefaultProcessOptions = () =>
 	({

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -196,7 +196,6 @@ export const createDefaultProcessOptions = () =>
 		preserveThinFeatures: PROCESS_DEFAULTS.preserveThinFeatures,
 		enableDeskew: PROCESS_DEFAULTS.enableDeskew,
 		smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
-		floatingMaxPixels: PROCESS_DEFAULTS.floatingMaxPixels,
 		reduceColors: PROCESS_DEFAULTS.reduceColors,
 		reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
 		ditherMode: PROCESS_DEFAULTS.ditherMode,

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -164,6 +164,49 @@ export type ProcessOptions = DetectOptions & {
 	) => void;
 };
 
+/**
+ * 処理設定の既定値から、UI が処理器へ渡す詳細設定を構築する。
+ *
+ * [Intended] UI に表示していない設定もここへ含め、browser と品質テストが
+ * 同じ初期オプションを使う。新しい既定値を追加するときはこの関数にも反映する。
+ */
+export const createDefaultProcessOptions = () =>
+	({
+		detectionQuantStep: PROCESS_RANGES.detectionQuantStep.default,
+		backgroundMaskTolerance: PROCESS_RANGES.backgroundMaskTolerance.default,
+		backgroundTolerance: PROCESS_RANGES.backgroundTolerance.default,
+		sampleWindow: PROCESS_RANGES.sampleWindow.default,
+		maxSamplesPerCell: PROCESS_RANGES.maxSamplesPerCell.default,
+		cellAlphaThreshold: PROCESS_RANGES.cellAlphaThreshold.default,
+		trimAlphaThreshold: PROCESS_RANGES.trimAlphaThreshold.default,
+		processingMode: PROCESS_DEFAULTS.processingMode,
+		detailLevel: PROCESS_DEFAULTS.detailLevel,
+		preRemoveBackground: PROCESS_DEFAULTS.preRemoveBackground,
+		postRemoveBackground: PROCESS_DEFAULTS.postRemoveBackground,
+		bgExtractionMethod: PROCESS_DEFAULTS.bgExtractionMethod,
+		bgRemovalScope: PROCESS_DEFAULTS.bgRemovalScope,
+		bgConnectivity: PROCESS_DEFAULTS.bgConnectivity,
+		trimToContent: PROCESS_DEFAULTS.trimToContent,
+		autoGridFromTrimmed: PROCESS_DEFAULTS.autoGridFromTrimmed,
+		fastAutoGridFromTrimmed: PROCESS_DEFAULTS.fastAutoGridFromTrimmed,
+		enableGridDetection: PROCESS_DEFAULTS.enableGridDetection,
+		makeSquare: PROCESS_DEFAULTS.makeSquare,
+		keepAspectRatio: PROCESS_DEFAULTS.keepAspectRatio,
+		cellSamplingMode: PROCESS_DEFAULTS.cellSamplingMode,
+		preserveThinFeatures: PROCESS_DEFAULTS.preserveThinFeatures,
+		enableDeskew: PROCESS_DEFAULTS.enableDeskew,
+		smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
+		floatingMaxPixels: PROCESS_DEFAULTS.floatingMaxPixels,
+		reduceColors: PROCESS_DEFAULTS.reduceColors,
+		reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
+		ditherMode: PROCESS_DEFAULTS.ditherMode,
+		colorCount: PROCESS_DEFAULTS.colorCount,
+		ditherStrength: PROCESS_DEFAULTS.ditherStrength,
+		outlineStyle: PROCESS_DEFAULTS.outlineStyle,
+		outlineColor: { ...PROCESS_DEFAULTS.outlineColor },
+		debug: PROCESS_DEFAULTS.debug,
+	}) satisfies ProcessOptions;
+
 const getGlobalDebugHook = (): ProcessOptions["debugHook"] | undefined => {
 	const g = globalThis as unknown as {
 		__PIXEL_REFINER_DEBUG_HOOK__?: unknown;

--- a/test/quality/auto-cases.ts
+++ b/test/quality/auto-cases.ts
@@ -1,11 +1,7 @@
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
-import {
-	applyQuickSettingsToOptions,
-	QUICK_SETTINGS_DEFAULTS,
-} from "../../src/browser/quick-settings";
+import { createUiInitialProcessOptions } from "../../src/browser/quick-settings";
 import type { ProcessOptions } from "../../src/core/processor-options";
-import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../../src/shared/config";
 import type { FixtureAssetProvenance, QualityImageCase } from "./types";
 
 const FIXTURE_DIRECTORY = "test/fixtures";
@@ -25,45 +21,12 @@ export const loadAutoCaseExclusions = (): Record<string, string> =>
 		) as AutoCaseExclusionRegistry
 	).excluded;
 
-// [Intended] index.html の詳細設定は初期表示で PROCESS_DEFAULTS / PROCESS_RANGES の
-// 既定値を持ち、内蔵プリセットを選ぶと quick-settings-controls がこの既定値へ戻す。
-// DOM を起動せずに UI 初期状態の詳細設定を再現するための写しなので、
-// UI 側の初期値を変えたときはここも合わせる。
-const ADVANCED_DEFAULTS: ProcessOptions = {
-	detectionQuantStep: PROCESS_RANGES.detectionQuantStep.default,
-	backgroundTolerance: PROCESS_RANGES.backgroundTolerance.default,
-	sampleWindow: PROCESS_RANGES.sampleWindow.default,
-	trimAlphaThreshold: PROCESS_RANGES.trimAlphaThreshold.default,
-	preRemoveBackground: PROCESS_DEFAULTS.preRemoveBackground,
-	postRemoveBackground: PROCESS_DEFAULTS.postRemoveBackground,
-	bgRemovalScope: PROCESS_DEFAULTS.bgRemovalScope,
-	bgConnectivity: PROCESS_DEFAULTS.bgConnectivity,
-	bgExtractionMethod: PROCESS_DEFAULTS.bgExtractionMethod,
-	trimToContent: PROCESS_DEFAULTS.trimToContent,
-	autoGridFromTrimmed: PROCESS_DEFAULTS.autoGridFromTrimmed,
-	fastAutoGridFromTrimmed: PROCESS_DEFAULTS.fastAutoGridFromTrimmed,
-	enableGridDetection: PROCESS_DEFAULTS.enableGridDetection,
-	makeSquare: PROCESS_DEFAULTS.makeSquare,
-	keepAspectRatio: PROCESS_DEFAULTS.keepAspectRatio,
-	cellSamplingMode: PROCESS_DEFAULTS.cellSamplingMode,
-	smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
-	reduceColors: PROCESS_DEFAULTS.reduceColors,
-	reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
-	colorCount: PROCESS_DEFAULTS.colorCount,
-	ditherMode: PROCESS_DEFAULTS.ditherMode,
-	ditherStrength: PROCESS_DEFAULTS.ditherStrength,
-	outlineStyle: PROCESS_DEFAULTS.outlineStyle,
-	outlineColor: PROCESS_DEFAULTS.outlineColor,
-} as ProcessOptions;
-
 /**
  * UI を初期状態のまま（かんたん設定は Auto プリセット、詳細設定は既定値）で
  * 処理したときに processImage へ渡るオプション。
  */
-export const AUTO_CASE_OPTIONS: ProcessOptions = applyQuickSettingsToOptions(
-	ADVANCED_DEFAULTS,
-	QUICK_SETTINGS_DEFAULTS,
-);
+export const AUTO_CASE_OPTIONS: ProcessOptions =
+	createUiInitialProcessOptions();
 
 const caseIdForFixture = (fileName: string): string =>
 	`auto-${fileName


### PR DESCRIPTION
## 概要

UIの初期処理オプションを共通生成し、Auto品質ケースがブラウザと同じ既定状態を検証できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- UI初期処理で、表示されない詳細設定を含む既定値へQuick SettingsのAuto設定を適用する経路を統一した。

### 開発体験

- Auto品質ケースがブラウザの初期オプション生成を直接利用するため、既定値追加時の手書き同期を不要にした。

### その他

- なし

## 動作確認

- なし
