### PR TITLE
feat: 画像一覧の判定表示を整理し、バッチオプションに説明を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -402,16 +402,32 @@
                 <!-- JavaScript がここへ追加する -->
               </div>
               <div class="batch-options">
-                <label>
-                  <input id="shared-palette-toggle" type="checkbox" />
-                  <span data-i18n="ui.shared_palette">Shared palette</span>
-                </label>
-                <label>
-                  <input id="include-diagnostics-toggle" type="checkbox" />
-                  <span data-i18n="ui.include_diagnostics"
-                    >Include diagnostics</span
+                <div class="batch-option">
+                  <label>
+                    <input id="shared-palette-toggle" type="checkbox" />
+                    <span data-i18n="ui.shared_palette">Shared palette</span>
+                  </label>
+                  <span
+                    class="help"
+                    data-i18n-attr="data-tooltip:tooltip.help.shared_palette"
+                    data-tooltip="Reduces colors with a single palette shared by every image.&#10;&#10;A common palette is built from all processed images, limited to the color count setting, and reapplied to each image.&#10;Useful when colors must match across character variations or animation frames."
+                    >?</span
                   >
-                </label>
+                </div>
+                <div class="batch-option">
+                  <label>
+                    <input id="include-diagnostics-toggle" type="checkbox" />
+                    <span data-i18n="ui.include_diagnostics"
+                      >Include diagnostics</span
+                    >
+                  </label>
+                  <span
+                    class="help"
+                    data-i18n-attr="data-tooltip:tooltip.help.include_diagnostics"
+                    data-tooltip="Adds diagnostics.json to the ZIP download.&#10;&#10;It records the input and output filenames, detected input type, processing route, confidence, and warning codes for each image.&#10;Useful for narrowing down images that need a second look after a large batch."
+                    >?</span
+                  >
+                </div>
               </div>
             </section>
 

--- a/index.html
+++ b/index.html
@@ -409,6 +409,7 @@
                   </label>
                   <span
                     class="help"
+                    tabindex="0"
                     data-i18n-attr="data-tooltip:tooltip.help.shared_palette"
                     data-tooltip="Reduces colors with a single palette shared by every image.&#10;&#10;A common palette is built from all processed images, limited to the color count setting, and reapplied to each image.&#10;Useful when colors must match across character variations or animation frames."
                     >?</span
@@ -423,6 +424,7 @@
                   </label>
                   <span
                     class="help"
+                    tabindex="0"
                     data-i18n-attr="data-tooltip:tooltip.help.include_diagnostics"
                     data-tooltip="Adds diagnostics.json to the ZIP download.&#10;&#10;It records the input and output filenames, detected input type, processing route, confidence, and warning codes for each image.&#10;Useful for narrowing down images that need a second look after a large batch."
                     >?</span

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -1,5 +1,4 @@
 import { PROCESS_DEFAULTS } from "../shared/config";
