### PR TITLE
test: 品質レポートのケース fixture に候補モーダル診断の項目を追加

### DIFF
--- a/test/quality/report/render.test.ts
+++ b/test/quality/report/render.test.ts
@@ -25,8 +25,17 @@ const makeCaseResult = (
 	diffBoundingBox: null,
 	classification: "pixel-art",
 	route: "refine",
+	classificationConfidence: 0.5,
 	confidence: 0.5,
+	gridConfidence: 0.5,
 	warnings: [],
+	// [Intended] explicit ケースなので候補選択モーダルは対象外になる。
+	// evaluateCandidateModalDecision が isAuto=false に対して返す組み合わせと揃える。
+	candidateModalDecision: "not-applicable",
+	candidateModalReason: "NOT_AUTO",
+	warningPresentation: "none",
+	candidatePlanCount: 0,
+	candidateOptions: [],
 	expectedWidth: 8,
 	expectedHeight: 8,
 	gridCandidates: [],


### PR DESCRIPTION
## 概要

品質レポートのテストが CI で失敗している状態を解消する。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 品質レポートのケース詳細のテストが候補モーダル診断を含む結果でも実行できるようになり、release/1.0.0 の CI で型チェックとユニットテストが通るようになる。

### その他

- 候補モーダル診断の追加とケース詳細テストの追加が別ブランチで並行したため、双方をマージした時点でテスト側のケースデータだけが項目不足になっていた。
  ファイルが重ならず Git のコンフリクトにならなかったため、マージ後の CI で初めて検知された。

## 動作確認

- なし
