### PR TITLE
feat: 品質レポートの画像に実寸を表示

### DIFF
--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -21,6 +21,7 @@ import {
 	calculateTargetMetrics,
 	createBackgroundMaskImage,
 	createDiffImage,
+	diffImageSize,
 	targetQualityFailures,
 } from "./metrics";
 import {
@@ -33,6 +34,7 @@ import type {
 	QualityCandidateOption,
 	QualityCaseResult,
 	QualityImageCase,
+	QualityImageSize,
 } from "./types";
 
 const REPORT_ROOT = path.resolve("tmp/quality-report/latest");
@@ -137,6 +139,9 @@ const buildCandidateOptions = (
 			};
 		}
 	});
+
+const imageSize = (image: RawImage | null): QualityImageSize | null =>
+	image === null ? null : { width: image.width, height: image.height };
 
 const failedAssertions = (
 	qualityCase: QualityImageCase,
@@ -278,6 +283,22 @@ export const runQualityCase = (
 			baselineImage === null ? null : `${caseDirectory}/baseline-diff.png`,
 		backgroundMask: `${caseDirectory}/background-mask.png`,
 	};
+	const imageSizes = {
+		groundTruth: imageSize(targetImage),
+		input: imageSize(input),
+		baseline: imageSize(baselineImage),
+		result: imageSize(currentRun.result),
+		diff:
+			targetImage === null
+				? null
+				: diffImageSize(currentRun.result, targetImage),
+		baselineDiff:
+			baselineImage === null
+				? null
+				: diffImageSize(currentRun.result, baselineImage),
+		// [Intended] 背景マスクは出力画像から作るので、常に出力と同じ寸法になる。
+		backgroundMask: imageSize(currentRun.result),
+	};
 	const selectedCandidate =
 		currentRun.analysis.gridCandidates[
 			currentRun.analysis.selectedCandidateIndex ?? 0
@@ -398,6 +419,7 @@ export const runQualityCase = (
 				? (autoTargetSource(qualityCase.id) ?? null)
 				: null,
 		files,
+		imageSizes,
 	};
 };
 

--- a/test/quality/benchmark.ts
+++ b/test/quality/benchmark.ts
@@ -140,8 +140,14 @@ const buildCandidateOptions = (
 		}
 	});
 