-import type { ProcessingAnalysis } from "../shared/types";
 import {
 	extractColorsFromImage,
 	generateGPL,
@@ -27,7 +26,7 @@ import { formatProcessingAnalysis } from "./processing-analysis-display";
 import { createRunProcessing } from "./processing-controller";
 import { setupResultActions } from "./result-actions";
 import { ResultViewer } from "./result-viewer";
-import { ImageSession } from "./session";
+import { type ImageItem, ImageSession } from "./session";
 import { setupSettingsControls } from "./settings-controls";
 
 export const initApp = (): void => {
@@ -43,12 +42,17 @@ export const initApp = (): void => {
 	const modalResultViewer = new ResultViewer(
 		els.resultModal.querySelector(".result-modal-body") as HTMLElement,
 	);
-	const updateProcessingAnalysis = (analysis?: ProcessingAnalysis) => {
-		const text = analysis
-			? formatProcessingAnalysis(analysis, (key, params) =>
-					i18n.t(key as Parameters<typeof i18n.t>[0], params),
-				)
-			: "";
+	// [Intended] 一覧から判定表示を外したぶん、失敗した画像を選んだときは
+	// ホバーできる環境に頼らず結果表示で理由を読めるようにする。
+	const formatAnalysisText = (item: ImageItem | null | undefined): string => {
+		if (item?.status === "error" && item.error) return item.error;
+		if (!item?.analysis) return "";
+		return formatProcessingAnalysis(item.analysis, (key, params) =>
+			i18n.t(key as Parameters<typeof i18n.t>[0], params),
+		);
+	};
+	const updateProcessingAnalysis = (item: ImageItem | null | undefined) => {
+		const text = formatAnalysisText(item);
 		mainResultViewer.updateAnalysis(text);
 		modalResultViewer.updateAnalysis(text);
 	};
@@ -93,7 +97,7 @@ export const initApp = (): void => {
 		},
 		onActiveChange: (item) => {
 			candidateChooser.dismiss();
-			updateProcessingAnalysis(item?.analysis);
+			updateProcessingAnalysis(item);
 			if (item) {
 				// 結果があれば復元し、なければ元画像を使用
 				// const displayImage = item.result || item.original; // 未使用
@@ -250,7 +254,7 @@ export const initApp = (): void => {
 		runProcessing,
 		saveSettings,
 		onLanguageChange: () =>
-			updateProcessingAnalysis(imageSession.getActiveImage()?.analysis),
+			updateProcessingAnalysis(imageSession.getActiveImage()),
 	});
 	els.sharedPaletteToggle.addEventListener(
 		"change",

--- a/src/browser/batch-image-list.test.ts
+++ b/src/browser/batch-image-list.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ProcessingAnalysis } from "../shared/types";
+import { renderBatchImageList } from "./batch-image-list";
+import { i18n } from "./i18n";
+import type { ImageItem } from "./session";
+
+type FakeEvent = { stopPropagation: () => void };
+type FakeListener = (event: FakeEvent) => void;
+
+// [Policy] このリポジトリのテストは DOM 環境を持たないため、
+// 一覧の描画が使う要素の振る舞いだけを自前で用意する。
+class FakeElement {
+	public className = "";
+	public title = "";
+	public src = "";
+	public textContent = "";
+	public readonly dataset: Record<string, string> = {};
+	public readonly attributes: Record<string, string> = {};
+	public readonly children: FakeElement[] = [];
+	private readonly listeners = new Map<string, FakeListener[]>();
+
+	constructor(public readonly tagName: string) {}
+
+	public set innerHTML(_value: string) {
+		this.children.length = 0;
+	}
+
+	public setAttribute(name: string, value: string): void {
+		this.attributes[name] = value;
+	}
+
+	public appendChild(child: FakeElement): FakeElement {
+		this.children.push(child);
+		return child;
+	}
+
+	public addEventListener(type: string, listener: FakeListener): void {
+		const registered = this.listeners.get(type) ?? [];
+		registered.push(listener);
+		this.listeners.set(type, registered);
+	}
+
+	public dispatchClick(): { propagationStopped: boolean } {
+		let propagationStopped = false;
+		const event: FakeEvent = {
+			stopPropagation: () => {
+				propagationStopped = true;
+			},
+		};
+		const registered = this.listeners.get("click") ?? [];
+		for (let index = 0; index < registered.length; index += 1) {
+			registered[index](event);
+		}
+		return { propagationStopped };
+	}
+}
+
+const originalDocument = Object.getOwnPropertyDescriptor(
+	globalThis,
+	"document",
+);
+
+beforeAll(() => {
+	Object.defineProperty(globalThis, "document", {
+		configurable: true,
+		writable: true,
+		value: { createElement: (tag: string) => new FakeElement(tag) },
+	});
+});
+
+afterAll(() => {
+	if (originalDocument) {
+		Object.defineProperty(globalThis, "document", originalDocument);
+		return;
+	}
+	Reflect.deleteProperty(globalThis, "document");
+});
+
+const analysis: ProcessingAnalysis = {
+	classification: "scaled-pixel",
+	classificationConfidence: 0.77,
+	route: "refine",
+	confidence: 0.77,
+	warnings: ["LOW_GRID_CONFIDENCE"],
+	gridCandidates: [],
+};
+
+const createImage = (overrides: Partial<ImageItem> = {}): ImageItem => ({
+	id: "image-1",
+	file: new File([], "sample.png"),
+	original: { width: 1, height: 1, data: new Uint8ClampedArray(4) },
+	thumbnail: "data:image/png;base64,",
+	status: "done",
+	...overrides,
+});
+
+const render = (images: readonly ImageItem[], activeId?: string) => {
+	const container = new FakeElement("div");
+	const selected: string[] = [];
+	const removed: string[] = [];
+	renderBatchImageList({
+		container: container as unknown as HTMLElement,
+		images,
+		activeId,
+		onSelect: (id) => selected.push(id),
+		onRemove: (id) => removed.push(id),
+	});
+	return { container, selected, removed };
+};
+
+describe("renderBatchImageList", () => {
+	it("判定方式と信頼度のラベルを描画しない", () => {
+		const { container } = render([createImage({ analysis })]);
+
+		const item = container.children[0];
+		const classNames = item.children.map((child) => child.className);
+		expect(classNames).not.toContain("image-item-diagnostic");
+		expect(item.children.some((child) => child.textContent.includes("%"))).toBe(
+			false,
+		);
+		expect(item.title).toBe(`sample.png\n${i18n.t("batch.status.done")}`);
+		expect(item.attributes["aria-label"]).toBe(item.title);
+	});
+
+	it("要確認の画像でも枠の装飾用クラスを付けない", () => {
+		const { container } = render([createImage({ analysis })], "image-1");
+
+		expect(container.children[0].className).toBe("image-item active");
+		expect(container.children[0].dataset.status).toBe("done");
+	});
+
+	it("失敗した画像の理由を title と aria-label に残す", () => {
+		const { container } = render([
+			createImage({ status: "error", error: "decode failed" }),
+		]);
+
+		const item = container.children[0];
+		expect(item.title).toBe(
+			`sample.png\n${i18n.t("batch.status.error")}\ndecode failed`,
+		);
+		expect(item.attributes["aria-label"]).toBe(item.title);
+	});
+
+	it("選択と削除のコールバックを呼び、削除では選択へ伝播させない", () => {
+		const { container, selected, removed } = render([createImage()]);
+
+		const item = container.children[0];
+		const removeButton = item.children[item.children.length - 1];
+		const result = removeButton.dispatchClick();
+		expect(removed).toEqual(["image-1"]);
+		expect(result.propagationStopped).toBe(true);
+
+		item.dispatchClick();
+		expect(selected).toEqual(["image-1"]);
+	});
+});

--- a/src/browser/batch-image-list.ts
+++ b/src/browser/batch-image-list.ts
@@ -20,31 +20,21 @@ export const renderBatchImageList = ({
 	for (let index = 0; index < images.length; index += 1) {
 		const image = images[index];
 		const item = document.createElement("div");
-		item.className = [
-			"image-item",
-			image.id === activeId ? "active" : "",
-			image.attention ? "attention" : "",
-		]
+		item.className = ["image-item", image.id === activeId ? "active" : ""]
 			.filter(Boolean)
 			.join(" ");
 		item.dataset.status = image.status;
-		const confidence =
-			image.analysis?.classificationConfidence ?? image.analysis?.confidence;
-		const diagnostic = image.analysis
-			? `${i18n.t(`batch.route.${image.analysis.route}`)} ${Math.round((confidence ?? 0) * 100)}%`
-			: i18n.t(`batch.status.${image.status}`);
+		// [Intended] 一覧では判定方式と信頼度を見せない。数値は達成率と誤読されやすく、
+		// 判定の詳細は画像を選択したときの結果表示と診断サマリーが受け持つ。
+		const statusLabel = i18n.t(`batch.status.${image.status}`);
 		item.title = image.error
-			? `${image.file.name}\n${diagnostic}\n${image.error}`
-			: `${image.file.name}\n${diagnostic}`;
+			? `${image.file.name}\n${statusLabel}\n${image.error}`
+			: `${image.file.name}\n${statusLabel}`;
 		item.setAttribute("aria-label", item.title);
 
 		const thumbnail = document.createElement("img");
 		thumbnail.src = image.thumbnail;
 		item.appendChild(thumbnail);
-		const diagnosticLabel = document.createElement("div");
-		diagnosticLabel.className = "image-item-diagnostic";
-		diagnosticLabel.textContent = diagnostic;
-		item.appendChild(diagnosticLabel);
 		const status = document.createElement("div");
 		status.className = "status-indicator";
 		item.appendChild(status);

--- a/src/browser/i18n.test.ts
+++ b/src/browser/i18n.test.ts
@@ -87,7 +87,13 @@ describe("I18nManager", () => {
 			expect(i18n.t("ui.include_diagnostics")).not.toBe(
 				"ui.include_diagnostics",
 			);
-			expect(i18n.t("batch.route.convert")).not.toBe("batch.route.convert");
+			expect(i18n.t("batch.status.done")).not.toBe("batch.status.done");
+			expect(i18n.t("tooltip.help.shared_palette")).not.toBe(
+				"tooltip.help.shared_palette",
+			);
+			expect(i18n.t("tooltip.help.include_diagnostics")).not.toBe(
+				"tooltip.help.include_diagnostics",
+			);
 			expect(
 				i18n.t("warning.batch_partial_failure", { failed: 1, total: 3 }),
 			).toContain("1");

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -68,9 +68,6 @@ const resources = {
 		"candidate.description.preserve":
 			"縮小せず、安全に元の解像度を維持します。",
 		"candidate.description.convert": "通常画像としてドット絵風に変換します。",
-		"batch.route.refine": "復元",
-		"batch.route.convert": "変換",
-		"batch.route.preserve": "原寸維持",
 		"batch.status.pending": "未処理",
 		"batch.status.processing": "処理中",
 		"batch.status.done": "完了",
@@ -187,6 +184,10 @@ const resources = {
 			"指定ピクセル（縦）です。\n\nピクセル指定 + 自動検出: この値をヒントに精密探索を開始します。\n完全ピクセル指定: この値に強制変換します。\n\n設定範囲: 1〜1024 (デフォルト: 自動)",
 		"tooltip.help.fast_mode":
 			"ONにすると、効率的なアルゴリズムで探索を高速化します。\nOFFにすると、より広範囲を精密に探索します。\n\n自動検出の結果がズレる場合や、ノイズ・細かい模様が多い画像では、OFFにすると精度が向上します。",
+		"tooltip.help.shared_palette":
+			"すべての画像を同じパレットで減色します。\n\n処理後の全画像から共通のパレットを作り、色数の設定を上限としてまとめてから、各画像へ適用し直します。\nキャラクターの差分やアニメーションのコマなど、画像どうしで色味を揃えたい場合に使います。",
+		"tooltip.help.include_diagnostics":
+			"一括ダウンロード (ZIP) に diagnostics.json を追加します。\n\n画像ごとの入出力ファイル名、判定した入力の種類、処理方式、信頼度、警告コードを記録した JSON です。\n大量の画像を処理したあとで、確認が必要な画像を絞り込むときに使います。",
 		"tooltip.help.bg_method":
 			"背景色をどこから抽出するか選択します。\n\n自動: 外周全体から背景を推定します。\n透過しない: 背景透過を行いません。\n各四隅: 指定した角のピクセルを背景色とします。\nRGB指定: 指定した色を背景色とします。",
 		"tooltip.help.bg_rgb":
@@ -357,9 +358,6 @@ const resources = {
 		"candidate.description.coarser": "将图像整理为更大像素块的方案。",
 		"candidate.description.preserve": "不缩小图像，安全保留原始分辨率。",
 		"candidate.description.convert": "按普通图像转换为像素画风格。",
-		"batch.route.refine": "还原",
-		"batch.route.convert": "转换",
-		"batch.route.preserve": "保持原尺寸",
 		"batch.status.pending": "待处理",
 		"batch.status.processing": "处理中",
 		"batch.status.done": "完成",
@@ -475,6 +473,10 @@ const resources = {
 			"指定像素高度。\n\n像素指定 + 自动检测：用该值作为提示并在附近精细搜索。\n完全像素指定：强制转换为该高度。\n\n范围：1 到 1024 (默认：自动)",
 		"tooltip.help.fast_mode":
 			"开启后使用更高效的算法加快搜索。\n关闭后会进行更大范围、更精细的搜索。\n\n如果自动检测结果错位，或图片包含大量噪点和细碎纹理，关闭后可能提高准确度。",
+		"tooltip.help.shared_palette":
+			"使用同一个调色板对所有图片减色。\n\n处理完成后会从全部图片生成共用调色板，以色数设置为上限归纳后，再重新应用到每张图片。\n适合角色差分或动画帧等需要统一色调的场景。",
+		"tooltip.help.include_diagnostics":
+			"在全部下载 (ZIP) 中追加 diagnostics.json。\n\n该 JSON 记录每张图片的输入输出文件名、判定的输入类型、处理方式、置信度和警告代码。\n便于在批量处理后筛选需要确认的图片。",
 		"tooltip.help.bg_method":
 			"选择从哪里提取背景色。\n\n自动：从整个图像边缘估算背景。\n无：不移除背景。\n四角：使用指定角落的像素作为背景色。\nRGB：使用指定颜色作为背景色。",
 		"tooltip.help.bg_rgb":
@@ -645,9 +647,6 @@ const resources = {
 			"Avoids downscaling and safely keeps the original resolution.",
 		"candidate.description.convert":
 			"Treats the input as a regular image and converts it to pixel art.",
-		"batch.route.refine": "Refine",
-		"batch.route.convert": "Convert",
-		"batch.route.preserve": "Preserve",
 		"batch.status.pending": "Pending",
 		"batch.status.processing": "Processing",
 		"batch.status.done": "Done",
@@ -764,6 +763,10 @@ const resources = {
 			"Specified pixel height.\n\nPixel + Auto: Uses this as a hint and starts fine search near it.\nPixel Only: Forces conversion to this size.\n\nRange: 1 to 1024 (Default: Auto)",
 		"tooltip.help.fast_mode":
 			"When ON, uses an efficient algorithm to speed up the search.\nWhen OFF, performs a more comprehensive and precise search.\n\nIf automatic detection results are misaligned or the image has a lot of noise/fine patterns, turning this OFF may improve accuracy.",
+		"tooltip.help.shared_palette":
+			"Reduces colors with a single palette shared by every image.\n\nA common palette is built from all processed images, limited to the color count setting, and reapplied to each image.\nUseful when colors must match across character variations or animation frames.",
+		"tooltip.help.include_diagnostics":
+			"Adds diagnostics.json to the ZIP download.\n\nIt records the input and output filenames, detected input type, processing route, confidence, and warning codes for each image.\nUseful for narrowing down images that need a second look after a large batch.",
 		"tooltip.help.bg_method":
 			"Select where to extract the background color from.\n\nAuto: Estimates the background from the full image border.\nNone: No background removal.\nCorners: Uses the pixel at the specified corner as the background color.\nRGB: Uses the specified color as the background color.",
 		"tooltip.help.bg_rgb":

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -1,4 +1,3 @@
-import { needsBatchAttention } from "../core/batch";
 import type {
 	CandidateSelection,
 	PixelGrid,
@@ -18,7 +17,6 @@ export interface ImageItem {
 	status: "pending" | "processing" | "done" | "error";
 	error?: string;
 	analysis?: ProcessingAnalysis;
-	attention?: boolean;
 	outputFilename?: string;
 	/**
 	 * 候補プレビューで選んだ処理方針。設定変更で再処理しても自動判定へ戻らないよう保持する。
@@ -114,7 +112,6 @@ export class ImageSession {
 			img.result = processed.result;
 			img.grid = processed.grid;
 			img.analysis = processed.analysis;
-			img.attention = needsBatchAttention(processed.analysis);
 			img.status = "done";
 			img.error = undefined;
 			this.onUpdate();
@@ -156,7 +153,6 @@ export class ImageSession {
 			img.error = error;
 			if (status === "processing") {
 				img.analysis = undefined;
-				img.attention = false;
 				img.outputFilename = undefined;
 			}
 			this.onUpdate();

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -1757,6 +1757,12 @@ select:focus {
   font-size: 0.8rem;
 }
 
+.batch-option {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
 .batch-options label {
   display: inline-flex;
   gap: 0.4rem;
@@ -1808,7 +1814,7 @@ select:focus {
   position: relative;
   flex: 0 0 80px;
   width: 80px;
-  height: 112px;
+  height: 84px;
   border-radius: 6px;
   border: 2px solid transparent;
   background-color: #0f1115;
@@ -1829,32 +1835,12 @@ select:focus {
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.5);
 }
 
-.image-item.attention:not(.active) {
-  border-color: #f5b942;
-}
-
-.image-item.attention .image-item-diagnostic {
-  color: #ffd36a;
-}
-
 .image-item img {
   width: 100%;
   height: 80px;
   object-fit: contain;
   image-rendering: pixelated;
   pointer-events: none;
-}
-
-.image-item-diagnostic {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 28px;
-  padding: 0 0.2rem;
-  color: #c6cad1;
-  font-size: 0.65rem;
-  line-height: 1.1;
-  text-align: center;
 }
 
 .image-item .remove-btn {
@@ -1888,7 +1874,7 @@ select:focus {
 
 .image-item .status-indicator {
   position: absolute;
-  bottom: 32px;
+  bottom: 4px;
   right: 4px;
   width: 10px;
   height: 10px;

--- a/src/browser/tooltip.ts
+++ b/src/browser/tooltip.ts
@@ -91,6 +91,20 @@ export const initTooltip = () => {
 		}
 	});
 
+	// [Intended] マウスを使えない環境でも説明へ到達できるよう、
+	// フォーカスの出入りでも同じツールチップを開閉する。
+	document.addEventListener("focusin", (e) => {
+		const target = (e.target as HTMLElement).closest("[data-tooltip]");
+		if (!target) return;
+		const text = target.getAttribute("data-tooltip");
+		if (text) showTooltip(target as HTMLElement, text);
+	});
+
+	document.addEventListener("focusout", (e) => {
+		const target = (e.target as HTMLElement).closest("[data-tooltip]");
+		if (target && target === activeElement) hideTooltip();
+	});
+
 	// 必要に応じてスクロール時に位置を更新する（任意だが固定要素には有用）
 	window.addEventListener("scroll", updatePosition, true);
 	window.addEventListener("resize", updatePosition);


### PR DESCRIPTION
## 概要

複数画像を投入したときの画像一覧を、判定結果の数値ではなく画像そのものを見る場にする。

## 変更内容

### UI/UX

- 画像一覧のサムネイル下に出ていた「復元 77%」のような判定方式と信頼度の表記をやめ、サムネイルと処理状況だけを表示する。
これまでの数値は入力分類の適合度であり、復元の達成率と誤読されやすかった。
- 判定が不確かな画像に付いていた黄色の枠と文字色をやめ、一覧の表示を処理状況の色だけに揃える。
- 一覧下の「共通パレット」「診断サマリーを含める」に「？」を追加し、マウスオーバーで何をする設定かを説明する。「？」はキーボードでもフォーカスでき、フォーカス中も同じ説明を表示する。
- 処理に失敗した画像を選んだときは、その理由を結果表示にも出す。サムネイルのホバーに頼らずに原因を追えるようにする。

### ロジック

- 一覧の枠色をやめて読み手がいなくなった、画像単位の要確認フラグを削除する。診断サマリーは書き出し時に独立して判定しているため、出力は変わらない。

### 開発体験

- 一覧の描画に、判定ラベルを出さないことと、処理状況・エラー表示・選択と削除の挙動を固定するテストを追加する。

### その他

- 判定方式と信頼度は画像を選択したときの結果表示から、警告コードは診断サマリーの `diagnostics.json` から引き続き確認できる。

## 動作確認

- なし
