### PR TITLE
fix: 品質レポートの一覧とケース詳細の表示差分を解消

### DIFF
--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -271,6 +271,11 @@ describe.skipIf(!enabled)("quality report", () => {
 		);
 		expect(compactDetail).toContain('class="case-description"');
 		expect(compactDetail).toContain('class="image-stage dialog-stage"');
+		// [Intended] 一覧カードと同じ属性を詳細でも読み取れるようにする。
+		expect(compactDetail).toContain('class="badge parameter-explicit"');
+		expect(compactDetail).toContain(
+			'<strong data-i18n="processingTime">Time</strong>',
+		);
 		for (const imageKey of [
 			"input",
 			"groundTruth",
@@ -299,6 +304,7 @@ describe.skipIf(!enabled)("quality report", () => {
 				"<code>remove-background-trim-resize-46x13</code>",
 		);
 		expect(autoDetail).toContain('data-i18n="sizeMatches"');
+		expect(autoDetail).toContain('class="badge parameter-auto"');
 		expect(results.summary.targetMissing).toBe(0);
 		expect(html).toContain("品質レポート");
 		const markdown = readFileSync(path.join(reportRoot, "summary.md"), "utf8");

--- a/test/quality/report/client.test.ts
+++ b/test/quality/report/client.test.ts
@@ -50,6 +50,21 @@ const makeElement = (
 const makeButton = (name: string, value: string, label: string): MockElement =>
 	makeElement({ [`${name}Filter`]: value }, label);
 
+type MockLink = {
+	getAttribute: (name: string) => string | null;
+	setAttribute: (name: string, value: string) => void;
+};
+
+const makeLink = (href: string): MockLink => {
+	const attributes: Record<string, string> = { href };
+	return {
+		getAttribute: (name) => attributes[name] ?? null,
+		setAttribute: (name, value) => {
+			attributes[name] = value;
+		},
+	};
+};
+
 const createReportPage = (query = "") => {
 	const search = makeElement();
 	const visibleCount = makeElement();
@@ -93,6 +108,12 @@ const createReportPage = (query = "") => {
 			parameter: "auto",
 		}),
 	];
+	const localeButtons = [
+		makeElement({ locale: "ja" }),
+		makeElement({ locale: "en" }),
+		makeElement({ locale: "zh-CN" }),
+	];
+	const detailLink = makeLink("cases/restore-bilinear-to-8x8/index.html");
 	const selectorGroups: Record<string, MockElement[]> = {
 		"[data-quality-filter]": qualityButtons,
 		"[data-change-filter]": changeButtons,
@@ -108,10 +129,11 @@ const createReportPage = (query = "") => {
 	};
 	const documentMock = {
 		documentElement: { lang: "" },
-		querySelectorAll(selector: string): MockElement[] {
+		querySelectorAll(selector: string): (MockElement | MockLink)[] {
 			if (selector === ".case") return cards;
 			if (selector === ".images img") return [];
-			if (selector === "[data-locale]") return [];
+			if (selector === "[data-locale]") return localeButtons;
+			if (selector === "a.detail-link, a.back-link") return [detailLink];
 			if (selector === "[data-i18n]" || selector === "[data-i18n-alt]") {
 				return [];
 			}
@@ -142,6 +164,8 @@ const createReportPage = (query = "") => {
 		cards,
 		qualityButtons,
 		changeButtons,
+		localeButtons,
+		detailLink,
 		search,
 		documentMock,
 		windowMock,
@@ -149,7 +173,41 @@ const createReportPage = (query = "") => {
 	};
 };
 
-const runPage = (page: ReturnType<typeof createReportPage>): void => {
+/** ケース詳細ページ。サイドバーが無いので絞り込みも言語ボタンも持たない。 */
+const createCaseDetailPage = (query = "") => {
+	const backLink = makeLink("../../index.html");
+	const documentMock = {
+		documentElement: { lang: "" },
+		querySelectorAll(selector: string): (MockElement | MockLink)[] {
+			if (selector === "a.detail-link, a.back-link") return [backLink];
+			return [];
+		},
+		querySelector: (): MockElement | null => null,
+	} as unknown as Document;
+	const location = new URL(
+		`https://example.test/report/cases/restore-bilinear-to-8x8/index.html${query}`,
+	);
+	const replaceState = vi.fn(
+		(_state: unknown, _title: string, nextUrl: string) => {
+			const nextLocation = new URL(nextUrl, location.href);
+			location.href = nextLocation.href;
+			location.search = nextLocation.search;
+			location.hash = nextLocation.hash;
+		},
+	);
+	const windowMock = {
+		__QUALITY_REPORT_TRANSLATIONS__: { en: {}, ja: {}, "zh-CN": {} },
+		location,
+		history: { replaceState },
+		addEventListener: vi.fn(),
+	} as unknown as Window;
+	return { backLink, documentMock, windowMock, replaceState };
+};
+
+const runPage = (page: {
+	documentMock: Document;
+	windowMock: Window;
+}): void => {
 	vi.stubGlobal("document", page.documentMock);
 	vi.stubGlobal("window", page.windowMock);
 	vi.stubGlobal("navigator", { languages: ["en"], language: "en" });
@@ -210,5 +268,49 @@ describe("quality report filter query state", () => {
 
 		page.changeButtons[3].trigger("click");
 		expect(page.cards.map((card) => card.hidden)).toEqual([true, true, false]);
+	});
+});
+
+describe("quality report locale query state", () => {
+	it("carries an explicitly chosen locale into the URL and case links", () => {
+		const page = createReportPage();
+		runPage(page);
+
+		// [Intended] ブラウザ言語のままなら遷移先でも同じ判定になるので、選ばれるまでは
+		// クエリもリンクも書き換えない。
+		expect(page.detailLink.getAttribute("href")).toBe(
+			"cases/restore-bilinear-to-8x8/index.html",
+		);
+		expect(
+			new URL(page.windowMock.location.href).searchParams.has("locale"),
+		).toBe(false);
+
+		page.localeButtons[2].trigger("click");
+
+		expect(page.documentMock.documentElement.lang).toBe("zh-CN");
+		expect(
+			new URL(page.windowMock.location.href).searchParams.get("locale"),
+		).toBe("zh-CN");
+		expect(page.detailLink.getAttribute("href")).toBe(
+			"cases/restore-bilinear-to-8x8/index.html?locale=zh-CN",
+		);
+	});
+
+	it("restores the locale from the query on a case detail page", () => {
+		const page = createCaseDetailPage("?locale=ja");
+		runPage(page);
+
+		expect(page.documentMock.documentElement.lang).toBe("ja");
+		expect(page.backLink.getAttribute("href")).toBe(
+			"../../index.html?locale=ja",
+		);
+	});
+
+	it("falls back to the browser language for an unknown locale", () => {
+		const page = createCaseDetailPage("?locale=fr");
+		runPage(page);
+
+		expect(page.documentMock.documentElement.lang).toBe("en");
+		expect(page.backLink.getAttribute("href")).toBe("../../index.html");
 	});
 });

--- a/test/quality/report/client.ts
+++ b/test/quality/report/client.ts
@@ -16,11 +16,24 @@ export const runQualityReportClient = (): void => {
 		navigator.language ??
 		"en"
 	).toLowerCase();
-	let locale = preferredLanguage.startsWith("ja")
-		? "ja"
-		: preferredLanguage.startsWith("zh")
-			? "zh-CN"
-			: "en";
+	// [Intended] 言語切り替えは一覧のサイドバーにしかないので、選択結果をクエリで運んで
+	// ケース詳細へ引き継ぐ。ブラウザ言語のままなら遷移先でも同じ判定になるため、
+	// 明示的に選ばれた言語だけをクエリとリンクに残す。
+	const requestedLocale = new URLSearchParams(window.location.search).get(
+		"locale",
+	);
+	const pinnedLocale =
+		requestedLocale !== null && requestedLocale in translations
+			? requestedLocale
+			: null;
+	let localePinned = pinnedLocale !== null;
+	let locale =
+		pinnedLocale ??
+		(preferredLanguage.startsWith("ja")
+			? "ja"
+			: preferredLanguage.startsWith("zh")
+				? "zh-CN"
+				: "en");
 	let messages = translations[locale];
 
 	const translate = (key: string): string | undefined => {
@@ -64,6 +77,37 @@ export const runQualityReportClient = (): void => {
 	const localeButtons = [
 		...document.querySelectorAll<HTMLButtonElement>("[data-locale]"),
 	];
+	const localeLinks = [
+		...document.querySelectorAll<HTMLAnchorElement>(
+			"a.detail-link, a.back-link",
+		),
+	];
+	const persistLocale = (): void => {
+		for (const link of localeLinks) {
+			const href = link.getAttribute("href");
+			if (href === null) continue;
+			// [Intended] href は相対のまま組み直す。絶対URLへ直すと file:// で開いた
+			// レポートのリンクが壊れる。
+			const [target, hash] = href.split("#");
+			const [pathOnly] = target.split("?");
+			link.setAttribute(
+				"href",
+				`${pathOnly}?locale=${encodeURIComponent(locale)}` +
+					(hash === undefined ? "" : `#${hash}`),
+			);
+		}
+		try {
+			const url = new URL(window.location.href);
+			url.searchParams.set("locale", locale);
+			window.history.replaceState(
+				null,
+				"",
+				`${url.pathname}${url.search}${url.hash}`,
+			);
+		} catch {
+			// [Workaround] URLを更新できない環境でも、表示言語の切り替えは妨げない。
+		}
+	};
 	let refreshFilter = (): void => {};
 	const setLocale = (nextLocale: string): void => {
 		if (!(nextLocale in translations)) return;
@@ -75,12 +119,14 @@ export const runQualityReportClient = (): void => {
 			button.classList.toggle("active", active);
 			button.setAttribute("aria-pressed", String(active));
 		}
+		if (localePinned) persistLocale();
 		refreshFilter();
 	};
 	for (const button of localeButtons) {
-		button.addEventListener("click", () =>
-			setLocale(button.dataset.locale ?? "en"),
-		);
+		button.addEventListener("click", () => {
+			localePinned = true;
+			setLocale(button.dataset.locale ?? "en");
+		});
 	}
 	setLocale(locale);
 

--- a/test/quality/report/render.test.ts
+++ b/test/quality/report/render.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import type { QualityCaseResult, QualityResults } from "../types";
+import { renderCaseDetailHtml, renderHtml } from "./render";
+
+const CASE_ID = "restore-bilinear-to-8x8";
+
+const makeCaseResult = (
+	overrides: Partial<QualityCaseResult> = {},
+): QualityCaseResult => ({
+	id: CASE_ID,
+	featureIds: ["PRF-001"],
+	parameterMode: "explicit",
+	inputKind: "pixel-art",
+	degradationPatterns: ["bilinear-blur"],
+	status: "passed",
+	targetStatus: "unmet",
+	targetFailedAssertions: ["mean-rgba-error"],
+	targetExpectation: null,
+	changeStatus: "unchanged",
+	failedAssertions: [],
+	regressedMetrics: [],
+	improvedMetrics: [],
+	changedPixelCount: 12,
+	changedPixelRate: 0.05,
+	diffBoundingBox: null,
+	classification: "pixel-art",
+	route: "refine",
+	confidence: 0.5,
+	warnings: [],
+	expectedWidth: 8,
+	expectedHeight: 8,
+	gridCandidates: [],
+	expectation: {},
+	options: {},
+	metrics: {
+		outputWidth: 8,
+		outputHeight: 8,
+		sizeCorrect: true,
+		top3SizeCorrect: true,
+		gridPhaseError: 0,
+		meanRgbaError: 1.5,
+		edgeF1: 0.9,
+		backgroundMaskIou: 0.8,
+		smallComponentRetention: 1,
+		byteIdentical: false,
+		catastrophicFailure: false,
+		runtimeMs: 12.345,
+		approxPeakBytes: 1024,
+	},
+	baselineMetrics: null,
+	targetMetrics: {
+		targetWidth: 8,
+		targetHeight: 8,
+		sizeMatches: true,
+		exactMatch: false,
+		meanRgbaError: 1.5,
+		edgeF1: 0.9,
+		backgroundMaskIou: 0.8,
+		smallComponentRetention: 1,
+	},
+	targetSource: null,
+	files: {
+		groundTruth: `cases/${CASE_ID}/ground-truth.png`,
+		input: `cases/${CASE_ID}/input.png`,
+		baseline: null,
+		result: `cases/${CASE_ID}/result.png`,
+		diff: `cases/${CASE_ID}/diff.png`,
+		baselineDiff: null,
+		backgroundMask: `cases/${CASE_ID}/background-mask.png`,
+	},
+	...overrides,
+});
+
+const makeResults = (cases: QualityCaseResult[]): QualityResults => ({
+	metadata: {
+		repositoryUrl: "https://example.test/repo",
+		prNumber: "local",
+		headCommit: "local",
+		baseCommit: "local",
+		generatedAt: "2026-08-11T04:25:51.000Z",
+		workflowRunUrl: "local",
+		benchmarkVersion: "2",
+		reportVersion: "4",
+		baselineCommit: "local",
+	},
+	summary: {
+		caseCount: cases.length,
+		passed: cases.length,
+		failed: 0,
+		changed: 0,
+		unchanged: cases.length,
+		newCases: 0,
+		explicitCases: cases.length,
+		autoCases: 0,
+		targetMet: 0,
+		targetUnmet: cases.length,
+		targetMissing: 0,
+		top1SizeAccuracy: 1,
+		top3SizeAccuracy: 1,
+		confidenceCorrectnessCorrelation: null,
+		byteIdentityRate: 0,
+		catastrophicFailureRate: 0,
+		meanRgbaError: 1.5,
+		meanRuntimeMs: 12.345,
+		approxPeakBytes: 1024,
+	},
+	cases,
+});
+
+const between = (html: string, start: string, end: string): string => {
+	const startIndex = html.indexOf(start);
+	expect(startIndex).toBeGreaterThan(-1);
+	return html.slice(startIndex, html.indexOf(end, startIndex));
+};
+
+const badges = (
+	html: string,
+): Array<{ className: string; translationKey: string }> =>
+	[...html.matchAll(/class="badge ([^"]+)"\s+data-i18n="([^"]+)"/g)].map(
+		(match) => ({ className: match[1], translationKey: match[2] }),
+	);
+
+describe("quality report case detail", () => {
+	// [Intended] 一覧と詳細で同じケースの見出しバッジが食い違うと、片方でしか
+	// 分からない属性が生まれる。両方の見出しを同じ形で突き合わせる。
+	it("shows the same heading badges as the index card", () => {
+		const result = makeCaseResult();
+		const indexHeading = between(
+			renderHtml(makeResults([result])),
+			"<h2>",
+			"</h2>",
+		);
+		const detailHeading = between(
+			renderCaseDetailHtml(result),
+			"<h1>",
+			"</h1>",
+		);
+		expect(badges(indexHeading)).toEqual([
+			{ className: "target-unmet", translationKey: "targetUnmet" },
+			{ className: "unchanged", translationKey: "unchanged" },
+			{ className: "parameter-explicit", translationKey: "explicitParameters" },
+		]);
+		expect(badges(detailHeading)).toEqual(badges(indexHeading));
+	});
+
+	it("marks an auto case with the auto parameter badge", () => {
+		const detailHeading = between(
+			renderCaseDetailHtml(makeCaseResult({ parameterMode: "auto" })),
+			"<h1>",
+			"</h1>",
+		);
+		expect(badges(detailHeading)).toContainEqual({
+			className: "parameter-auto",
+			translationKey: "autoParameters",
+		});
+	});
+
+	// [Intended] 実行時間はベースラインを持たないので、比較列のある指標テーブルには
+	// 出さない。表へ紛れ込むと毎回「判定不能」の行が増える。
+	it("shows the processing time outside the metric table", () => {
+		const detail = renderCaseDetailHtml(makeCaseResult());
+		expect(detail).toContain(
+			'<strong data-i18n="processingTime">Time</strong>: 12.35ms',
+		);
+		expect(between(detail, "<tbody>", "</tbody>")).not.toContain(
+			"processingTime",
+		);
+	});
+
+	// [Intended] failed は「ケース定義の許容値を満たさない」を指す別概念なので、
+	// 目標未達の見出しには使わない。
+	it("labels unmet target assertions with the target verdict key", () => {
+		const result = makeCaseResult();
+		const targetSection = between(
+			renderCaseDetailHtml(result),
+			'<h2 data-i18n="targetComparison">',
+			"</section>",
+		);
+		expect(targetSection).toContain(
+			'<strong data-i18n="targetUnmet">Target unmet</strong>',
+		);
+		expect(targetSection).not.toContain('data-i18n="failed"');
+		expect(renderHtml(makeResults([result]))).toContain(
+			'<p class="target-failures"><strong data-i18n="targetUnmet">',
+		);
+	});
+});

--- a/test/quality/report/render.ts
+++ b/test/quality/report/render.ts
@@ -349,7 +349,7 @@ export const renderHtml = (results: QualityResults): string => {
 			const targetFailures =
 				result.targetFailedAssertions.length === 0
 					? ""
-					: `<p class="target-failures"><strong data-i18n="failed">Target unmet</strong>: ` +
+					: `<p class="target-failures"><strong data-i18n="targetUnmet">Target unmet</strong>: ` +
 						result.targetFailedAssertions
 							.map(
 								(assertion) =>
@@ -587,6 +587,12 @@ export const renderCaseDetailHtml = (result: QualityCaseResult): string => {
 	const tags = result.degradationPatterns
 		.map((pattern) => `<span class="tag">${escapeHtml(pattern)}</span>`)
 		.join(" ");
+	// [Intended] 実行時間はベースラインを持たない指標なので、指標比較の表には入れず
+	// 単独の行で出す。表へ足すと Baseline も Delta も "-" のまま判定列だけが埋まり、
+	// 前回基準と比べられる指標と見分けがつかなくなる。
+	const processingTime =
+		'<p><strong data-i18n="processingTime">Time</strong>: ' +
+		`${result.metrics.runtimeMs.toFixed(2)}ms</p>`;
 	return `<!doctype html>
 <html lang="en">
 <head>
@@ -603,11 +609,14 @@ ${DETAIL_REPORT_STYLES}	</style>
 			${escapeHtml(result.id)}
 			<span class="badge target-${result.targetStatus}" data-i18n="${targetStateKey}">${result.targetStatus}</span>
 			<span class="badge ${result.changeStatus}" data-i18n="${result.changeStatus}">${result.changeStatus}</span>
+			<span class="badge parameter-${result.parameterMode}"
+				data-i18n="${result.parameterMode === "auto" ? "autoParameters" : "explicitParameters"}">${result.parameterMode}</span>
 		</h1>
 		<p class="case-description" data-description-en="${escapeHtml(description.en)}"
 			data-description-ja="${escapeHtml(description.ja)}">${escapeHtml(description.en)}</p>
 		<p>${tags}</p>
 		<p><strong data-i18n="changedPixels">Changed pixels</strong>: ${changedPixels}</p>
+		${processingTime}
 		<section>
 			<h2 data-i18n="diagnostics">All images and settings</h2>
 			<div class="images">${allImages}</div>

--- a/test/quality/report/styles.test.ts
+++ b/test/quality/report/styles.test.ts
@@ -9,4 +9,11 @@ describe("quality report image styles", () => {
 			);
 		}
 	});
+
+	// [Intended] 劣化パターンのタグはケース詳細にしか出ない。一覧側へ残しても
+	// 参照されないまま、一覧にもタグがあるように読めてしまう。
+	it("keeps the tag style only where tags are rendered", () => {
+		expect(DETAIL_REPORT_STYLES).toContain(".badge, .tag {");
+		expect(INDEX_REPORT_STYLES).not.toContain(".tag");
+	});
 });

--- a/test/quality/report/styles.ts
+++ b/test/quality/report/styles.ts
@@ -67,7 +67,7 @@ a { color: #b9a7ff; }
 .target-failures { margin: -6px 0 12px; color: #ffb0b0; }
 .detail-link { display: inline-block; padding: 8px 12px; border: 1px solid #635a70; border-radius: 6px; background: #302a39; text-decoration: none; }
 .detail-link:hover { border-color: #c2b4ff; background: #3b3346; }
-.badge, .tag { display: inline-block; padding: 3px 7px; border-radius: 999px; font-size: .75em; background: #393241; }
+.badge { display: inline-block; padding: 3px 7px; border-radius: 999px; font-size: .75em; background: #393241; }
 .badge.failed, .badge.target-unmet { background: #7a2930; }
 .badge.passed, .badge.target-met { background: #236044; }
 .badge.target-missing { background: #48536b; }

--- a/test/quality/report/target-section.ts
+++ b/test/quality/report/target-section.ts
@@ -69,7 +69,7 @@ export const renderTargetComparison = (result: QualityCaseResult): string => {
 	const failures =
 		result.targetFailedAssertions.length === 0
 			? ""
-			: `<p><strong data-i18n="failed">Target unmet</strong>: ` +
+			: `<p><strong data-i18n="targetUnmet">Target unmet</strong>: ` +
 				result.targetFailedAssertions
 					.map(
 						(assertion) =>


### PR DESCRIPTION
## 概要

品質レポートで、一覧とケース詳細のどちらを開いても同じ基本情報を読み取れるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 品質レポートのケース詳細で、パラメータの種別（自動判定 / オプション指定あり）と処理時間を確認できるようにする（一覧カードにしかなく、詳細を開くと読み取れる情報が減っていたため）。
- 品質レポートで選んだ表示言語が、一覧とケース詳細を行き来しても保たれるようにする（言語切り替えは一覧のサイドバーにしかなく、詳細を開くとブラウザ言語に戻っていたため）。
- 目標未達の項目名の見出しを「目標未達」の訳語で表示するようにする（従来はケース定義の許容値未達を指す別概念の訳語が当たり、翻訳の前後で意味が変わっていたため）。

### その他

- 処理時間はベースラインを持たない指標のため、比較列のある指標テーブルではなく単独の行として表示している。

## 動作確認

- なし