-const imageSize = (image: RawImage | null): QualityImageSize | null =>
-	image === null ? null : { width: image.width, height: image.height };
+const imageSize = (image: RawImage): QualityImageSize => ({
+	width: image.width,
+	height: image.height,
+});
+
+/** 存在しない画像を持つキー用。files の null 許容と対応させる。 */
+const optionalImageSize = (image: RawImage | null): QualityImageSize | null =>
+	image === null ? null : imageSize(image);
 
 const failedAssertions = (
 	qualityCase: QualityImageCase,
@@ -284,9 +290,9 @@ export const runQualityCase = (
 		backgroundMask: `${caseDirectory}/background-mask.png`,
 	};
 	const imageSizes = {
-		groundTruth: imageSize(targetImage),
+		groundTruth: optionalImageSize(targetImage),
 		input: imageSize(input),
-		baseline: imageSize(baselineImage),
+		baseline: optionalImageSize(baselineImage),
 		result: imageSize(currentRun.result),
 		diff:
 			targetImage === null

--- a/test/quality/metrics.ts
+++ b/test/quality/metrics.ts
@@ -2,6 +2,7 @@ import type { PixelGrid, RawImage } from "../../src/shared/types";
 import { imagesEqual } from "./image";
 import type {
 	QualityExpectation,
+	QualityImageSize,
 	QualityMetrics,
 	QualityTargetMetrics,
 } from "./types";
@@ -336,7 +337,7 @@ export const targetQualityFailures = (
 export const diffImageSize = (
 	actual: RawImage,
 	expected: RawImage,
-): { width: number; height: number } => ({
+): QualityImageSize => ({
 	width: Math.max(actual.width, expected.width),
 	height: Math.max(actual.height, expected.height),
 });

--- a/test/quality/metrics.ts
+++ b/test/quality/metrics.ts
@@ -328,12 +328,24 @@ export const targetQualityFailures = (
 	return [...new Set(failed)];
 };
 
+/**
+ * 差分画像の寸法。寸法の違う 2 枚を重ねるため、両方が収まる大きさになる。
+ * [Intended] 画素を作らずに寸法だけ要るレポート側と定義を共有し、書き出した画像と
+ * レポートに載る寸法がずれないようにする。
+ */
+export const diffImageSize = (
+	actual: RawImage,
+	expected: RawImage,
+): { width: number; height: number } => ({
+	width: Math.max(actual.width, expected.width),
+	height: Math.max(actual.height, expected.height),
+});
+
 export const createDiffImage = (
 	actual: RawImage,
 	expected: RawImage,
 ): RawImage => {
-	const width = Math.max(actual.width, expected.width);
-	const height = Math.max(actual.height, expected.height);
+	const { width, height } = diffImageSize(actual, expected);
 	const data = new Uint8ClampedArray(width * height * 4);
 	for (let y = 0; y < height; y += 1) {
 		for (let x = 0; x < width; x += 1) {

--- a/test/quality/report.test.ts
+++ b/test/quality/report.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Script } from "node:vm";
 import { describe, expect, it } from "vitest";
 import { reportRoot } from "./benchmark";
+import { readPng } from "./image";
 import { loadCases, selectCasesForProfile } from "./manifest";
 import { aggregateQualityReport } from "./report/aggregate";
 import { renderHtml } from "./report/render";
@@ -471,6 +472,25 @@ describe.skipIf(!enabled)("quality report", () => {
 				expect(existsSync(path.join(reportRoot, result.files.baseline))).toBe(
 					true,
 				);
+			}
+		}
+		// [Intended] レポートに載る寸法は、書き出した画像そのものを読み直して突き合わせる。
+		// 生成側は背景マスクを出力と同寸だと決め打ちするなど実装への暗黙の依存を持つため、
+		// その前提が崩れたときに表示だけが実物とずれた状態で残らないようにする。
+		for (const result of results.cases) {
+			for (const [key, file] of Object.entries(result.files)) {
+				const size = result.imageSizes[key as keyof typeof result.files];
+				if (file === null) {
+					expect([result.id, key, size]).toEqual([result.id, key, null]);
+					continue;
+				}
+				const image = readPng(path.join(reportRoot, file));
+				expect([result.id, key, size?.width, size?.height]).toEqual([
+					result.id,
+					key,
+					image.width,
+					image.height,
+				]);
 			}
 		}
 	}, 120_000);

--- a/test/quality/report/auto-diagnostics.ts
+++ b/test/quality/report/auto-diagnostics.ts
@@ -4,7 +4,7 @@ import type {
 	WarningPresentation,
 } from "../../../src/core/candidate-modal-decision";
 import type { QualityCandidateOption, QualityCaseResult } from "../types";
-import { escapeHtml, formatConfidence } from "./format";
+import { escapeHtml, formatConfidence, formatImageSize } from "./format";
 
 const CANDIDATE_MODAL_DECISION_KEYS: Record<CandidateModalDecision, string> = {
 	"would-show": "candidateModalWouldShow",
@@ -83,10 +83,17 @@ const renderCandidateOption = (option: QualityCandidateOption): string => {
 		: "";
 	// [Intended] 生成に失敗した候補も欠番として残す。モーダルの表示見込みは候補プラン数だけで
 	// 決まるため、生成できなかった選択肢はここに出さないとレポートから消えてしまう。
+	const outputSize =
+		option.outputWidth === null || option.outputHeight === null
+			? "-"
+			: formatImageSize({
+					width: option.outputWidth,
+					height: option.outputHeight,
+				});
 	const metadata =
 		option.file === null
 			? '<span data-i18n="candidateOptionFailed">generation failed</span>'
-			: `${String(option.outputWidth)} &times; ${String(option.outputHeight)} px ` +
+			: `${outputSize} ` +
 				`&middot; <span data-i18n="colorCount">Colors</span> ${String(option.colorCount)}`;
 	const stage =
 		option.file === null

--- a/test/quality/report/format.ts
+++ b/test/quality/report/format.ts
@@ -1,3 +1,5 @@
+import type { QualityImageSize } from "../types";
+
 export const escapeHtml = (value: string): string =>
 	value
 		.replace(/&/g, "&amp;")
@@ -11,3 +13,6 @@ export const formatMetric = (value: number | undefined): string =>
 
 export const formatConfidence = (value: number | null): string =>
 	value === null ? "-" : value.toFixed(4);
+
+export const formatImageSize = (size: QualityImageSize): string =>
+	`${String(size.width)}x${String(size.height)}px`;

--- a/test/quality/report/images.ts
+++ b/test/quality/report/images.ts
@@ -14,14 +14,11 @@ type ReportImage = {
 
 /**
  * 今回生成が目標と違う寸法か。目標を持たないケースは比べられないので false。
- * 一覧と詳細で同じ判定を使い、片方だけ警告色になることを防ぐ。
+ * [Intended] 寸法一致は指標側の sizeMatches が唯一の定義。ここで比べ直すと、
+ * 同じ詳細ページの Size matches 行と警告色が別々の判定から描かれる。
  */
-const resultSizeMismatched = (result: QualityCaseResult): boolean => {
-	const target = result.imageSizes.groundTruth;
-	const current = result.imageSizes.result;
-	if (target === null || current === null) return false;
-	return target.width !== current.width || target.height !== current.height;
-};
+const resultSizeMismatched = (result: QualityCaseResult): boolean =>
+	result.targetMetrics?.sizeMatches === false;
 
 /**
  * 実寸の class 名。CSS 側の規則と対応していることをテストで確かめるため、

--- a/test/quality/report/images.ts
+++ b/test/quality/report/images.ts
@@ -1,0 +1,143 @@
+import path from "node:path";
+import type { QualityCaseResult, QualityImageSize } from "../types";
+import { escapeHtml, formatImageSize } from "./format";
+
+type ReportImage = {
+	/** 見出しの翻訳キー。 */
+	key: string;
+	label: string;
+	source: string | null;
+	size: QualityImageSize | null;
+	/** 目標と寸法が食い違う画像。実寸を警告色で出す。 */
+	sizeMismatched?: boolean;
+};
+
+/**
+ * 今回生成が目標と違う寸法か。目標を持たないケースは比べられないので false。
+ * 一覧と詳細で同じ判定を使い、片方だけ警告色になることを防ぐ。
+ */
+const resultSizeMismatched = (result: QualityCaseResult): boolean => {
+	const target = result.imageSizes.groundTruth;
+	const current = result.imageSizes.result;
+	if (target === null || current === null) return false;
+	return target.width !== current.width || target.height !== current.height;
+};
+
+/**
+ * 画像の見出しへ添える実寸。
+ * [Intended] 翻訳は data-i18n を持つ要素の textContent を丸ごと置き換えるので、実寸は
+ * 見出しの span の外へ出す。figcaption 直下へ置くと言語切り替えで消える。
+ */
+const renderImageSize = (image: ReportImage): string => {
+	if (image.size === null) return "";
+	const className = image.sizeMismatched
+		? "image-size size-mismatch"
+		: "image-size";
+	return ` <small class="${className}">(${formatImageSize(image.size)})</small>`;
+};
+
+/**
+ * 画像一式の figure。src の書き方が一覧（レポート起点の相対パス）と詳細
+ * （ケースディレクトリ内のファイル名）で違うので、変換だけを呼び出し側から受け取る。
+ */
+const renderImages = (
+	images: ReportImage[],
+	toSource: (source: string) => string,
+): string =>
+	images
+		.filter(
+			(image): image is ReportImage & { source: string } =>
+				image.source !== null,
+		)
+		.map(
+			(image) =>
+				`<figure><figcaption><span data-i18n="${image.key}">${image.label}</span>` +
+				`${renderImageSize(image)}</figcaption>` +
+				`<div class="image-stage"><img src="${escapeHtml(toSource(image.source))}" alt="${image.label}" ` +
+				`data-i18n-alt="${image.key}" loading="lazy"></div></figure>`,
+		)
+		.join("");
+
+/** 一覧のカードに並べる画像。目標・今回生成・目標との差分だけを出す。 */
+export const renderPrimaryImages = (result: QualityCaseResult): string =>
+	renderImages(
+		[
+			{
+				key: "groundTruth",
+				label: "Target",
+				source: result.files.groundTruth,
+				size: result.imageSizes.groundTruth,
+			},
+			{
+				key: "result",
+				label: "Result",
+				source: result.files.result,
+				size: result.imageSizes.result,
+				sizeMismatched: resultSizeMismatched(result),
+			},
+			{
+				key: "groundTruthDifference",
+				label: "Target difference",
+				source: result.files.diff,
+				size: result.imageSizes.diff,
+			},
+		],
+		(source) => source,
+	);
+
+/** ケース詳細に並べる画像。書き出した画像をすべて出す。 */
+export const renderAllImages = (result: QualityCaseResult): string =>
+	renderImages(
+		[
+			{
+				key: "input",
+				label: "Input",
+				source: result.files.input,
+				size: result.imageSizes.input,
+			},
+			{
+				key: "groundTruth",
+				label: "Ground truth",
+				source: result.files.groundTruth,
+				size: result.imageSizes.groundTruth,
+			},
+			{
+				key: "baseline",
+				label: "Baseline",
+				source: result.files.baseline,
+				size: result.imageSizes.baseline,
+			},
+			{
+				key: "result",
+				label: "Result",
+				source: result.files.result,
+				size: result.imageSizes.result,
+				sizeMismatched: resultSizeMismatched(result),
+			},
+			{
+				key: "groundTruthDifference",
+				label: "Ground-truth difference",
+				source: result.files.diff,
+				size: result.imageSizes.diff,
+			},
+			{
+				key: "baselineDifference",
+				label: "Baseline difference",
+				source: result.files.baselineDiff,
+				size: result.imageSizes.baselineDiff,
+			},
+			{
+				key: "backgroundMask",
+				label: "Background mask",
+				source: result.files.backgroundMask,
+				size: result.imageSizes.backgroundMask,
+			},
+		],
+		(source) => path.posix.basename(source),
+	);
+
+export const renderImageDialog = (): string => `
+<dialog id="image-dialog">
+	<button id="dialog-close">&times;</button>
+	<div class="image-stage dialog-stage"><img alt=""></div>
+</dialog>`;

--- a/test/quality/report/images.ts
+++ b/test/quality/report/images.ts
@@ -24,6 +24,15 @@ const resultSizeMismatched = (result: QualityCaseResult): boolean => {
 };
 
 /**
+ * 実寸の class 名。CSS 側の規則と対応していることをテストで確かめるため、
+ * マークアップに直書きせずここから配る。
+ */
+export const IMAGE_SIZE_CLASS = "image-size";
+
+/** 目標と寸法が食い違う実寸へ足す修飾。 */
+export const IMAGE_SIZE_MISMATCH_CLASS = "size-mismatch";
+
+/**
  * 画像の見出しへ添える実寸。
  * [Intended] 翻訳は data-i18n を持つ要素の textContent を丸ごと置き換えるので、実寸は
  * 見出しの span の外へ出す。figcaption 直下へ置くと言語切り替えで消える。
@@ -31,8 +40,8 @@ const resultSizeMismatched = (result: QualityCaseResult): boolean => {
 const renderImageSize = (image: ReportImage): string => {
 	if (image.size === null) return "";
 	const className = image.sizeMismatched
-		? "image-size size-mismatch"
-		: "image-size";
+		? `${IMAGE_SIZE_CLASS} ${IMAGE_SIZE_MISMATCH_CLASS}`
+		: IMAGE_SIZE_CLASS;
 	return ` <small class="${className}">(${formatImageSize(image.size)})</small>`;
 };
 

--- a/test/quality/report/partial.ts
+++ b/test/quality/report/partial.ts
@@ -7,6 +7,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import type { QualityCaseResult } from "../types";
+import { QUALITY_REPORT_VERSION } from "../types";
 
 // [Policy] 部分結果はレポート成果物と混ぜない。tmp/quality-report/latest は
 // そのまま CI のアップロード対象になるため、中間ファイルを含めない場所へ書く。
@@ -15,21 +16,33 @@ const PARTIAL_ROOT = path.resolve("tmp/quality-report/partial");
 const partialFile = (shardIndex: number): string =>
 	path.join(PARTIAL_ROOT, `shard-${String(shardIndex).padStart(2, "0")}.json`);
 
+type QualityReportPartial = {
+	shardIndex: number;
+	/** 書き出したときのレポート形式。読み出し側で世代の食い違いを弾くために持つ。 */
+	reportVersion: string;
+	cases: QualityCaseResult[];
+};
+
 /** シャードが担当したケースの結果を、集約側が読める中間ファイルへ書き出す。 */
 export const writeQualityReportPartial = (
 	shardIndex: number,
 	cases: QualityCaseResult[],
 ): void => {
 	mkdirSync(PARTIAL_ROOT, { recursive: true });
-	writeFileSync(
-		partialFile(shardIndex),
-		`${JSON.stringify({ shardIndex, cases })}\n`,
-	);
+	const partial: QualityReportPartial = {
+		shardIndex,
+		reportVersion: QUALITY_REPORT_VERSION,
+		cases,
+	};
+	writeFileSync(partialFile(shardIndex), `${JSON.stringify(partial)}\n`);
 };
 
 /**
  * 全シャードの部分結果を読み出す。
  * ケース順序は集約側でケース定義の順に並べ直すため、ここでは保証しない。
+ * [Intended] 世代の違う部分結果は読まずに落とす。JSON はそのままキャストして流すので、
+ * 前の形式で書かれたケースが残っていると、欠けたフィールドを読む描画側が
+ * 意味の分からない例外で落ち、途中まで書いた成果物だけが残る。
  */
 export const readQualityReportPartials = (): QualityCaseResult[] => {
 	if (!existsSync(PARTIAL_ROOT)) return [];
@@ -38,8 +51,15 @@ export const readQualityReportPartials = (): QualityCaseResult[] => {
 		if (!fileName.endsWith(".json")) continue;
 		const partial = JSON.parse(
 			readFileSync(path.join(PARTIAL_ROOT, fileName), "utf8"),
-		) as { shardIndex: number; cases: QualityCaseResult[] };
-		cases.push(...partial.cases);
+		) as Partial<QualityReportPartial>;
+		if (partial.reportVersion !== QUALITY_REPORT_VERSION) {
+			throw new Error(
+				`Quality report partial ${fileName} was written for report version ` +
+					`${partial.reportVersion ?? "unknown"}, but this run expects ` +
+					`${QUALITY_REPORT_VERSION}. Remove ${PARTIAL_ROOT} and rerun the shards.`,
+			);
+		}
+		cases.push(...(partial.cases ?? []));
 	}
 	return cases;
 };

--- a/test/quality/report/render.test.ts
+++ b/test/quality/report/render.test.ts
@@ -77,6 +77,15 @@ const makeCaseResult = (
 		baselineDiff: null,
 		backgroundMask: `cases/${CASE_ID}/background-mask.png`,
 	},
+	imageSizes: {
+		groundTruth: { width: 8, height: 8 },
+		input: { width: 64, height: 64 },
+		baseline: null,
+		result: { width: 8, height: 8 },
+		diff: { width: 8, height: 8 },
+		baselineDiff: null,
+		backgroundMask: { width: 8, height: 8 },
+	},
 	...overrides,
 });
 
@@ -173,6 +182,80 @@ describe("quality report case detail", () => {
 		);
 		expect(between(detail, "<tbody>", "</tbody>")).not.toContain(
 			"processingTime",
+		);
+	});
+
+	// [Intended] 画像の寸法は一覧でも詳細でも同じ形で読めるようにする。片方にしか無いと、
+	// 目標と出力の食い違いに気付くために毎回詳細を開くことになる。
+	it("shows each image size next to its caption in both views", () => {
+		const result = makeCaseResult();
+		expect(renderHtml(makeResults([result]))).toContain(
+			'<span data-i18n="result">Result</span> <small class="image-size">(8x8px)</small>',
+		);
+		expect(renderCaseDetailHtml(result)).toContain(
+			'<span data-i18n="input">Input</span> <small class="image-size">(64x64px)</small>',
+		);
+	});
+
+	// [Intended] 翻訳は data-i18n の要素の textContent を丸ごと置き換えるので、実寸を
+	// figcaption 直下へ置くと言語切り替えで消える。見出しは span に閉じ込める。
+	it("keeps the image size outside the translated caption element", () => {
+		const result = makeCaseResult();
+		expect(renderHtml(makeResults([result]))).not.toContain(
+			"<figcaption data-i18n=",
+		);
+		expect(renderCaseDetailHtml(result)).not.toContain(
+			"<figcaption data-i18n=",
+		);
+	});
+
+	it("highlights the current-run size when it differs from the target", () => {
+		const result = makeCaseResult({
+			imageSizes: {
+				groundTruth: { width: 8, height: 8 },
+				input: { width: 64, height: 64 },
+				baseline: null,
+				result: { width: 16, height: 16 },
+				diff: { width: 16, height: 16 },
+				baselineDiff: null,
+				backgroundMask: { width: 16, height: 16 },
+			},
+		});
+		for (const html of [
+			renderHtml(makeResults([result])),
+			renderCaseDetailHtml(result),
+		]) {
+			expect(html).toContain(
+				'<span data-i18n="result">Result</span> <small class="image-size size-mismatch">(16x16px)</small>',
+			);
+			expect(html).toContain('<small class="image-size">(8x8px)</small>');
+		}
+	});
+
+	// [Intended] 目標を持たないケースは寸法を比べられないので、警告色にはしない。
+	it("does not highlight the current-run size without a target image", () => {
+		const result = makeCaseResult({
+			files: {
+				groundTruth: null,
+				input: `cases/${CASE_ID}/input.png`,
+				baseline: null,
+				result: `cases/${CASE_ID}/result.png`,
+				diff: null,
+				baselineDiff: null,
+				backgroundMask: `cases/${CASE_ID}/background-mask.png`,
+			},
+			imageSizes: {
+				groundTruth: null,
+				input: { width: 64, height: 64 },
+				baseline: null,
+				result: { width: 16, height: 16 },
+				diff: null,
+				baselineDiff: null,
+				backgroundMask: { width: 16, height: 16 },
+			},
+		});
+		expect(renderCaseDetailHtml(result)).not.toContain(
+			'<small class="image-size size-mismatch">',
 		);
 	});
 

--- a/test/quality/report/render.test.ts
+++ b/test/quality/report/render.test.ts
@@ -211,6 +211,16 @@ describe("quality report case detail", () => {
 
 	it("highlights the current-run size when it differs from the target", () => {
 		const result = makeCaseResult({
+			targetMetrics: {
+				targetWidth: 8,
+				targetHeight: 8,
+				sizeMatches: false,
+				exactMatch: false,
+				meanRgbaError: 1.5,
+				edgeF1: 0,
+				backgroundMaskIou: 0,
+				smallComponentRetention: 0,
+			},
 			imageSizes: {
 				groundTruth: { width: 8, height: 8 },
 				input: { width: 64, height: 64 },
@@ -235,6 +245,7 @@ describe("quality report case detail", () => {
 	// [Intended] 目標を持たないケースは寸法を比べられないので、警告色にはしない。
 	it("does not highlight the current-run size without a target image", () => {
 		const result = makeCaseResult({
+			targetMetrics: null,
 			files: {
 				groundTruth: null,
 				input: `cases/${CASE_ID}/input.png`,

--- a/test/quality/report/render.ts
+++ b/test/quality/report/render.ts
@@ -6,7 +6,12 @@ import {
 	renderWarningDetails,
 } from "./auto-diagnostics";
 import { runQualityReportClient } from "./client";
-import { escapeHtml, formatConfidence, formatMetric } from "./format";
+import {
+	escapeHtml,
+	formatConfidence,
+	formatImageSize,
+	formatMetric,
+} from "./format";
 import {
 	renderAllImages,
 	renderImageDialog,
@@ -503,14 +508,27 @@ export const renderCaseDetailHtml = (result: QualityCaseResult): string => {
 	const expectedSize =
 		result.expectation.expectedWidth !== undefined &&
 		result.expectation.expectedHeight !== undefined
-			? `${result.expectation.expectedWidth}x${result.expectation.expectedHeight}`
+			? formatImageSize({
+					width: result.expectation.expectedWidth,
+					height: result.expectation.expectedHeight,
+				})
 			: "correct";
 	const sizeState = result.metrics.sizeCorrect ? "passed" : "failed";
 	const sizeRow = `<tr class="${sizeState}">
 		<th data-i18n="outputSize">Output size</th>
 		<td>${expectedSize}</td>
-		<td>${baselineMetrics ? `${baselineMetrics.outputWidth}x${baselineMetrics.outputHeight}` : "-"}</td>
-		<td>${result.metrics.outputWidth}x${result.metrics.outputHeight}</td>
+		<td>${
+			baselineMetrics
+				? formatImageSize({
+						width: baselineMetrics.outputWidth,
+						height: baselineMetrics.outputHeight,
+					})
+				: "-"
+		}</td>
+		<td>${formatImageSize({
+			width: result.metrics.outputWidth,
+			height: result.metrics.outputHeight,
+		})}</td>
 		<td>-</td>
 		<td data-i18n="${sizeState}">${sizeState}</td>
 	</tr>`;

--- a/test/quality/report/render.ts
+++ b/test/quality/report/render.ts
@@ -7,6 +7,11 @@ import {
 } from "./auto-diagnostics";
 import { runQualityReportClient } from "./client";
 import { escapeHtml, formatConfidence, formatMetric } from "./format";
+import {
+	renderAllImages,
+	renderImageDialog,
+	renderPrimaryImages,
+} from "./images";
 import { DETAIL_REPORT_STYLES, INDEX_REPORT_STYLES } from "./styles";
 import { renderTargetComparison, TARGET_STATE_KEYS } from "./target-section";
 import { REPORT_TRANSLATIONS } from "./translations";
@@ -225,12 +230,6 @@ const describeCase = (
 	};
 };
 
-const renderImageDialog = (): string => `
-<dialog id="image-dialog">
-	<button id="dialog-close">&times;</button>
-	<div class="image-stage dialog-stage"><img alt=""></div>
-</dialog>`;
-
 const renderReportSidebar = (results: QualityResults): string => {
 	const repositoryUrl = escapeHtml(results.metadata.repositoryUrl);
 	const commitUrl = (commit: string): string =>
@@ -400,25 +399,7 @@ export const renderHtml = (results: QualityResults): string => {
 				...result.warnings,
 				...result.degradationPatterns,
 			].join(" ");
-			const renderImages = (
-				images: Array<[string, string, string | null]>,
-			): string =>
-				images
-					.filter(
-						(image): image is [string, string, string] => image[2] !== null,
-					)
-					.map(
-						([key, label, source]) =>
-							`<figure><figcaption data-i18n="${key}">${label}</figcaption>` +
-							`<div class="image-stage"><img src="${escapeHtml(source)}" alt="${label}" ` +
-							`data-i18n-alt="${key}" loading="lazy"></div></figure>`,
-					)
-					.join("");
-			const primaryImages = renderImages([
-				["groundTruth", "Target", result.files.groundTruth],
-				["result", "Result", result.files.result],
-				["groundTruthDifference", "Target difference", result.files.diff],
-			]);
+			const primaryImages = renderPrimaryImages(result);
 			return `<article class="case target-${targetState}"
 			data-quality="${targetState}" data-change="${result.changeStatus}"
 			data-parameter="${result.parameterMode}"
@@ -463,29 +444,7 @@ ${renderImageDialog()}
 export const renderCaseDetailHtml = (result: QualityCaseResult): string => {
 	const description = describeCase(result);
 	const targetStateKey = TARGET_STATE_KEYS[result.targetStatus];
-	const renderImages = (
-		images: Array<[string, string, string | null]>,
-	): string =>
-		images
-			.filter((image): image is [string, string, string] => image[2] !== null)
-			.map(([key, label, source]) => {
-				const fileName = escapeHtml(path.posix.basename(source));
-				return (
-					`<figure><figcaption data-i18n="${key}">${label}</figcaption>` +
-					`<div class="image-stage"><img src="${fileName}" alt="${label}" ` +
-					`data-i18n-alt="${key}" loading="lazy"></div></figure>`
-				);
-			})
-			.join("");
-	const allImages = renderImages([
-		["input", "Input", result.files.input],
-		["groundTruth", "Ground truth", result.files.groundTruth],
-		["baseline", "Baseline", result.files.baseline],
-		["result", "Result", result.files.result],
-		["groundTruthDifference", "Ground-truth difference", result.files.diff],
-		["baselineDifference", "Baseline difference", result.files.baselineDiff],
-		["backgroundMask", "Background mask", result.files.backgroundMask],
-	]);
+	const allImages = renderAllImages(result);
 	const metricState = (
 		key: string,
 		hasBaseline: boolean,

--- a/test/quality/report/styles.test.ts
+++ b/test/quality/report/styles.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { IMAGE_SIZE_CLASS, IMAGE_SIZE_MISMATCH_CLASS } from "./images";
 import { DETAIL_REPORT_STYLES, INDEX_REPORT_STYLES } from "./styles";
 
 describe("quality report image styles", () => {
@@ -6,6 +7,17 @@ describe("quality report image styles", () => {
 		for (const styles of [INDEX_REPORT_STYLES, DETAIL_REPORT_STYLES]) {
 			expect(styles).toMatch(
 				/\.image-stage img \{[^}]*max-width: 100%;[^}]*max-height: 100%;/,
+			);
+		}
+	});
+
+	// [Intended] 実寸とその警告色は一覧と詳細へ同じ規則を複製している。マークアップは
+	// class を出し続けるので、片方の規則だけ欠けても HTML の目視では気付けない。
+	it("styles the image size and its mismatch highlight in both views", () => {
+		for (const styles of [INDEX_REPORT_STYLES, DETAIL_REPORT_STYLES]) {
+			expect(styles).toContain(`.${IMAGE_SIZE_CLASS} {`);
+			expect(styles).toContain(
+				`.${IMAGE_SIZE_CLASS}.${IMAGE_SIZE_MISMATCH_CLASS} {`,
 			);
 		}
 	});

--- a/test/quality/report/styles.ts
+++ b/test/quality/report/styles.ts
@@ -79,6 +79,8 @@ a { color: #b9a7ff; }
 .badge.has-candidate-selection { background: #1f5f6b; }
 .images { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
 .images figure { margin: 0; }
+.image-size { color: #d6cce4; font-weight: 400; }
+.image-size.size-mismatch { color: #ff8f8f; font-weight: 700; }
 .image-stage { display: flex; align-items: center; justify-content: center; width: 100%; height: 220px; }
 .image-stage img {
 	display: block;
@@ -137,6 +139,8 @@ a { color: #b9a7ff; }
 .badge.parameter-explicit { background: #3d3550; }
 .images { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
 .images figure { margin: 0; }
+.image-size { color: #d6cce4; font-weight: 400; }
+.image-size.size-mismatch { color: #ff8f8f; font-weight: 700; }
 .image-stage { display: flex; align-items: center; justify-content: center; width: 100%; height: 280px; }
 .image-stage img {
 	display: block;

--- a/test/quality/report/target-section.ts
+++ b/test/quality/report/target-section.ts
@@ -3,7 +3,7 @@ import type {
 	QualityTargetMetrics,
 	QualityTargetStatus,
 } from "../types";
-import { escapeHtml, formatMetric } from "./format";
+import { escapeHtml, formatImageSize, formatMetric } from "./format";
 
 export const TARGET_STATE_KEYS: Record<QualityTargetStatus, string> = {
 	met: "targetMet",
@@ -25,7 +25,10 @@ const targetRows = (target: QualityTargetMetrics): string =>
 		metricRow(
 			"outputSize",
 			"Output size",
-			`${String(target.targetWidth)}x${String(target.targetHeight)}`,
+			formatImageSize({
+				width: target.targetWidth,
+				height: target.targetHeight,
+			}),
 		),
 		metricRow("sizeMatches", "Size matches", booleanValue(target.sizeMatches)),
 		metricRow("exactMatch", "Exact match", booleanValue(target.exactMatch)),

--- a/test/quality/types.ts
+++ b/test/quality/types.ts
@@ -10,7 +10,7 @@ import type {
 	ProcessingMode,
 } from "../../src/shared/types";
 
-export const QUALITY_REPORT_VERSION = "5";
+export const QUALITY_REPORT_VERSION = "6";
 export const QUALITY_BENCHMARK_VERSION = "2";
 export const QUALITY_BASELINE_VERSION = 3;
 
@@ -169,6 +169,24 @@ export type QualityBaseline = {
 	cases: QualityBaselineCase[];
 };
 
+/** レポートへ書き出した画像 1 枚の実寸。 */
+export type QualityImageSize = {
+	width: number;
+	height: number;
+};
+
+export type QualityCaseFiles = {
+	/** 目標画像。登録のない auto ケースでは存在しない。 */
+	groundTruth: string | null;
+	input: string;
+	baseline: string | null;
+	result: string;
+	/** 目標との差分。目標がないケースでは存在しない。 */
+	diff: string | null;
+	baselineDiff: string | null;
+	backgroundMask: string;
+};
+
 export type QualityCaseResult = {
 	id: string;
 	featureIds: string[];
@@ -229,17 +247,12 @@ export type QualityCaseResult = {
 	 * explicit ケースはケース定義の正解画像そのものが目標なので null。
 	 */
 	targetSource: string | null;
-	files: {
-		/** 目標画像。登録のない auto ケースでは存在しない。 */
-		groundTruth: string | null;
-		input: string;
-		baseline: string | null;
-		result: string;
-		/** 目標との差分。目標がないケースでは存在しない。 */
-		diff: string | null;
-		baselineDiff: string | null;
-		backgroundMask: string;
-	};
+	files: QualityCaseFiles;
+	/**
+	 * レポートへ書き出した各画像の実寸。存在しない画像は null。
+	 * [Intended] files と同じキーで持ち、画像とサイズの対応をキー名だけで辿れるようにする。
+	 */
+	imageSizes: { [Key in keyof QualityCaseFiles]: QualityImageSize | null };
 };
 
 export type QualityResults = {

--- a/test/quality/types.ts
+++ b/test/quality/types.ts
@@ -251,8 +251,14 @@ export type QualityCaseResult = {
 	/**
 	 * レポートへ書き出した各画像の実寸。存在しない画像は null。
 	 * [Intended] files と同じキーで持ち、画像とサイズの対応をキー名だけで辿れるようにする。
+	 * null 許容も files に合わせる。常に書き出す画像の寸法を入れ忘れたときに、
+	 * 型検査を通り抜けてレポートから寸法が黙って消えることを防ぐ。
 	 */
-	imageSizes: { [Key in keyof QualityCaseFiles]: QualityImageSize | null };
+	imageSizes: {
+		[Key in keyof QualityCaseFiles]: null extends QualityCaseFiles[Key]
+			? QualityImageSize | null
+			: QualityImageSize;
+	};
 };
 
 export type QualityResults = {


### PR DESCRIPTION
## 概要

品質レポートで、各画像の実寸と目標との寸法の食い違いをひと目で確認できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 品質レポートの一覧と詳細で、各画像の見出し横に実寸が並び、画像を開かずに寸法を読めるようになる。
- 今回生成が目標と違う寸法のケースでは、その寸法だけが警告色になるため、寸法の取り違えを一覧のまま見つけられる。

### その他

- 各画像の実寸を results.json へ持たせたので、レポート形式のバージョンを 6 へ上げている。

## 動作確認

- [ ] 品質レポートをブラウザで開き、auto-quality-prf400-soft-edged-sprite の今回生成の寸法が赤く表示されること、言語を切り替えても寸法表示が消えないことを確認する。
