### PR TITLE
feat: Auto の全設定を詳細設定から変更できるようにする

### DIFF
--- a/index.html
+++ b/index.html
@@ -983,17 +983,36 @@
 
                       <label class="setting-item">
                         <span class="label-text">
-                          <span data-i18n="setting.preserve_partial_alpha"
-                            >Preserve Semi-transparent Edges</span
+                          <span data-i18n="setting.cell_sampling_mode"
+                            >Cell Color Sampling</span
                           >
                           <span
                             class="help"
-                            data-i18n-attr="data-tooltip:tooltip.help.preserve_partial_alpha"
-                            data-tooltip="When ON, preserves area-coverage alpha with alpha-aware medoid sampling. This is useful for intentionally soft or semi-transparent edges.&#10;When OFF, favors hard alpha edges and avoids retaining partial transparency introduced by interpolation."
+                            data-i18n-attr="data-tooltip:tooltip.help.cell_sampling_mode"
+                            data-tooltip="How the representative colour of each logical pixel is chosen.&#10;&#10;Hard Alpha: Avoids keeping partial transparency introduced by interpolation.&#10;Alpha Aware: Preserves area-coverage alpha for intentionally soft edges.&#10;Compatible: The legacy median sampler, used automatically after watermark removal."
                             >?</span
                           >
                         </span>
-                        <input id="alpha-aware-medoid" type="checkbox" />
+                        <select id="cell-sampling-mode">
+                          <option
+                            value="hard-alpha-medoid"
+                            data-i18n="option.cell_sampling_hard"
+                          >
+                            Hard Alpha (Default)
+                          </option>
+                          <option
+                            value="alpha-aware-medoid"
+                            data-i18n="option.cell_sampling_alpha_aware"
+                          >
+                            Alpha Aware
+                          </option>
+                          <option
+                            value="legacy-median"
+                            data-i18n="option.cell_sampling_legacy"
+                          >
+                            Compatible (Median)
+                          </option>
+                        </select>
                       </label>
 
                       <label class="setting-item">
@@ -1050,6 +1069,280 @@
                           id="fast-auto-grid-from-trimmed"
                           type="checkbox"
                         />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.preserve_thin_features"
+                            >Preserve Thin Features</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.preserve_thin_features"
+                            data-tooltip="Protects minority colours that cross a cell so that thin lines and outlines survive downsampling."
+                            >?</span
+                          >
+                        </span>
+                        <input id="preserve-thin-features" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.auto_grid_from_trimmed"
+                            >Estimate Grid From Content</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.auto_grid_from_trimmed"
+                            data-tooltip="Estimates the output grid from the trimmed content area.&#10;When OFF, the fallback detector scans the whole canvas instead."
+                            >?</span
+                          >
+                        </span>
+                        <input id="auto-grid-from-trimmed" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.phase_aware_grid_search"
+                            >Phase-aware Grid Search</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.phase_aware_grid_search"
+                            data-tooltip="Also runs a phase-aware search and prefers it when both axes are confident enough."
+                            >?</span
+                          >
+                        </span>
+                        <input id="phase-aware-grid-search" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.boundary_contrast_override"
+                            >Boundary Contrast Override</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.boundary_contrast_override"
+                            data-tooltip="Switches the chosen grid to a coarser harmonic when its cell boundaries align clearly better with real edges."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="boundary-contrast-override"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.small_aspect_grid_alignment"
+                            >Small Grid Alignment</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.small_aspect_grid_alignment"
+                            data-tooltip="For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.&#10;&#10;This used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine."
+                            >?</span
+                          >
+                        </span>
+                        <select id="small-aspect-grid-alignment">
+                          <option
+                            value="auto"
+                            data-i18n="option.auto_behavior_auto"
+                          >
+                            Auto (Follow Processing Mode)
+                          </option>
+                          <option
+                            value="on"
+                            data-i18n="option.auto_behavior_on"
+                          >
+                            Always On
+                          </option>
+                          <option
+                            value="off"
+                            data-i18n="option.auto_behavior_off"
+                          >
+                            Always Off
+                          </option>
+                        </select>
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.max_samples_per_cell"
+                            >Max Samples per Cell</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.max_samples_per_cell"
+                            data-tooltip="Upper bound on the pixels sampled from one cell when picking its colour.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="max-samples-per-cell" type="number" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.cell_alpha_threshold"
+                            >Cell Alpha Threshold</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.cell_alpha_threshold"
+                            data-tooltip="Minimum alpha for a pixel to be considered a colour candidate inside a cell.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="cell-alpha-threshold" type="number" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.auto_max_cells_w"
+                            >Max Cells (Width)</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.auto_max_cells_w"
+                            data-tooltip="Upper bound on the detected cell count for the fallback detector.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="auto-max-cells-w" type="number" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.auto_max_cells_h"
+                            >Max Cells (Height)</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.auto_max_cells_h"
+                            data-tooltip="Upper bound on the detected cell count for the fallback detector.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="auto-max-cells-h" type="number" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.detection_background_mask"
+                            >Mask Background For Detection</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.detection_background_mask"
+                            data-tooltip="Guesses the background colour and masks it before grid detection so that background noise does not bias the result."
+                            >?</span
+                          >
+                        </span>
+                        <input id="detection-background-mask" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_mask_tolerance"
+                            >Detection Mask Tolerance</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_mask_tolerance"
+                            data-tooltip="Per-channel tolerance used by the detection background mask.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="background-mask-tolerance" type="number" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.grid_signal_color_boundary"
+                            >Signal: Colour Boundary</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.grid_signal_color_boundary"
+                            data-tooltip="Includes the colour-boundary signal when scoring grid candidates."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="grid-signal-color-boundary"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.grid_signal_luminance_alpha"
+                            >Signal: Luminance / Alpha</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.grid_signal_luminance_alpha"
+                            data-tooltip="Includes the luminance and alpha gradient signals when scoring grid candidates."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="grid-signal-luminance-alpha"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.grid_signal_autocorrelation"
+                            >Signal: Autocorrelation</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.grid_signal_autocorrelation"
+                            data-tooltip="Includes the autocorrelation signal when scoring grid candidates."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="grid-signal-autocorrelation"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.grid_signal_reconstruction"
+                            >Signal: Reconstruction</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.grid_signal_reconstruction"
+                            data-tooltip="Includes the reconstruction-error signal when scoring grid candidates."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="grid-signal-reconstruction"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.grid_signal_local_phase"
+                            >Signal: Local Phase</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.grid_signal_local_phase"
+                            data-tooltip="Includes the local phase stability signal when scoring grid candidates."
+                            >?</span
+                          >
+                        </span>
+                        <input id="grid-signal-local-phase" type="checkbox" />
                       </label>
                     </div>
                   </div>
@@ -1319,6 +1612,159 @@
                           </option>
                         </select>
                       </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_dehalo"
+                            >Reduce Edge Halo</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_dehalo"
+                            data-tooltip="Pushes anti-aliased edge pixels away from the background colour after removal."
+                            >?</span
+                          >
+                        </span>
+                        <input id="background-dehalo" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_edge_cleanup"
+                            >Clean Contaminated Edges</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_edge_cleanup"
+                            data-tooltip="Replaces edge pixels that still carry the background colour after downscaling with their original colour."
+                            >?</span
+                          >
+                        </span>
+                        <input id="background-edge-cleanup" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_ramp_follow"
+                            >Follow Gradient Background</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_ramp_follow"
+                            data-tooltip="Follows a smooth gradient background as a chain of small steps instead of an absolute colour difference."
+                            >?</span
+                          >
+                        </span>
+                        <input id="background-ramp-follow" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_removal_rollback"
+                            >Roll Back Over-removal</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_removal_rollback"
+                            data-tooltip="Discards the whole background removal when it would erase almost all of the visible pixels."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="background-removal-rollback"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span
+                            data-i18n="setting.alpha_border_background_guard"
+                            >Trust Existing Transparency</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.alpha_border_background_guard"
+                            data-tooltip="Skips colour-cluster estimation when most of the border band is already transparent."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="alpha-border-background-guard"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.background_confidence_gate"
+                            >Require Confident Background</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.background_confidence_gate"
+                            data-tooltip="Skips background removal when the estimated background model is not confident enough."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="background-confidence-gate"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span
+                            data-i18n="setting.small_component_background_gate"
+                            >Gate Cleanup On Background</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.small_component_background_gate"
+                            data-tooltip="Skips small-detail cleanup when the estimated background model is not confident enough."
+                            >?</span
+                          >
+                        </span>
+                        <input
+                          id="small-component-background-gate"
+                          type="checkbox"
+                        />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.watermark_sampling_compat"
+                            >Watermark Sampling Fallback</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.watermark_sampling_compat"
+                            data-tooltip="Switches to the compatible median sampler once a watermark has been removed, which prevents the last row from being dropped.&#10;&#10;This used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine."
+                            >?</span
+                          >
+                        </span>
+                        <select id="watermark-sampling-compat">
+                          <option
+                            value="auto"
+                            data-i18n="option.auto_behavior_auto"
+                          >
+                            Auto (Follow Processing Mode)
+                          </option>
+                          <option
+                            value="on"
+                            data-i18n="option.auto_behavior_on"
+                          >
+                            Always On
+                          </option>
+                          <option
+                            value="off"
+                            data-i18n="option.auto_behavior_off"
+                          >
+                            Always Off
+                          </option>
+                        </select>
+                      </label>
                     </div>
                   </div>
 
@@ -1341,6 +1787,21 @@
                           >
                         </span>
                         <input id="trim-to-content" type="checkbox" />
+                      </label>
+
+                      <label class="setting-item">
+                        <span class="label-text">
+                          <span data-i18n="setting.trim_alpha_threshold"
+                            >Trim Alpha Threshold</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.trim_alpha_threshold"
+                            data-tooltip="Minimum alpha for a pixel to count as content when computing the trimming bounds.&#10;&#10;Range: {min} to {max} (Default: {default})"
+                            >?</span
+                          >
+                        </span>
+                        <input id="trim-alpha-threshold" type="number" />
                       </label>
 
                       <label class="setting-item">

--- a/index.html
+++ b/index.html
@@ -1174,6 +1174,7 @@
                             >Max Samples per Cell</span
                           >
                           <span
+                            id="help-max-samples-per-cell"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.max_samples_per_cell"
                             data-tooltip="Upper bound on the pixels sampled from one cell when picking its colour.&#10;&#10;Range: {min} to {max} (Default: {default})"
@@ -1189,6 +1190,7 @@
                             >Cell Alpha Threshold</span
                           >
                           <span
+                            id="help-cell-alpha-threshold"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.cell_alpha_threshold"
                             data-tooltip="Minimum alpha for a pixel to be considered a colour candidate inside a cell.&#10;&#10;Range: {min} to {max} (Default: {default})"
@@ -1204,6 +1206,7 @@
                             >Max Cells (Width)</span
                           >
                           <span
+                            id="help-auto-max-cells-w"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.auto_max_cells_w"
                             data-tooltip="Upper bound on the detected cell count for the fallback detector.&#10;&#10;Range: {min} to {max} (Default: {default})"
@@ -1219,6 +1222,7 @@
                             >Max Cells (Height)</span
                           >
                           <span
+                            id="help-auto-max-cells-h"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.auto_max_cells_h"
                             data-tooltip="Upper bound on the detected cell count for the fallback detector.&#10;&#10;Range: {min} to {max} (Default: {default})"
@@ -1249,6 +1253,7 @@
                             >Detection Mask Tolerance</span
                           >
                           <span
+                            id="help-background-mask-tolerance"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.background_mask_tolerance"
                             data-tooltip="Per-channel tolerance used by the detection background mask.&#10;&#10;Range: {min} to {max} (Default: {default})"
@@ -1795,6 +1800,7 @@
                             >Trim Alpha Threshold</span
                           >
                           <span
+                            id="help-trim-alpha-threshold"
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.trim_alpha_threshold"
                             data-tooltip="Minimum alpha for a pixel to count as content when computing the trimming bounds.&#10;&#10;Range: {min} to {max} (Default: {default})"

--- a/index.html
+++ b/index.html
@@ -1142,7 +1142,7 @@
                           <span
                             class="help"
                             data-i18n-attr="data-tooltip:tooltip.help.small_aspect_grid_alignment"
-                            data-tooltip="For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.&#10;&#10;This used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine."
+                            data-tooltip="For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.&#10;&#10;This used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.&#10;&#10;With Always Off, the Auto route selection also stops allowing small grids and may fall back to the preserve route."
                             >?</span
                           >
                         </span>

--- a/src/browser/advanced-settings-fields.test.ts
+++ b/src/browser/advanced-settings-fields.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import { migrateAdvancedSettings } from "./advanced-settings-fields";
+
+describe("migrateAdvancedSettings", () => {
+	it("fills newly exposed settings with the previous behaviour", () => {
+		const state: Record<string, string | number | boolean> = {};
+
+		migrateAdvancedSettings(state);
+
+		// [Intended] 既定値は従来の挙動そのままなので、古いプリセットの出力は変わらない。
+		expect(state["cell-sampling-mode"]).toBe(PROCESS_DEFAULTS.cellSamplingMode);
+		expect(state["small-aspect-grid-alignment"]).toBe("auto");
+		expect(state["watermark-sampling-compat"]).toBe("auto");
+		expect(state["background-dehalo"]).toBe(true);
+		expect(state["background-edge-cleanup"]).toBe(true);
+		expect(state["background-confidence-gate"]).toBe(true);
+		expect(state["phase-aware-grid-search"]).toBe(true);
+		expect(state["boundary-contrast-override"]).toBe(true);
+		expect(state["grid-signal-color-boundary"]).toBe(true);
+		expect(state["trim-alpha-threshold"]).toBe(
+			PROCESS_RANGES.trimAlphaThreshold.default,
+		);
+		expect(state["auto-max-cells-w"]).toBe(PROCESS_RANGES.autoMaxCells.default);
+	});
+
+	it("carries the old semi-transparent-edge toggle into the sampling mode", () => {
+		const enabled: Record<string, string | number | boolean> = {
+			"alpha-aware-medoid": true,
+		};
+		const disabled: Record<string, string | number | boolean> = {
+			"alpha-aware-medoid": false,
+		};
+
+		migrateAdvancedSettings(enabled);
+		migrateAdvancedSettings(disabled);
+
+		expect(enabled["cell-sampling-mode"]).toBe("alpha-aware-medoid");
+		expect(disabled["cell-sampling-mode"]).toBe(
+			PROCESS_DEFAULTS.cellSamplingMode,
+		);
+	});
+
+	it("keeps a value that the preset already carries", () => {
+		const state: Record<string, string | number | boolean> = {
+			"cell-sampling-mode": "legacy-median",
+			"background-dehalo": false,
+			"small-aspect-grid-alignment": "on",
+		};
+
+		migrateAdvancedSettings(state);
+
+		expect(state["cell-sampling-mode"]).toBe("legacy-median");
+		expect(state["background-dehalo"]).toBe(false);
+		expect(state["small-aspect-grid-alignment"]).toBe("on");
+	});
+});

--- a/src/browser/advanced-settings-fields.ts
+++ b/src/browser/advanced-settings-fields.ts
@@ -41,6 +41,44 @@ export const advancedSettingControls = (
 	els.trimAlphaThresholdInput,
 ];
 
+/**
+ * 格子検出でしか効かない詳細設定。
+ *
+ * [Intended] 候補選択のクリア対象と、グリッド検出モードに応じた無効表示が
+ * 同じ一覧を見るようにする。片方だけに足すと、設定を変えても候補の固定サイズが
+ * 残る／効かない項目が有効に見える、という壊れ方をする。
+ */
+export const gridDetectionAdvancedControls = (
+	els: Elements,
+): Array<HTMLInputElement | HTMLSelectElement> => [
+	els.autoGridFromTrimmedCheck,
+	els.phaseAwareGridSearchCheck,
+	els.boundaryContrastOverrideCheck,
+	els.detectionBackgroundMaskCheck,
+	els.backgroundMaskToleranceInput,
+	els.gridSignalColorBoundaryCheck,
+	els.gridSignalLuminanceAlphaCheck,
+	els.gridSignalAutocorrelationCheck,
+	els.gridSignalReconstructionCheck,
+	els.gridSignalLocalPhaseCheck,
+	els.autoMaxCellsWInput,
+	els.autoMaxCellsHInput,
+];
+
+/**
+ * 背景抽出が無効なら効かない詳細設定。
+ *
+ * [Intended] createProcessOptions が bgEnabled で強制 false にしている項目に限る。
+ * 巻き戻しや信頼度ゲートは背景抽出が無効でも透かし除去の経路で効くため含めない。
+ */
+export const backgroundDependentAdvancedControls = (
+	els: Elements,
+): Array<HTMLInputElement | HTMLSelectElement> => [
+	els.backgroundDehaloCheck,
+	els.backgroundEdgeCleanupCheck,
+	els.backgroundRampFollowCheck,
+];
+
 /** 詳細設定へ公開した項目に既定値を反映する。 */
 export const applyAdvancedSettingDefaults = (
 	els: Elements,

--- a/src/browser/advanced-settings-fields.ts
+++ b/src/browser/advanced-settings-fields.ts
@@ -1,0 +1,165 @@
+import type { createDefaultProcessOptions } from "../core/processor-options";
+import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import type { Elements } from "./app-elements";
+
+type ProcessDefaults = ReturnType<typeof createDefaultProcessOptions>;
+
+/**
+ * 詳細設定へ公開した「Auto の自動判定」と検出器の調整項目。
+ *
+ * [Intended] 既定値の反映・変更監視・プリセット保存の 3 箇所が同じ一覧を見るようにする。
+ * 項目を足すときにどこか 1 箇所だけ漏れる、という壊れ方を防ぐのが目的。
+ */
+export const advancedSettingControls = (
+	els: Elements,
+): Array<HTMLInputElement | HTMLSelectElement> => [
+	els.cellSamplingModeSelect,
+	els.smallAspectGridAlignmentSelect,
+	els.watermarkSamplingCompatSelect,
+	els.preserveThinFeaturesCheck,
+	els.autoGridFromTrimmedCheck,
+	els.phaseAwareGridSearchCheck,
+	els.boundaryContrastOverrideCheck,
+	els.detectionBackgroundMaskCheck,
+	els.gridSignalColorBoundaryCheck,
+	els.gridSignalLuminanceAlphaCheck,
+	els.gridSignalAutocorrelationCheck,
+	els.gridSignalReconstructionCheck,
+	els.gridSignalLocalPhaseCheck,
+	els.backgroundDehaloCheck,
+	els.backgroundEdgeCleanupCheck,
+	els.backgroundRampFollowCheck,
+	els.backgroundRemovalRollbackCheck,
+	els.alphaBorderBackgroundGuardCheck,
+	els.backgroundConfidenceGateCheck,
+	els.smallComponentBackgroundGateCheck,
+	els.maxSamplesPerCellInput,
+	els.cellAlphaThresholdInput,
+	els.autoMaxCellsWInput,
+	els.autoMaxCellsHInput,
+	els.backgroundMaskToleranceInput,
+	els.trimAlphaThresholdInput,
+];
+
+/** 詳細設定へ公開した項目に既定値を反映する。 */
+export const applyAdvancedSettingDefaults = (
+	els: Elements,
+	defaults: ProcessDefaults,
+): void => {
+	els.cellSamplingModeSelect.value = defaults.cellSamplingMode;
+	els.smallAspectGridAlignmentSelect.value = defaults.smallAspectGridAlignment;
+	els.watermarkSamplingCompatSelect.value = defaults.watermarkSamplingCompat;
+
+	els.preserveThinFeaturesCheck.checked = defaults.preserveThinFeatures;
+	els.autoGridFromTrimmedCheck.checked = defaults.autoGridFromTrimmed;
+	els.phaseAwareGridSearchCheck.checked = defaults.phaseAwareGridSearch;
+	els.boundaryContrastOverrideCheck.checked = defaults.boundaryContrastOverride;
+	els.detectionBackgroundMaskCheck.checked = defaults.backgroundMask;
+
+	els.gridSignalColorBoundaryCheck.checked = defaults.gridSignals.colorBoundary;
+	els.gridSignalLuminanceAlphaCheck.checked =
+		defaults.gridSignals.luminanceAlphaGradient;
+	els.gridSignalAutocorrelationCheck.checked =
+		defaults.gridSignals.autocorrelation;
+	els.gridSignalReconstructionCheck.checked =
+		defaults.gridSignals.reconstruction;
+	els.gridSignalLocalPhaseCheck.checked =
+		defaults.gridSignals.localPhaseStability;
+
+	els.backgroundDehaloCheck.checked = defaults.backgroundDehalo;
+	els.backgroundEdgeCleanupCheck.checked = defaults.backgroundEdgeCleanup;
+	els.backgroundRampFollowCheck.checked = defaults.backgroundRampFollow;
+	els.backgroundRemovalRollbackCheck.checked =
+		defaults.backgroundRemovalRollback;
+	els.alphaBorderBackgroundGuardCheck.checked =
+		defaults.alphaBorderBackgroundGuard;
+	els.backgroundConfidenceGateCheck.checked = defaults.backgroundConfidenceGate;
+	els.smallComponentBackgroundGateCheck.checked =
+		defaults.smallComponentBackgroundGate;
+
+	const applyRange = (
+		input: HTMLInputElement,
+		range: { min: number; max: number },
+	): void => {
+		input.min = String(range.min);
+		input.max = String(range.max);
+	};
+	applyRange(els.maxSamplesPerCellInput, PROCESS_RANGES.maxSamplesPerCell);
+	applyRange(els.cellAlphaThresholdInput, PROCESS_RANGES.cellAlphaThreshold);
+	applyRange(els.autoMaxCellsWInput, PROCESS_RANGES.autoMaxCells);
+	applyRange(els.autoMaxCellsHInput, PROCESS_RANGES.autoMaxCells);
+	applyRange(
+		els.backgroundMaskToleranceInput,
+		PROCESS_RANGES.backgroundMaskTolerance,
+	);
+	applyRange(els.trimAlphaThresholdInput, PROCESS_RANGES.trimAlphaThreshold);
+
+	els.maxSamplesPerCellInput.value = String(defaults.maxSamplesPerCell);
+	els.cellAlphaThresholdInput.value = String(defaults.cellAlphaThreshold);
+	els.autoMaxCellsWInput.value = String(defaults.autoMaxCellsW);
+	els.autoMaxCellsHInput.value = String(defaults.autoMaxCellsH);
+	els.backgroundMaskToleranceInput.value = String(
+		defaults.backgroundMaskTolerance,
+	);
+	els.trimAlphaThresholdInput.value = String(defaults.trimAlphaThreshold);
+};
+
+/**
+ * UI 追加前に保存されたプリセットを、新しい設定項目の既定値で補う。
+ *
+ * [Policy] 既定値はいずれも従来の挙動と同じなので、古いプリセットを読み込んでも
+ * 出力は変わらない。旧 boolean の "alpha-aware-medoid" だけは、同じ意味を保つよう
+ * 3 択のセルサンプリングへ読み替える。
+ */
+export const migrateAdvancedSettings = (
+	state: Record<string, string | number | boolean>,
+): void => {
+	if (state["cell-sampling-mode"] === undefined) {
+		state["cell-sampling-mode"] =
+			state["alpha-aware-medoid"] === true
+				? "alpha-aware-medoid"
+				: PROCESS_DEFAULTS.cellSamplingMode;
+	}
+	state["small-aspect-grid-alignment"] ??=
+		PROCESS_DEFAULTS.smallAspectGridAlignment;
+	state["watermark-sampling-compat"] ??=
+		PROCESS_DEFAULTS.watermarkSamplingCompat;
+
+	state["preserve-thin-features"] ??= PROCESS_DEFAULTS.preserveThinFeatures;
+	state["auto-grid-from-trimmed"] ??= PROCESS_DEFAULTS.autoGridFromTrimmed;
+	state["phase-aware-grid-search"] ??= PROCESS_DEFAULTS.phaseAwareGridSearch;
+	state["boundary-contrast-override"] ??=
+		PROCESS_DEFAULTS.boundaryContrastOverride;
+	state["detection-background-mask"] ??= PROCESS_DEFAULTS.backgroundMask;
+
+	state["grid-signal-color-boundary"] ??=
+		PROCESS_DEFAULTS.gridSignals.colorBoundary;
+	state["grid-signal-luminance-alpha"] ??=
+		PROCESS_DEFAULTS.gridSignals.luminanceAlphaGradient;
+	state["grid-signal-autocorrelation"] ??=
+		PROCESS_DEFAULTS.gridSignals.autocorrelation;
+	state["grid-signal-reconstruction"] ??=
+		PROCESS_DEFAULTS.gridSignals.reconstruction;
+	state["grid-signal-local-phase"] ??=
+		PROCESS_DEFAULTS.gridSignals.localPhaseStability;
+
+	state["background-dehalo"] ??= PROCESS_DEFAULTS.backgroundDehalo;
+	state["background-edge-cleanup"] ??= PROCESS_DEFAULTS.backgroundEdgeCleanup;
+	state["background-ramp-follow"] ??= PROCESS_DEFAULTS.backgroundRampFollow;
+	state["background-removal-rollback"] ??=
+		PROCESS_DEFAULTS.backgroundRemovalRollback;
+	state["alpha-border-background-guard"] ??=
+		PROCESS_DEFAULTS.alphaBorderBackgroundGuard;
+	state["background-confidence-gate"] ??=
+		PROCESS_DEFAULTS.backgroundConfidenceGate;
+	state["small-component-background-gate"] ??=
+		PROCESS_DEFAULTS.smallComponentBackgroundGate;
+
+	state["max-samples-per-cell"] ??= PROCESS_RANGES.maxSamplesPerCell.default;
+	state["cell-alpha-threshold"] ??= PROCESS_RANGES.cellAlphaThreshold.default;
+	state["auto-max-cells-w"] ??= PROCESS_RANGES.autoMaxCells.default;
+	state["auto-max-cells-h"] ??= PROCESS_RANGES.autoMaxCells.default;
+	state["background-mask-tolerance"] ??=
+		PROCESS_RANGES.backgroundMaskTolerance.default;
+	state["trim-alpha-threshold"] ??= PROCESS_RANGES.trimAlphaThreshold.default;
+};

--- a/src/browser/app-elements.ts
+++ b/src/browser/app-elements.ts
@@ -15,7 +15,33 @@ export type Elements = {
 	forcePixelsHInput: HTMLInputElement;
 	sampleWindowInput: HTMLInputElement;
 	sampleWindowSlider: HTMLInputElement;
-	alphaAwareMedoidCheck: HTMLInputElement;
+	// 詳細設定（Auto の自動判定と検出器の調整）
+	cellSamplingModeSelect: HTMLSelectElement;
+	smallAspectGridAlignmentSelect: HTMLSelectElement;
+	watermarkSamplingCompatSelect: HTMLSelectElement;
+	preserveThinFeaturesCheck: HTMLInputElement;
+	autoGridFromTrimmedCheck: HTMLInputElement;
+	phaseAwareGridSearchCheck: HTMLInputElement;
+	boundaryContrastOverrideCheck: HTMLInputElement;
+	detectionBackgroundMaskCheck: HTMLInputElement;
+	gridSignalColorBoundaryCheck: HTMLInputElement;
+	gridSignalLuminanceAlphaCheck: HTMLInputElement;
+	gridSignalAutocorrelationCheck: HTMLInputElement;
+	gridSignalReconstructionCheck: HTMLInputElement;
+	gridSignalLocalPhaseCheck: HTMLInputElement;
+	backgroundDehaloCheck: HTMLInputElement;
+	backgroundEdgeCleanupCheck: HTMLInputElement;
+	backgroundRampFollowCheck: HTMLInputElement;
+	backgroundRemovalRollbackCheck: HTMLInputElement;
+	alphaBorderBackgroundGuardCheck: HTMLInputElement;
+	backgroundConfidenceGateCheck: HTMLInputElement;
+	smallComponentBackgroundGateCheck: HTMLInputElement;
+	maxSamplesPerCellInput: HTMLInputElement;
+	cellAlphaThresholdInput: HTMLInputElement;
+	autoMaxCellsWInput: HTMLInputElement;
+	autoMaxCellsHInput: HTMLInputElement;
+	backgroundMaskToleranceInput: HTMLInputElement;
+	trimAlphaThresholdInput: HTMLInputElement;
 	toleranceInput: HTMLInputElement;
 	toleranceSlider: HTMLInputElement;
 	preRemoveCheck: HTMLInputElement;
@@ -138,7 +164,61 @@ export const getElements = (): Elements => {
 		forcePixelsHInput: get<HTMLInputElement>("force-pixels-h"),
 		sampleWindowInput: get<HTMLInputElement>("sample-window"),
 		sampleWindowSlider: get<HTMLInputElement>("sample-window-slider"),
-		alphaAwareMedoidCheck: get<HTMLInputElement>("alpha-aware-medoid"),
+		// 詳細設定（Auto の自動判定と検出器の調整）
+		cellSamplingModeSelect: get<HTMLSelectElement>("cell-sampling-mode"),
+		smallAspectGridAlignmentSelect: get<HTMLSelectElement>(
+			"small-aspect-grid-alignment",
+		),
+		watermarkSamplingCompatSelect: get<HTMLSelectElement>(
+			"watermark-sampling-compat",
+		),
+		preserveThinFeaturesCheck: get<HTMLInputElement>("preserve-thin-features"),
+		autoGridFromTrimmedCheck: get<HTMLInputElement>("auto-grid-from-trimmed"),
+		phaseAwareGridSearchCheck: get<HTMLInputElement>("phase-aware-grid-search"),
+		boundaryContrastOverrideCheck: get<HTMLInputElement>(
+			"boundary-contrast-override",
+		),
+		detectionBackgroundMaskCheck: get<HTMLInputElement>(
+			"detection-background-mask",
+		),
+		gridSignalColorBoundaryCheck: get<HTMLInputElement>(
+			"grid-signal-color-boundary",
+		),
+		gridSignalLuminanceAlphaCheck: get<HTMLInputElement>(
+			"grid-signal-luminance-alpha",
+		),
+		gridSignalAutocorrelationCheck: get<HTMLInputElement>(
+			"grid-signal-autocorrelation",
+		),
+		gridSignalReconstructionCheck: get<HTMLInputElement>(
+			"grid-signal-reconstruction",
+		),
+		gridSignalLocalPhaseCheck: get<HTMLInputElement>("grid-signal-local-phase"),
+		backgroundDehaloCheck: get<HTMLInputElement>("background-dehalo"),
+		backgroundEdgeCleanupCheck: get<HTMLInputElement>(
+			"background-edge-cleanup",
+		),
+		backgroundRampFollowCheck: get<HTMLInputElement>("background-ramp-follow"),
+		backgroundRemovalRollbackCheck: get<HTMLInputElement>(
+			"background-removal-rollback",
+		),
+		alphaBorderBackgroundGuardCheck: get<HTMLInputElement>(
+			"alpha-border-background-guard",
+		),
+		backgroundConfidenceGateCheck: get<HTMLInputElement>(
+			"background-confidence-gate",
+		),
+		smallComponentBackgroundGateCheck: get<HTMLInputElement>(
+			"small-component-background-gate",
+		),
+		maxSamplesPerCellInput: get<HTMLInputElement>("max-samples-per-cell"),
+		cellAlphaThresholdInput: get<HTMLInputElement>("cell-alpha-threshold"),
+		autoMaxCellsWInput: get<HTMLInputElement>("auto-max-cells-w"),
+		autoMaxCellsHInput: get<HTMLInputElement>("auto-max-cells-h"),
+		backgroundMaskToleranceInput: get<HTMLInputElement>(
+			"background-mask-tolerance",
+		),
+		trimAlphaThresholdInput: get<HTMLInputElement>("trim-alpha-threshold"),
 		toleranceInput: get<HTMLInputElement>("tolerance"),
 		toleranceSlider: get<HTMLInputElement>("tolerance-slider"),
 		preRemoveCheck: get<HTMLInputElement>("pre-remove"),

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -129,7 +129,38 @@ const resources = {
 		"setting.grid_mode": "グリッド検出モード",
 		"setting.quant_step": "減色段階",
 		"setting.sample_window": "グリッド探索のサンプル範囲",
-		"setting.preserve_partial_alpha": "半透明エッジを保持",
+		"setting.cell_sampling_mode": "セル色のサンプリング",
+		"setting.preserve_thin_features": "細い線を保護",
+		"setting.auto_grid_from_trimmed": "内容から格子を推定",
+		"setting.phase_aware_grid_search": "位相考慮の格子探索",
+		"setting.boundary_contrast_override": "境界コントラストで乗り換え",
+		"setting.small_aspect_grid_alignment": "小さな格子の基準合わせ",
+		"setting.max_samples_per_cell": "セルごとの最大サンプル数",
+		"setting.cell_alpha_threshold": "セル色のアルファ下限",
+		"setting.auto_max_cells_w": "最大セル数（幅）",
+		"setting.auto_max_cells_h": "最大セル数（高さ）",
+		"setting.detection_background_mask": "検出前に背景をマスク",
+		"setting.background_mask_tolerance": "検出マスクの許容差",
+		"setting.grid_signal_color_boundary": "信号: 色境界",
+		"setting.grid_signal_luminance_alpha": "信号: 輝度・アルファ",
+		"setting.grid_signal_autocorrelation": "信号: 自己相関",
+		"setting.grid_signal_reconstruction": "信号: 再構成誤差",
+		"setting.grid_signal_local_phase": "信号: 局所位相",
+		"setting.background_dehalo": "縁のにじみを補正",
+		"setting.background_edge_cleanup": "縁の汚染色を差し替え",
+		"setting.background_ramp_follow": "グラデーション背景を追従",
+		"setting.background_removal_rollback": "消えすぎたら巻き戻す",
+		"setting.alpha_border_background_guard": "既存の透過を信用する",
+		"setting.background_confidence_gate": "背景の信頼度を要求",
+		"setting.small_component_background_gate": "整理も背景の信頼度に従う",
+		"setting.watermark_sampling_compat": "透かし除去後のサンプリング",
+		"setting.trim_alpha_threshold": "トリミングのアルファ下限",
+		"option.cell_sampling_hard": "ハードアルファ（既定）",
+		"option.cell_sampling_alpha_aware": "半透明を保持",
+		"option.cell_sampling_legacy": "互換（中央値）",
+		"option.auto_behavior_auto": "Auto（処理方法に従う）",
+		"option.auto_behavior_on": "常に有効",
+		"option.auto_behavior_off": "常に無効",
 		"setting.force_width": "強制幅 (px)",
 		"setting.force_height": "強制高さ (px)",
 		"setting.fast_mode": "高速モード",
@@ -179,8 +210,58 @@ const resources = {
 			"グリッド検出用の減色レベルを設定します。\n\n【大】色がまとまりノイズに強くなりますが、微妙な色の違いが消える場合があります。\n【小】色の境界を細かく拾いますが、ノイズを誤検出するリスクが高まります。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.sample_window":
 			"Auto・Hintでグリッドサイズ候補を比較する際の参照範囲（ピクセル数）です。\n\n【大】グリッド検出がノイズに強くなりますが、細かな境界を見落とす可能性があります。\n【小】細かな境界を捉えやすくなりますが、位置ズレやノイズの影響を強く受けます。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
-		"tooltip.help.preserve_partial_alpha":
-			"ONにすると、alpha-aware medoidで面積被覆アルファを保持します。意図的に柔らかい輪郭や半透明を残したい場合に有効です。\nOFFにすると、ハードなアルファ境界を優先し、補間で生じた半端な透過を残しにくくします。",
+		"tooltip.help.cell_sampling_mode":
+			"論理ピクセル 1 つの代表色をどう選ぶかを決めます。\n\nハードアルファ: 補間で生じた中間の透明度を残しません。\n半透明を保持: 面積被覆としての半透明を残します。意図的に柔らかい縁向けです。\n互換: 旧方式の中央値サンプラーです。透かし除去後に自動で使われるのもこれです。",
+		"tooltip.help.preserve_thin_features":
+			"セルを横切る少数派の色を、線や輪郭として残します。切ると細部が面色に飲まれます。",
+		"tooltip.help.auto_grid_from_trimmed":
+			"背景を除いた内容の範囲から出力格子を推定します。\n切ると、画像全体を走査する旧来の検出器だけで判断します。",
+		"tooltip.help.phase_aware_grid_search":
+			"位相を考慮した探索も行い、縦横どちらの軸も十分に確からしい場合はそちらを採用します。",
+		"tooltip.help.boundary_contrast_override":
+			"セル境界が実際のエッジに明確によく乗る粗い倍率が見つかったとき、採用する格子をそちらへ乗り換えます。",
+		"tooltip.help.small_aspect_grid_alignment":
+			"論理解像度が小さいとき、角から求めたマスクの範囲を格子の基準に使います。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。",
+		"tooltip.help.max_samples_per_cell":
+			"1 つのセルの色を決めるときに読み取る画素数の上限です。大きいほど安定しますが遅くなります。",
+		"tooltip.help.cell_alpha_threshold":
+			"セル内で色の候補として扱うために必要な、最低限のアルファ値です。",
+		"tooltip.help.auto_max_cells_w":
+			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。",
+		"tooltip.help.auto_max_cells_h":
+			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。",
+		"tooltip.help.detection_background_mask":
+			"背景色を推測して格子検出の前に隠します。背景のノイズが検出結果を引っぱるのを防ぎます。",
+		"tooltip.help.background_mask_tolerance":
+			"検出用の背景マスクが背景色とみなす、チャンネルごとの色差です。",
+		"tooltip.help.grid_signal_color_boundary":
+			"格子候補の採点に色境界の信号を含めます。",
+		"tooltip.help.grid_signal_luminance_alpha":
+			"格子候補の採点に輝度勾配とアルファ勾配の信号を含めます。",
+		"tooltip.help.grid_signal_autocorrelation":
+			"格子候補の採点に自己相関の信号を含めます。",
+		"tooltip.help.grid_signal_reconstruction":
+			"格子候補の採点に再構成誤差の信号を含めます。",
+		"tooltip.help.grid_signal_local_phase":
+			"格子候補の採点に局所位相の安定性を含めます。",
+		"tooltip.help.background_dehalo":
+			"背景を消したあと、アンチエイリアスの縁を背景色から遠ざけて残った色かぶりを薄めます。",
+		"tooltip.help.background_edge_cleanup":
+			"縮小後の縁に背景色が混ざって残った画素を、原寸の本来の色へ差し替えます。",
+		"tooltip.help.background_ramp_follow":
+			"なめらかに変化する背景を、絶対的な色差ではなく小さな段差の連なりとしてたどります。",
+		"tooltip.help.background_removal_rollback":
+			"背景除去で可視画素のほとんどが消えてしまう場合に、その除去を丸ごと取り消します。",
+		"tooltip.help.alpha_border_background_guard":
+			"画像の縁の多くがすでに透明なら、色から背景を推定しません。切り抜き済みの画像の輪郭が削れるのを防ぎます。",
+		"tooltip.help.background_confidence_gate":
+			"推定した背景モデルの確からしさが足りないときは、背景除去そのものを見送ります。",
+		"tooltip.help.small_component_background_gate":
+			"推定した背景モデルの確からしさが足りないときは、「小さな要素の整理」も見送ります。",
+		"tooltip.help.watermark_sampling_compat":
+			"透かしを消したあと、末尾の行が欠けるのを防ぐために互換の中央値サンプラーへ切り替えます。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。",
+		"tooltip.help.trim_alpha_threshold":
+			"トリミング範囲を求めるときに、内容とみなすために必要な最低限のアルファ値です。",
 		"tooltip.help.force_width":
 			"指定ピクセル（横）です。\n\nピクセル指定 + 自動検出: この値をヒントに精密探索を開始します。\n完全ピクセル指定: この値に強制変換します。\n\n設定範囲: 1〜1024 (デフォルト: 自動)",
 		"tooltip.help.force_height":
@@ -418,7 +499,38 @@ const resources = {
 		"setting.grid_mode": "网格检测模式",
 		"setting.quant_step": "量化步长",
 		"setting.sample_window": "网格搜索采样范围",
-		"setting.preserve_partial_alpha": "保留半透明边缘",
+		"setting.cell_sampling_mode": "单元格颜色采样",
+		"setting.preserve_thin_features": "保护细线",
+		"setting.auto_grid_from_trimmed": "从内容推定网格",
+		"setting.phase_aware_grid_search": "相位感知网格搜索",
+		"setting.boundary_contrast_override": "按边界对比度切换",
+		"setting.small_aspect_grid_alignment": "小网格基准对齐",
+		"setting.max_samples_per_cell": "每单元格最大采样数",
+		"setting.cell_alpha_threshold": "单元格 Alpha 下限",
+		"setting.auto_max_cells_w": "最大单元格数（宽）",
+		"setting.auto_max_cells_h": "最大单元格数（高）",
+		"setting.detection_background_mask": "检测前遮罩背景",
+		"setting.background_mask_tolerance": "检测遮罩容差",
+		"setting.grid_signal_color_boundary": "信号：颜色边界",
+		"setting.grid_signal_luminance_alpha": "信号：亮度／Alpha",
+		"setting.grid_signal_autocorrelation": "信号：自相关",
+		"setting.grid_signal_reconstruction": "信号：重建误差",
+		"setting.grid_signal_local_phase": "信号：局部相位",
+		"setting.background_dehalo": "修正边缘光晕",
+		"setting.background_edge_cleanup": "替换边缘污染色",
+		"setting.background_ramp_follow": "跟随渐变背景",
+		"setting.background_removal_rollback": "过度移除时回滚",
+		"setting.alpha_border_background_guard": "信任已有透明度",
+		"setting.background_confidence_gate": "要求背景可信",
+		"setting.small_component_background_gate": "清理依赖背景可信度",
+		"setting.watermark_sampling_compat": "水印移除后的采样",
+		"setting.trim_alpha_threshold": "裁剪 Alpha 下限",
+		"option.cell_sampling_hard": "硬 Alpha（默认）",
+		"option.cell_sampling_alpha_aware": "保留半透明",
+		"option.cell_sampling_legacy": "兼容（中值）",
+		"option.auto_behavior_auto": "Auto（跟随处理方式）",
+		"option.auto_behavior_on": "始终启用",
+		"option.auto_behavior_off": "始终禁用",
 		"setting.force_width": "强制宽度 (px)",
 		"setting.force_height": "强制高度 (px)",
 		"setting.fast_mode": "快速模式",
@@ -467,8 +579,58 @@ const resources = {
 			"设置网格检测使用的减色级别。\n\n高：颜色会被归并，更抗噪，但细微色差可能丢失。\n低：能捕捉更细的颜色边界，但更容易误判噪点。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.sample_window":
 			"在自动和提示模式下比较网格尺寸候选项时使用的参考范围（像素数）。\n\n高：网格检测更能抵抗噪点，但可能忽略细微边界。\n低：更容易捕捉细微边界，但更容易受错位和噪点影响。\n\n范围：{min} 到 {max} (默认：{default})",
-		"tooltip.help.preserve_partial_alpha":
-			"开启后使用 alpha-aware medoid 保留面积覆盖率产生的透明度，适合有意保留柔和或半透明边缘的图片。\n关闭后优先生成硬透明边缘，减少保留插值产生的不完全透明。",
+		"tooltip.help.cell_sampling_mode":
+			"决定如何选择每个逻辑像素的代表色。\n\n硬 Alpha：不保留插值产生的中间透明度。\n保留半透明：保留作为面积覆盖的半透明，适合刻意柔和的边缘。\n兼容：旧版中值采样器，水印移除后也会自动使用。",
+		"tooltip.help.preserve_thin_features":
+			"保护横跨单元格的少数色，使细线与轮廓在缩小后仍然保留。",
+		"tooltip.help.auto_grid_from_trimmed":
+			"从去除背景后的内容范围推定输出网格。\n关闭时仅使用扫描整幅图像的旧版检测器。",
+		"tooltip.help.phase_aware_grid_search":
+			"同时执行相位感知搜索，当两个轴都足够可信时优先采用其结果。",
+		"tooltip.help.boundary_contrast_override":
+			"当更粗的倍率其单元格边界明显更贴合真实边缘时，将采用的网格切换过去。",
+		"tooltip.help.small_aspect_grid_alignment":
+			"当逻辑分辨率较小时，使用从角落求得的遮罩范围作为网格基准。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。",
+		"tooltip.help.max_samples_per_cell":
+			"决定单个单元格颜色时读取的像素数上限。数值越大越稳定，但速度更慢。",
+		"tooltip.help.cell_alpha_threshold":
+			"像素在单元格内被视为颜色候选所需的最低 Alpha 值。",
+		"tooltip.help.auto_max_cells_w":
+			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。",
+		"tooltip.help.auto_max_cells_h":
+			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。",
+		"tooltip.help.detection_background_mask":
+			"在网格检测前推测并遮罩背景色，避免背景噪点影响检测结果。",
+		"tooltip.help.background_mask_tolerance":
+			"检测用背景遮罩视为背景的各通道色差。",
+		"tooltip.help.grid_signal_color_boundary":
+			"在网格候选评分中纳入颜色边界信号。",
+		"tooltip.help.grid_signal_luminance_alpha":
+			"在网格候选评分中纳入亮度梯度与 Alpha 梯度信号。",
+		"tooltip.help.grid_signal_autocorrelation":
+			"在网格候选评分中纳入自相关信号。",
+		"tooltip.help.grid_signal_reconstruction":
+			"在网格候选评分中纳入重建误差信号。",
+		"tooltip.help.grid_signal_local_phase":
+			"在网格候选评分中纳入局部相位稳定性信号。",
+		"tooltip.help.background_dehalo":
+			"移除背景后，将抗锯齿边缘推离背景色，减轻残留的偏色。",
+		"tooltip.help.background_edge_cleanup":
+			"将缩小后仍带有背景色的边缘像素替换为原始尺寸下的本来颜色。",
+		"tooltip.help.background_ramp_follow":
+			"将平滑渐变的背景视为一连串细小台阶来追踪，而非依据绝对色差。",
+		"tooltip.help.background_removal_rollback":
+			"当背景移除会抹掉几乎所有可见像素时，整体撤销该次移除。",
+		"tooltip.help.alpha_border_background_guard":
+			"当图像边缘大部分已透明时，不再依据颜色推定背景，避免削掉已抠图图像的轮廓。",
+		"tooltip.help.background_confidence_gate":
+			"当推定的背景模型可信度不足时，直接跳过背景移除。",
+		"tooltip.help.small_component_background_gate":
+			"当推定的背景模型可信度不足时，同样跳过「细小元素整理」。",
+		"tooltip.help.watermark_sampling_compat":
+			"移除水印后切换到兼容的中值采样器，以避免末行缺失。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。",
+		"tooltip.help.trim_alpha_threshold":
+			"计算裁剪范围时，像素被视为内容所需的最低 Alpha 值。",
 		"tooltip.help.force_width":
 			"指定像素宽度。\n\n像素指定 + 自动检测：用该值作为提示并在附近精细搜索。\n完全像素指定：强制转换为该宽度。\n\n范围：1 到 1024 (默认：自动)",
 		"tooltip.help.force_height":
@@ -706,7 +868,38 @@ const resources = {
 		"setting.grid_mode": "Grid Detection Mode",
 		"setting.quant_step": "Quantization Step",
 		"setting.sample_window": "Grid Sampling Window",
-		"setting.preserve_partial_alpha": "Preserve Semi-transparent Edges",
+		"setting.cell_sampling_mode": "Cell Color Sampling",
+		"setting.preserve_thin_features": "Preserve Thin Features",
+		"setting.auto_grid_from_trimmed": "Estimate Grid From Content",
+		"setting.phase_aware_grid_search": "Phase-aware Grid Search",
+		"setting.boundary_contrast_override": "Boundary Contrast Override",
+		"setting.small_aspect_grid_alignment": "Small Grid Alignment",
+		"setting.max_samples_per_cell": "Max Samples per Cell",
+		"setting.cell_alpha_threshold": "Cell Alpha Threshold",
+		"setting.auto_max_cells_w": "Max Cells (Width)",
+		"setting.auto_max_cells_h": "Max Cells (Height)",
+		"setting.detection_background_mask": "Mask Background For Detection",
+		"setting.background_mask_tolerance": "Detection Mask Tolerance",
+		"setting.grid_signal_color_boundary": "Signal: Colour Boundary",
+		"setting.grid_signal_luminance_alpha": "Signal: Luminance / Alpha",
+		"setting.grid_signal_autocorrelation": "Signal: Autocorrelation",
+		"setting.grid_signal_reconstruction": "Signal: Reconstruction",
+		"setting.grid_signal_local_phase": "Signal: Local Phase",
+		"setting.background_dehalo": "Reduce Edge Halo",
+		"setting.background_edge_cleanup": "Clean Contaminated Edges",
+		"setting.background_ramp_follow": "Follow Gradient Background",
+		"setting.background_removal_rollback": "Roll Back Over-removal",
+		"setting.alpha_border_background_guard": "Trust Existing Transparency",
+		"setting.background_confidence_gate": "Require Confident Background",
+		"setting.small_component_background_gate": "Gate Cleanup On Background",
+		"setting.watermark_sampling_compat": "Watermark Sampling Fallback",
+		"setting.trim_alpha_threshold": "Trim Alpha Threshold",
+		"option.cell_sampling_hard": "Hard Alpha (Default)",
+		"option.cell_sampling_alpha_aware": "Alpha Aware",
+		"option.cell_sampling_legacy": "Compatible (Median)",
+		"option.auto_behavior_auto": "Auto (Follow Processing Mode)",
+		"option.auto_behavior_on": "Always On",
+		"option.auto_behavior_off": "Always Off",
 		"setting.force_width": "Force Width (px)",
 		"setting.force_height": "Force Height (px)",
 		"setting.fast_mode": "Fast Mode",
@@ -756,8 +949,58 @@ const resources = {
 			"Sets the color reduction level for grid detection.\n\nHigh: Colors are grouped, making it resistant to noise, but subtle color differences may be lost.\nLow: Picks up fine color boundaries, but increases the risk of false noise detection.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.sample_window":
 			"The reference range (in pixels) used to compare grid-size candidates in Auto and Hint modes.\n\nHigh: Grid detection is more resistant to noise, but fine boundaries may be overlooked.\nLow: Grid detection follows fine boundaries, but is more affected by misalignment and noise.\n\nRange: {min} to {max} (Default: {default})",
-		"tooltip.help.preserve_partial_alpha":
-			"When ON, preserves area-coverage alpha with alpha-aware medoid sampling. This is useful for intentionally soft or semi-transparent edges.\nWhen OFF, favors hard alpha edges and avoids retaining partial transparency introduced by interpolation.",
+		"tooltip.help.cell_sampling_mode":
+			"How the representative colour of each logical pixel is chosen.\n\nHard Alpha: Avoids keeping partial transparency introduced by interpolation.\nAlpha Aware: Preserves area-coverage alpha for intentionally soft edges.\nCompatible: The legacy median sampler, also used automatically after watermark removal.",
+		"tooltip.help.preserve_thin_features":
+			"Protects minority colours that cross a cell so that thin lines and outlines survive downsampling.",
+		"tooltip.help.auto_grid_from_trimmed":
+			"Estimates the output grid from the trimmed content area.\nWhen OFF, only the fallback detector that scans the whole canvas is used.",
+		"tooltip.help.phase_aware_grid_search":
+			"Also runs a phase-aware search and prefers its result when both axes are confident enough.",
+		"tooltip.help.boundary_contrast_override":
+			"Switches the chosen grid to a coarser harmonic when its cell boundaries align clearly better with real edges.",
+		"tooltip.help.small_aspect_grid_alignment":
+			"For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.",
+		"tooltip.help.max_samples_per_cell":
+			"Upper bound on the pixels sampled from one cell when picking its colour. Higher is more stable but slower.",
+		"tooltip.help.cell_alpha_threshold":
+			"Minimum alpha for a pixel to be considered a colour candidate inside a cell.",
+		"tooltip.help.auto_max_cells_w":
+			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.",
+		"tooltip.help.auto_max_cells_h":
+			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.",
+		"tooltip.help.detection_background_mask":
+			"Guesses the background colour and masks it before grid detection so that background noise does not bias the result.",
+		"tooltip.help.background_mask_tolerance":
+			"Per-channel colour difference the detection background mask treats as background.",
+		"tooltip.help.grid_signal_color_boundary":
+			"Includes the colour-boundary signal when scoring grid candidates.",
+		"tooltip.help.grid_signal_luminance_alpha":
+			"Includes the luminance and alpha gradient signals when scoring grid candidates.",
+		"tooltip.help.grid_signal_autocorrelation":
+			"Includes the autocorrelation signal when scoring grid candidates.",
+		"tooltip.help.grid_signal_reconstruction":
+			"Includes the reconstruction-error signal when scoring grid candidates.",
+		"tooltip.help.grid_signal_local_phase":
+			"Includes the local phase stability signal when scoring grid candidates.",
+		"tooltip.help.background_dehalo":
+			"Pushes anti-aliased edge pixels away from the background colour after removal.",
+		"tooltip.help.background_edge_cleanup":
+			"Replaces edge pixels that still carry the background colour after downscaling with their original colour.",
+		"tooltip.help.background_ramp_follow":
+			"Follows a smooth gradient background as a chain of small steps instead of an absolute colour difference.",
+		"tooltip.help.background_removal_rollback":
+			"Discards the whole background removal when it would erase almost all of the visible pixels.",
+		"tooltip.help.alpha_border_background_guard":
+			"Skips colour-cluster estimation when most of the border band is already transparent, which protects the outline of pre-cut images.",
+		"tooltip.help.background_confidence_gate":
+			"Skips background removal entirely when the estimated background model is not confident enough.",
+		"tooltip.help.small_component_background_gate":
+			"Skips the small-detail cleanup when the estimated background model is not confident enough.",
+		"tooltip.help.watermark_sampling_compat":
+			"Switches to the compatible median sampler once a watermark has been removed, which prevents the last row from being dropped.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.",
+		"tooltip.help.trim_alpha_threshold":
+			"Minimum alpha for a pixel to count as content when computing the trimming bounds.",
 		"tooltip.help.force_width":
 			"Specified pixel width.\n\nPixel + Auto: Uses this as a hint and starts fine search near it.\nPixel Only: Forces conversion to this size.\n\nRange: 1 to 1024 (Default: Auto)",
 		"tooltip.help.force_height":

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -221,7 +221,7 @@ const resources = {
 		"tooltip.help.boundary_contrast_override":
 			"セル境界が実際のエッジに明確によく乗る粗い倍率が見つかったとき、採用する格子をそちらへ乗り換えます。",
 		"tooltip.help.small_aspect_grid_alignment":
-			"論理解像度が小さいとき、角から求めたマスクの範囲を格子の基準に使います。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。",
+			"論理解像度が小さいとき、角から求めたマスクの範囲を格子の基準に使います。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。\n\n「常に無効」にすると、Auto の経路判定でも小さな格子が許可されなくなり、等倍のまま仕上げる経路へ切り替わる場合があります。",
 		"tooltip.help.max_samples_per_cell":
 			"1 つのセルの色を決めるときに読み取る画素数の上限です。大きいほど安定しますが遅くなります。",
 		"tooltip.help.cell_alpha_threshold":
@@ -590,7 +590,7 @@ const resources = {
 		"tooltip.help.boundary_contrast_override":
 			"当更粗的倍率其单元格边界明显更贴合真实边缘时，将采用的网格切换过去。",
 		"tooltip.help.small_aspect_grid_alignment":
-			"当逻辑分辨率较小时，使用从角落求得的遮罩范围作为网格基准。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。",
+			"当逻辑分辨率较小时，使用从角落求得的遮罩范围作为网格基准。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。\n\n设为「始终关闭」时，Auto 的路径判定也将不再允许小网格，可能改为按原尺寸完成的路径。",
 		"tooltip.help.max_samples_per_cell":
 			"决定单个单元格颜色时读取的像素数上限。数值越大越稳定，但速度更慢。",
 		"tooltip.help.cell_alpha_threshold":
@@ -960,7 +960,7 @@ const resources = {
 		"tooltip.help.boundary_contrast_override":
 			"Switches the chosen grid to a coarser harmonic when its cell boundaries align clearly better with real edges.",
 		"tooltip.help.small_aspect_grid_alignment":
-			"For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.",
+			"For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.\n\nWith Always Off, the Auto route selection also stops allowing small grids and may fall back to the preserve route.",
 		"tooltip.help.max_samples_per_cell":
 			"Upper bound on the pixels sampled from one cell when picking its colour. Higher is more stable but slower.",
 		"tooltip.help.cell_alpha_threshold":

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -223,17 +223,17 @@ const resources = {
 		"tooltip.help.small_aspect_grid_alignment":
 			"論理解像度が小さいとき、角から求めたマスクの範囲を格子の基準に使います。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。\n\n「常に無効」にすると、Auto の経路判定でも小さな格子が許可されなくなり、等倍のまま仕上げる経路へ切り替わる場合があります。",
 		"tooltip.help.max_samples_per_cell":
-			"1 つのセルの色を決めるときに読み取る画素数の上限です。大きいほど安定しますが遅くなります。",
+			"1 つのセルの色を決めるときに読み取る画素数の上限です。大きいほど安定しますが遅くなります。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.cell_alpha_threshold":
-			"セル内で色の候補として扱うために必要な、最低限のアルファ値です。",
+			"セル内で色の候補として扱うために必要な、最低限のアルファ値です。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.auto_max_cells_w":
-			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。",
+			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.auto_max_cells_h":
-			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。",
+			"旧来の検出器が自動検出するセル数の上限です。「内容から格子を推定」を切ったときに効きます。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.detection_background_mask":
 			"背景色を推測して格子検出の前に隠します。背景のノイズが検出結果を引っぱるのを防ぎます。",
 		"tooltip.help.background_mask_tolerance":
-			"検出用の背景マスクが背景色とみなす、チャンネルごとの色差です。",
+			"検出用の背景マスクが背景色とみなす、チャンネルごとの色差です。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.grid_signal_color_boundary":
 			"格子候補の採点に色境界の信号を含めます。",
 		"tooltip.help.grid_signal_luminance_alpha":
@@ -261,7 +261,7 @@ const resources = {
 		"tooltip.help.watermark_sampling_compat":
 			"透かしを消したあと、末尾の行が欠けるのを防ぐために互換の中央値サンプラーへ切り替えます。\n\nこれまで Auto でしか働きませんでした。「常に有効」にすると、処理方法が「ドットを整える」でも Auto と同じ結果を再現できます。",
 		"tooltip.help.trim_alpha_threshold":
-			"トリミング範囲を求めるときに、内容とみなすために必要な最低限のアルファ値です。",
+			"トリミング範囲を求めるときに、内容とみなすために必要な最低限のアルファ値です。\n\n設定範囲: {min}〜{max} (デフォルト: {default})",
 		"tooltip.help.force_width":
 			"指定ピクセル（横）です。\n\nピクセル指定 + 自動検出: この値をヒントに精密探索を開始します。\n完全ピクセル指定: この値に強制変換します。\n\n設定範囲: 1〜1024 (デフォルト: 自動)",
 		"tooltip.help.force_height":
@@ -592,17 +592,17 @@ const resources = {
 		"tooltip.help.small_aspect_grid_alignment":
 			"当逻辑分辨率较小时，使用从角落求得的遮罩范围作为网格基准。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。\n\n设为「始终关闭」时，Auto 的路径判定也将不再允许小网格，可能改为按原尺寸完成的路径。",
 		"tooltip.help.max_samples_per_cell":
-			"决定单个单元格颜色时读取的像素数上限。数值越大越稳定，但速度更慢。",
+			"决定单个单元格颜色时读取的像素数上限。数值越大越稳定，但速度更慢。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.cell_alpha_threshold":
-			"像素在单元格内被视为颜色候选所需的最低 Alpha 值。",
+			"像素在单元格内被视为颜色候选所需的最低 Alpha 值。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.auto_max_cells_w":
-			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。",
+			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.auto_max_cells_h":
-			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。",
+			"旧版检测器自动检测的单元格数上限。关闭「从内容推定网格」时生效。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.detection_background_mask":
 			"在网格检测前推测并遮罩背景色，避免背景噪点影响检测结果。",
 		"tooltip.help.background_mask_tolerance":
-			"检测用背景遮罩视为背景的各通道色差。",
+			"检测用背景遮罩视为背景的各通道色差。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.grid_signal_color_boundary":
 			"在网格候选评分中纳入颜色边界信号。",
 		"tooltip.help.grid_signal_luminance_alpha":
@@ -630,7 +630,7 @@ const resources = {
 		"tooltip.help.watermark_sampling_compat":
 			"移除水印后切换到兼容的中值采样器，以避免末行缺失。\n\n以往仅在 Auto 下生效。设为「始终启用」后，在「整理点阵」模式下也能重现 Auto 的结果。",
 		"tooltip.help.trim_alpha_threshold":
-			"计算裁剪范围时，像素被视为内容所需的最低 Alpha 值。",
+			"计算裁剪范围时，像素被视为内容所需的最低 Alpha 值。\n\n范围：{min} 到 {max} (默认：{default})",
 		"tooltip.help.force_width":
 			"指定像素宽度。\n\n像素指定 + 自动检测：用该值作为提示并在附近精细搜索。\n完全像素指定：强制转换为该宽度。\n\n范围：1 到 1024 (默认：自动)",
 		"tooltip.help.force_height":
@@ -962,17 +962,17 @@ const resources = {
 		"tooltip.help.small_aspect_grid_alignment":
 			"For small logical resolutions, uses the corner-seeded mask bounds as the grid reference area.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.\n\nWith Always Off, the Auto route selection also stops allowing small grids and may fall back to the preserve route.",
 		"tooltip.help.max_samples_per_cell":
-			"Upper bound on the pixels sampled from one cell when picking its colour. Higher is more stable but slower.",
+			"Upper bound on the pixels sampled from one cell when picking its colour. Higher is more stable but slower.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.cell_alpha_threshold":
-			"Minimum alpha for a pixel to be considered a colour candidate inside a cell.",
+			"Minimum alpha for a pixel to be considered a colour candidate inside a cell.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.auto_max_cells_w":
-			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.",
+			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.auto_max_cells_h":
-			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.",
+			"Upper bound on the cell count found by the fallback detector. Applies when grid estimation from content is off.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.detection_background_mask":
 			"Guesses the background colour and masks it before grid detection so that background noise does not bias the result.",
 		"tooltip.help.background_mask_tolerance":
-			"Per-channel colour difference the detection background mask treats as background.",
+			"Per-channel colour difference the detection background mask treats as background.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.grid_signal_color_boundary":
 			"Includes the colour-boundary signal when scoring grid candidates.",
 		"tooltip.help.grid_signal_luminance_alpha":
@@ -1000,7 +1000,7 @@ const resources = {
 		"tooltip.help.watermark_sampling_compat":
 			"Switches to the compatible median sampler once a watermark has been removed, which prevents the last row from being dropped.\n\nThis used to run only in Auto. Set it to Always On to reproduce the Auto result from Refine.",
 		"tooltip.help.trim_alpha_threshold":
-			"Minimum alpha for a pixel to count as content when computing the trimming bounds.",
+			"Minimum alpha for a pixel to count as content when computing the trimming bounds.\n\nRange: {min} to {max} (Default: {default})",
 		"tooltip.help.force_width":
 			"Specified pixel width.\n\nPixel + Auto: Uses this as a hint and starts fine search near it.\nPixel Only: Forces conversion to this size.\n\nRange: 1 to 1024 (Default: Auto)",
 		"tooltip.help.force_height":

--- a/src/browser/preset-controls.ts
+++ b/src/browser/preset-controls.ts
@@ -1,4 +1,8 @@
 import { PROCESS_DEFAULTS } from "../shared/config";
+import {
+	advancedSettingControls,
+	migrateAdvancedSettings,
+} from "./advanced-settings-fields";
 import type { Elements } from "./app-elements";
 import { i18n } from "./i18n";
 import type { ModalController } from "./modal-controller";
@@ -68,7 +72,7 @@ export const setupPresetControls = ({
 			els.forcePixelsHInput,
 			els.sampleWindowInput,
 			els.sampleWindowSlider,
-			els.alphaAwareMedoidCheck,
+			...advancedSettingControls(els),
 			els.toleranceInput,
 			els.toleranceSlider,
 			els.preRemoveCheck,
@@ -124,8 +128,7 @@ export const setupPresetControls = ({
 		// [Policy] 旧プリセットの割合設定は、無効か安全な自動判定へだけ移行する。
 		migrateSmallComponentMode(state);
 		// [Policy] UI追加前のプリセットは新しい既定値へ移行し、読み込み順で挙動を変えない。
-		state["alpha-aware-medoid"] ??=
-			(PROCESS_DEFAULTS.cellSamplingMode as string) === "alpha-aware-medoid";
+		migrateAdvancedSettings(state);
 		state["gemini-watermark-removal"] ??=
 			PROCESS_DEFAULTS.geminiWatermarkRemoval;
 		// 後方互換性: 旧 boolean の "enable-grid-detection" を新しいモード選択へ移行

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -136,9 +136,57 @@ export const createProcessOptions = (
 			: "4",
 		backgroundTolerance: tolerance,
 		sampleWindow,
-		cellSamplingMode: els.alphaAwareMedoidCheck.checked
-			? "alpha-aware-medoid"
-			: "hard-alpha-medoid",
+		cellSamplingMode: els.cellSamplingModeSelect
+			.value as ProcessOptions["cellSamplingMode"],
+		maxSamplesPerCell: clampInt(
+			Number(els.maxSamplesPerCellInput.value),
+			PROCESS_RANGES.maxSamplesPerCell,
+		),
+		cellAlphaThreshold: clampInt(
+			Number(els.cellAlphaThresholdInput.value),
+			PROCESS_RANGES.cellAlphaThreshold,
+		),
+		trimAlphaThreshold: clampInt(
+			Number(els.trimAlphaThresholdInput.value),
+			PROCESS_RANGES.trimAlphaThreshold,
+		),
+		autoMaxCellsW: clampInt(
+			Number(els.autoMaxCellsWInput.value),
+			PROCESS_RANGES.autoMaxCells,
+		),
+		autoMaxCellsH: clampInt(
+			Number(els.autoMaxCellsHInput.value),
+			PROCESS_RANGES.autoMaxCells,
+		),
+		backgroundMask: els.detectionBackgroundMaskCheck.checked,
+		backgroundMaskTolerance: clampInt(
+			Number(els.backgroundMaskToleranceInput.value),
+			PROCESS_RANGES.backgroundMaskTolerance,
+		),
+		preserveThinFeatures: els.preserveThinFeaturesCheck.checked,
+		autoGridFromTrimmed: els.autoGridFromTrimmedCheck.checked,
+		phaseAwareGridSearch: els.phaseAwareGridSearchCheck.checked,
+		boundaryContrastOverride: els.boundaryContrastOverrideCheck.checked,
+		smallAspectGridAlignment: els.smallAspectGridAlignmentSelect
+			.value as ProcessOptions["smallAspectGridAlignment"],
+		watermarkSamplingCompat: els.watermarkSamplingCompatSelect
+			.value as ProcessOptions["watermarkSamplingCompat"],
+		gridSignals: {
+			colorBoundary: els.gridSignalColorBoundaryCheck.checked,
+			luminanceAlphaGradient: els.gridSignalLuminanceAlphaCheck.checked,
+			autocorrelation: els.gridSignalAutocorrelationCheck.checked,
+			reconstruction: els.gridSignalReconstructionCheck.checked,
+			localPhaseStability: els.gridSignalLocalPhaseCheck.checked,
+		},
+		// [Intended] 背景の自動判定は、背景抽出そのものが無効なら意味を持たない。
+		// 既存の bgEnabled と同じ従属関係へ置き、UI の指定が独り歩きしないようにする。
+		backgroundDehalo: bgEnabled && els.backgroundDehaloCheck.checked,
+		backgroundEdgeCleanup: bgEnabled && els.backgroundEdgeCleanupCheck.checked,
+		backgroundRampFollow: bgEnabled && els.backgroundRampFollowCheck.checked,
+		backgroundRemovalRollback: els.backgroundRemovalRollbackCheck.checked,
+		alphaBorderBackgroundGuard: els.alphaBorderBackgroundGuardCheck.checked,
+		backgroundConfidenceGate: els.backgroundConfidenceGateCheck.checked,
+		smallComponentBackgroundGate: els.smallComponentBackgroundGateCheck.checked,
 		trimToContent: els.trimToContentCheck.checked,
 		fastAutoGridFromTrimmed: els.fastAutoGridFromTrimmedCheck.checked,
 		makeSquare: els.makeSquareCheck.checked,

--- a/src/browser/quick-settings-controls.test.ts
+++ b/src/browser/quick-settings-controls.test.ts
@@ -44,7 +44,32 @@ const controlNames = [
 	"forcePixelsHInput",
 	"sampleWindowInput",
 	"sampleWindowSlider",
-	"alphaAwareMedoidCheck",
+	"cellSamplingModeSelect",
+	"smallAspectGridAlignmentSelect",
+	"watermarkSamplingCompatSelect",
+	"preserveThinFeaturesCheck",
+	"autoGridFromTrimmedCheck",
+	"phaseAwareGridSearchCheck",
+	"boundaryContrastOverrideCheck",
+	"detectionBackgroundMaskCheck",
+	"gridSignalColorBoundaryCheck",
+	"gridSignalLuminanceAlphaCheck",
+	"gridSignalAutocorrelationCheck",
+	"gridSignalReconstructionCheck",
+	"gridSignalLocalPhaseCheck",
+	"backgroundDehaloCheck",
+	"backgroundEdgeCleanupCheck",
+	"backgroundRampFollowCheck",
+	"backgroundRemovalRollbackCheck",
+	"alphaBorderBackgroundGuardCheck",
+	"backgroundConfidenceGateCheck",
+	"smallComponentBackgroundGateCheck",
+	"maxSamplesPerCellInput",
+	"cellAlphaThresholdInput",
+	"autoMaxCellsWInput",
+	"autoMaxCellsHInput",
+	"backgroundMaskToleranceInput",
+	"trimAlphaThresholdInput",
 	"fastAutoGridFromTrimmedCheck",
 	"makeSquareCheck",
 	"keepAspectRatioCheck",
@@ -142,7 +167,7 @@ describe("quick settings controls", () => {
 
 		expect(clearCandidateSelections).toHaveBeenCalledOnce();
 		expect(els.smallComponentModeSelect.value).toBe("auto");
-		expect(els.alphaAwareMedoidCheck.checked).toBe(false);
+		expect(els.cellSamplingModeSelect.value).toBe("hard-alpha-medoid");
 	});
 
 	it("reads the background removal scope from the quick settings", () => {

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -7,6 +7,10 @@ import type {
 	OutlineStyle,
 	ProcessingMode,
 } from "../shared/types";
+import {
+	advancedSettingControls,
+	applyAdvancedSettingDefaults,
+} from "./advanced-settings-fields";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
 import type {
@@ -117,8 +121,7 @@ export const setupQuickSettingsControls = ({
 			els.postRemoveCheck.checked = defaults.postRemoveBackground;
 			els.bgConnectivitySelect.value = defaults.bgConnectivity;
 			els.smallComponentModeSelect.value = defaults.smallComponentMode;
-			els.alphaAwareMedoidCheck.checked =
-				(defaults.cellSamplingMode as string) === "alpha-aware-medoid";
+			applyAdvancedSettingDefaults(els, defaults);
 			els.fastAutoGridFromTrimmedCheck.checked =
 				defaults.fastAutoGridFromTrimmed;
 			els.makeSquareCheck.checked = defaults.makeSquare;
@@ -213,7 +216,7 @@ export const setupQuickSettingsControls = ({
 		els.forcePixelsHInput,
 		els.sampleWindowInput,
 		els.sampleWindowSlider,
-		els.alphaAwareMedoidCheck,
+		...advancedSettingControls(els),
 		els.toleranceInput,
 		els.toleranceSlider,
 		els.preRemoveCheck,

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -365,6 +365,7 @@ export const setupSettingsControls = ({
 			els.quantStepInput,
 			els.quantStepSlider,
 			els.fastAutoGridFromTrimmedCheck,
+			...gridDetectionAdvancedControls(els),
 		].forEach((el) => {
 			setDisabledClass(el, !isAutoOrHint);
 		});
@@ -470,6 +471,7 @@ export const setupSettingsControls = ({
 			els.bgConnectivitySelect,
 			els.smallComponentModeSelect,
 			els.geminiWatermarkRemovalSelect,
+			...backgroundDependentAdvancedControls(els),
 		].forEach((el) => {
 			const item = el.closest(".setting-item");
 			if (item) {

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -168,6 +168,54 @@ export const setupSettingsControls = ({
 		}
 	});
 
+	/**
+	 * ツールチップ内の {min} / {max} / {default} を設定ファイルの範囲で置き換える。
+	 *
+	 * [Intended] i18n.updatePage() は data-tooltip を翻訳リソースの原文で上書きするため、
+	 * 置換は必ず翻訳の適用後（言語切替のたび）に行う。
+	 */
+	const applyTooltipRanges = () => {
+		const applyTooltipRange = (
+			id: string,
+			range: { min: number; max: number; default: number },
+		) => {
+			const el = document.getElementById(id);
+			if (!el) return;
+			const cur = el.getAttribute("data-tooltip");
+			if (!cur) return;
+			el.setAttribute(
+				"data-tooltip",
+				cur
+					.replace(/\{min\}/g, String(range.min))
+					.replace(/\{max\}/g, String(range.max))
+					.replace(/\{default\}/g, String(range.default)),
+			);
+		};
+		applyTooltipRange("help-quant-step", PROCESS_RANGES.detectionQuantStep);
+		applyTooltipRange("help-sample-window", PROCESS_RANGES.sampleWindow);
+		applyTooltipRange("help-tolerance", PROCESS_RANGES.backgroundTolerance);
+		applyTooltipRange("help-color-count", PROCESS_RANGES.colorCount);
+		applyTooltipRange("help-dither-strength", PROCESS_RANGES.ditherStrength);
+		applyTooltipRange(
+			"help-max-samples-per-cell",
+			PROCESS_RANGES.maxSamplesPerCell,
+		);
+		applyTooltipRange(
+			"help-cell-alpha-threshold",
+			PROCESS_RANGES.cellAlphaThreshold,
+		);
+		applyTooltipRange("help-auto-max-cells-w", PROCESS_RANGES.autoMaxCells);
+		applyTooltipRange("help-auto-max-cells-h", PROCESS_RANGES.autoMaxCells);
+		applyTooltipRange(
+			"help-background-mask-tolerance",
+			PROCESS_RANGES.backgroundMaskTolerance,
+		);
+		applyTooltipRange(
+			"help-trim-alpha-threshold",
+			PROCESS_RANGES.trimAlphaThreshold,
+		);
+	};
+
 	// 設定ファイルの既定値・範囲を UI に適用
 	const applyConfigToUi = () => {
 		const defaults = createDefaultProcessOptions();
@@ -252,34 +300,13 @@ export const setupSettingsControls = ({
 		els.builtInPresetSelect.value = "auto";
 		syncQuickSettingsToAdvanced();
 
-		const applyTooltipRange = (
-			id: string,
-			range: { min: number; max: number; default: number },
-		) => {
-			const el = document.getElementById(id);
-			if (!el) return;
-			const cur = el.getAttribute("data-tooltip");
-			if (!cur) return;
-			el.setAttribute(
-				"data-tooltip",
-				cur
-					.replace(/\{min\}/g, String(range.min))
-					.replace(/\{max\}/g, String(range.max))
-					.replace(/\{default\}/g, String(range.default)),
-			);
-		};
-		applyTooltipRange("help-quant-step", PROCESS_RANGES.detectionQuantStep);
-		applyTooltipRange("help-sample-window", PROCESS_RANGES.sampleWindow);
-		applyTooltipRange("help-tolerance", PROCESS_RANGES.backgroundTolerance);
-		applyTooltipRange("help-color-count", PROCESS_RANGES.colorCount);
-		applyTooltipRange("help-dither-strength", PROCESS_RANGES.ditherStrength);
-
 		// 言語切替ボタンのイベントリスナー
 		document.querySelectorAll("[data-lang-btn]").forEach((el) => {
 			el.addEventListener("click", () => {
 				const lang = el.getAttribute("data-lang-btn") as Language | null;
 				if (lang) {
 					i18n.setLanguage(lang);
+					applyTooltipRanges();
 					onLanguageChange();
 				}
 			});
@@ -287,6 +314,7 @@ export const setupSettingsControls = ({
 
 		// 初期翻訳を適用
 		i18n.updatePage();
+		applyTooltipRanges();
 	};
 
 	// 自動処理の状態に応じて処理ボタンの表示を切り替え

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -1,6 +1,10 @@
 import { rgbToHex } from "../core/colorUtils";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import {
+	advancedSettingControls,
+	applyAdvancedSettingDefaults,
+} from "./advanced-settings-fields";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
 import { isDitherSettingsEnabled } from "./batch-options";
@@ -223,8 +227,7 @@ export const setupSettingsControls = ({
 		els.bgConnectivitySelect.value = defaults.bgConnectivity;
 		els.smallComponentModeSelect.value = defaults.smallComponentMode;
 		els.geminiWatermarkRemovalSelect.value = defaults.geminiWatermarkRemoval;
-		els.alphaAwareMedoidCheck.checked =
-			(defaults.cellSamplingMode as string) === "alpha-aware-medoid";
+		applyAdvancedSettingDefaults(els, defaults);
 		els.trimToContentCheck.checked = defaults.trimToContent;
 		els.fastAutoGridFromTrimmedCheck.checked = defaults.fastAutoGridFromTrimmed;
 		els.makeSquareCheck.checked = defaults.makeSquare;
@@ -551,7 +554,7 @@ export const setupSettingsControls = ({
 	[
 		els.forcePixelsWInput,
 		els.forcePixelsHInput,
-		els.alphaAwareMedoidCheck,
+		...advancedSettingControls(els),
 		els.preRemoveCheck,
 		els.postRemoveCheck,
 		els.bgConnectivitySelect,

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -4,6 +4,8 @@ import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
 import {
 	advancedSettingControls,
 	applyAdvancedSettingDefaults,
+	backgroundDependentAdvancedControls,
+	gridDetectionAdvancedControls,
 } from "./advanced-settings-fields";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
@@ -320,6 +322,7 @@ export const setupSettingsControls = ({
 		els.gridDetectionModeSelect,
 		els.forcePixelsWInput,
 		els.forcePixelsHInput,
+		...gridDetectionAdvancedControls(els),
 	].forEach((el) => {
 		el.addEventListener("change", clearCandidateSelections);
 		el.addEventListener("input", clearCandidateSelections);

--- a/src/core/background-removal.ts
+++ b/src/core/background-removal.ts
@@ -148,12 +148,13 @@ const fillWithRampFallback = (
 		? detectBackgroundRamp(img, tolerance)
 		: undefined;
 	if (ramp !== undefined) {
-		const opaqueBefore = countOpaquePixels(img);
 		const ramped = cloneImage(img);
 		fill(ramped, ramp);
+		// 巻き戻しが無効なら除去率を測る必要がないので、全画素走査へ入る前に返す。
+		if (!behavior.rollback) return ramped;
+		const opaqueBefore = countOpaquePixels(img);
 		const removed = opaqueBefore - countOpaquePixels(ramped);
 		if (
-			!behavior.rollback ||
 			opaqueBefore === 0 ||
 			removed <= opaqueBefore * BACKGROUND_RAMP_LIMITS.maxRemovalRatio
 		) {

--- a/src/core/background-removal.ts
+++ b/src/core/background-removal.ts
@@ -7,7 +7,12 @@ import type {
 	Connectivity,
 	RawImage,
 } from "../shared/types";
-import { type BackgroundModel, removeAutomaticBackground } from "./background";
+import {
+	type BackgroundBehavior,
+	type BackgroundModel,
+	DEFAULT_BACKGROUND_BEHAVIOR,
+	removeAutomaticBackground,
+} from "./background";
 import { addEnclosedBackground } from "./enclosed-background";
 import { type FloodFillRamp, floodFillTransparent } from "./floodfill";
 import { cloneImage } from "./image-operations";
@@ -137,14 +142,18 @@ const fillWithRampFallback = (
 	img: RawImage,
 	tolerance: number,
 	fill: (target: RawImage, ramp: FloodFillRamp | undefined) => void,
+	behavior: BackgroundBehavior = DEFAULT_BACKGROUND_BEHAVIOR,
 ): RawImage => {
-	const ramp = detectBackgroundRamp(img, tolerance);
+	const ramp = behavior.rampFollow
+		? detectBackgroundRamp(img, tolerance)
+		: undefined;
 	if (ramp !== undefined) {
 		const opaqueBefore = countOpaquePixels(img);
 		const ramped = cloneImage(img);
 		fill(ramped, ramp);
 		const removed = opaqueBefore - countOpaquePixels(ramped);
 		if (
+			!behavior.rollback ||
 			opaqueBefore === 0 ||
 			removed <= opaqueBefore * BACKGROUND_RAMP_LIMITS.maxRemovalRatio
 		) {
@@ -189,6 +198,7 @@ export const removeBackgroundByFloodFillLegacy = (
 		| "top-right"
 		| "bottom-right"
 		| "rgb",
+	behavior: BackgroundBehavior = DEFAULT_BACKGROUND_BEHAVIOR,
 ): RawImage => {
 	if (method === "none") return cloneImage(img);
 
@@ -200,37 +210,42 @@ export const removeBackgroundByFloodFillLegacy = (
 	if (method === "rgb") {
 		if (bgTargets.length === 0) return cloneImage(img);
 		const src32 = new Uint32Array(img.data.buffer);
-		return fillWithRampFallback(img, tolerance, (out, ramp) => {
-			const visited = new Uint8Array(w * h);
-			for (let y = 0; y < h; y += 1) {
-				const row = y * w;
-				for (let x = 0; x < w; x += 1) {
-					const idx = row + x;
-					if (visited[idx]) continue;
+		return fillWithRampFallback(
+			img,
+			tolerance,
+			(out, ramp) => {
+				const visited = new Uint8Array(w * h);
+				for (let y = 0; y < h; y += 1) {
+					const row = y * w;
+					for (let x = 0; x < w; x += 1) {
+						const idx = row + x;
+						if (visited[idx]) continue;
 
-					const pixel = src32[idx];
-					const r = pixel & 0xff;
-					const g = (pixel >> 8) & 0xff;
-					const b = (pixel >> 16) & 0xff;
+						const pixel = src32[idx];
+						const r = pixel & 0xff;
+						const g = (pixel >> 8) & 0xff;
+						const b = (pixel >> 16) & 0xff;
 
-					if (isCandidate(r, g, b, bgTargets, tolerance)) {
-						const a = out.data[idx * 4 + 3];
-						if (a !== 0) {
-							floodFillTransparent(
-								out,
-								x,
-								y,
-								tolerance,
-								visited,
-								connectivity,
-								ramp,
-							);
+						if (isCandidate(r, g, b, bgTargets, tolerance)) {
+							const a = out.data[idx * 4 + 3];
+							if (a !== 0) {
+								floodFillTransparent(
+									out,
+									x,
+									y,
+									tolerance,
+									visited,
+									connectivity,
+									ramp,
+								);
+							}
 						}
+						visited[idx] = 1;
 					}
-					visited[idx] = 1;
 				}
-			}
-		});
+			},
+			behavior,
+		);
 	}
 
 	// 角の方式: 選択した角からのみフラッドフィルする（旧来の挙動）。
@@ -244,9 +259,22 @@ export const removeBackgroundByFloodFillLegacy = (
 		sx = w - 1;
 		sy = h - 1;
 	}
-	return fillWithRampFallback(img, tolerance, (out, ramp) => {
-		floodFillTransparent(out, sx, sy, tolerance, undefined, connectivity, ramp);
-	});
+	return fillWithRampFallback(
+		img,
+		tolerance,
+		(out, ramp) => {
+			floodFillTransparent(
+				out,
+				sx,
+				sy,
+				tolerance,
+				undefined,
+				connectivity,
+				ramp,
+			);
+		},
+		behavior,
+	);
 };
 
 /**
@@ -327,6 +355,7 @@ export const removeBackground = (
 		| "bottom-right"
 		| "rgb",
 	automaticModel?: BackgroundModel,
+	behavior: BackgroundBehavior = DEFAULT_BACKGROUND_BEHAVIOR,
 	// [Intended] 自動除去のロールバックは呼び出し側の診断へ集約する必要があるため、
 	// 戻り値を画像のままにして、この出力引数へ書き戻す。
 	outcome?: { removalRolledBack: boolean },
@@ -340,6 +369,7 @@ export const removeBackground = (
 			bgRemovalScope,
 			bgConnectivity,
 			automaticModel,
+			behavior,
 		);
 		if (outcome && automatic.rolledBack) outcome.removalRolledBack = true;
 		return automatic.image;
@@ -353,6 +383,7 @@ export const removeBackground = (
 			bgConnectivity,
 			bgTargets,
 			method,
+			behavior,
 		);
 	}
 
@@ -360,46 +391,57 @@ export const removeBackground = (
 		const w = img.width;
 		const h = img.height;
 		const border = getBorderPixels(w, h);
-		const outer = fillWithRampFallback(img, tolerance, (out, ramp) => {
-			const visited = new Uint8Array(w * h);
-			const data = out.data;
+		const outer = fillWithRampFallback(
+			img,
+			tolerance,
+			(out, ramp) => {
+				const visited = new Uint8Array(w * h);
+				const data = out.data;
 
-			const fillFrom = (sx: number, sy: number): void => {
-				if (sx < 0 || sy < 0 || sx >= w || sy >= h) return;
-				const idx = sy * w + sx;
-				if (visited[idx]) return;
-				const i = idx * 4;
-				if (data[i + 3] === 0) return;
-				if (bgTargets.length > 0) {
-					const r = data[i];
-					const g = data[i + 1];
-					const b = data[i + 2];
-					if (!isCandidate(r, g, b, bgTargets, tolerance)) return;
-				}
-				floodFillTransparent(
-					out,
-					sx,
-					sy,
-					tolerance,
-					visited,
-					bgConnectivity,
-					ramp,
-				);
-			};
+				const fillFrom = (sx: number, sy: number): void => {
+					if (sx < 0 || sy < 0 || sx >= w || sy >= h) return;
+					const idx = sy * w + sx;
+					if (visited[idx]) return;
+					const i = idx * 4;
+					if (data[i + 3] === 0) return;
+					if (bgTargets.length > 0) {
+						const r = data[i];
+						const g = data[i + 1];
+						const b = data[i + 2];
+						if (!isCandidate(r, g, b, bgTargets, tolerance)) return;
+					}
+					floodFillTransparent(
+						out,
+						sx,
+						sy,
+						tolerance,
+						visited,
+						bgConnectivity,
+						ramp,
+					);
+				};
 
-			for (const [x, y] of border) {
-				const idx = y * w + x;
-				const i = idx * 4;
-				if (data[i + 3] === 0) continue;
-				if (
-					bgTargets.length > 0 &&
-					!isCandidate(data[i], data[i + 1], data[i + 2], bgTargets, tolerance)
-				) {
-					continue;
+				for (const [x, y] of border) {
+					const idx = y * w + x;
+					const i = idx * 4;
+					if (data[i + 3] === 0) continue;
+					if (
+						bgTargets.length > 0 &&
+						!isCandidate(
+							data[i],
+							data[i + 1],
+							data[i + 2],
+							bgTargets,
+							tolerance,
+						)
+					) {
+						continue;
+					}
+					fillFrom(x, y);
 				}
-				fillFrom(x, y);
-			}
-		});
+			},
+			behavior,
+		);
 		if (bgRemovalScope === "auto") {
 			removeEnclosedTargets(outer, tolerance, bgConnectivity, bgTargets);
 		}
@@ -416,6 +458,7 @@ export const removeBackground = (
 		"4",
 		bgTargets,
 		method,
+		behavior,
 	);
 	if (bgTargets.length === 0) return out;
 

--- a/src/core/background.ts
+++ b/src/core/background.ts
@@ -1,4 +1,4 @@
-import { BACKGROUND_MODEL_LIMITS } from "../shared/config";
+import { BACKGROUND_MODEL_LIMITS, PROCESS_DEFAULTS } from "../shared/config";
 import type {
 	BackgroundRemovalScope,
 	Connectivity,
@@ -31,6 +31,33 @@ export type AutomaticBackgroundResult = {
 	model: BackgroundModel;
 	removedRatio: number;
 	rolledBack: boolean;
+};
+
+/**
+ * 背景処理の自動判定のうち、呼び出し側から個別に切れるようにしたもの。
+ *
+ * [Intended] 既定はすべて有効で、従来の挙動と一致する。設定から切れるようにするのが
+ * 目的なので、ここで新しい判定を足したり既定を反転させたりはしない。
+ */
+export type BackgroundBehavior = {
+	/** 縁のにじみを背景色から遠ざける補正。 */
+	dehalo: boolean;
+	/** 消えすぎ検出による除去の巻き戻し。 */
+	rollback: boolean;
+	/** 信頼度が下限未満のときに除去を見送る判定。 */
+	confidenceGate: boolean;
+	/** 境界帯が透明優位のときに色クラスタ推定を行わない判定。 */
+	alphaBorderGuard: boolean;
+	/** なめらかなグラデーション背景をたどるランプ許容。 */
+	rampFollow: boolean;
+};
+
+export const DEFAULT_BACKGROUND_BEHAVIOR: BackgroundBehavior = {
+	dehalo: PROCESS_DEFAULTS.backgroundDehalo,
+	rollback: PROCESS_DEFAULTS.backgroundRemovalRollback,
+	confidenceGate: PROCESS_DEFAULTS.backgroundConfidenceGate,
+	alphaBorderGuard: PROCESS_DEFAULTS.alphaBorderBackgroundGuard,
+	rampFollow: PROCESS_DEFAULTS.backgroundRampFollow,
 };
 
 const clampUnit = (value: number): number => Math.max(0, Math.min(1, value));
@@ -115,7 +142,10 @@ const isInBorderBand = (
 	band: number,
 ): boolean => x < band || y < band || x >= width - band || y >= height - band;
 
-export const estimateBackgroundModel = (img: RawImage): BackgroundModel => {
+export const estimateBackgroundModel = (
+	img: RawImage,
+	behavior: BackgroundBehavior = DEFAULT_BACKGROUND_BEHAVIOR,
+): BackgroundModel => {
 	const width = img.width;
 	const height = img.height;
 	const band = getBandSize(width, height);
@@ -151,8 +181,9 @@ export const estimateBackgroundModel = (img: RawImage): BackgroundModel => {
 	// 削ってしまう。アルファが背景を確定させている状況なので confidence は最大とし、
 	// 後段の小領域除去は許可する。
 	if (
+		behavior.alphaBorderGuard &&
 		guardTransparentCount / totalBorderCount >=
-		BACKGROUND_MODEL_LIMITS.alphaBackgroundBorderRatio
+			BACKGROUND_MODEL_LIMITS.alphaBackgroundBorderRatio
 	) {
 		return {
 			clusters: [],
@@ -698,12 +729,14 @@ export const removeAutomaticBackground = (
 	scope: BackgroundRemovalScope,
 	connectivity: Connectivity,
 	providedModel?: BackgroundModel,
+	behavior: BackgroundBehavior = DEFAULT_BACKGROUND_BEHAVIOR,
 ): AutomaticBackgroundResult => {
-	const model = providedModel ?? estimateBackgroundModel(img);
+	const model = providedModel ?? estimateBackgroundModel(img, behavior);
 	if (
 		scope === "off" ||
 		model.clusters.length === 0 ||
-		model.confidence < BACKGROUND_MODEL_LIMITS.minConfidence
+		(behavior.confidenceGate &&
+			model.confidence < BACKGROUND_MODEL_LIMITS.minConfidence)
 	) {
 		return {
 			image: cloneImage(img),
@@ -737,7 +770,10 @@ export const removeAutomaticBackground = (
 		if (selected[pixel]) removed += 1;
 	}
 	const removedRatio = opaqueBefore === 0 ? 0 : removed / opaqueBefore;
-	if (removedRatio > BACKGROUND_MODEL_LIMITS.maxContentLossRatio) {
+	if (
+		behavior.rollback &&
+		removedRatio > BACKGROUND_MODEL_LIMITS.maxContentLossRatio
+	) {
 		return {
 			image: cloneImage(img),
 			model,
@@ -751,6 +787,6 @@ export const removeAutomaticBackground = (
 			output.data[pixel * 4 + 3] = 0;
 		}
 	}
-	applyDehalo(output, model);
+	if (behavior.dehalo) applyDehalo(output, model);
 	return { image: output, model, removedRatio, rolledBack: false };
 };

--- a/src/core/components.ts
+++ b/src/core/components.ts
@@ -28,6 +28,11 @@ export type SmallComponentRemovalOptions = {
 	backgroundEnabled: boolean;
 	automaticBackground: boolean;
 	backgroundConfidence?: number;
+	/**
+	 * 背景モデルの信頼度が下限未満のときに除去を見送るか。
+	 * [Intended] 既定は従来どおり見送る。設定から切れるようにするためだけの受け口。
+	 */
+	backgroundConfidenceGate?: boolean;
 };
 
 export type SmallComponentRemovalResult = {
@@ -360,6 +365,7 @@ export const removeSmallComponents = (
 		};
 	}
 	if (
+		(options.backgroundConfidenceGate ?? true) &&
 		options.automaticBackground &&
 		(options.backgroundConfidence === undefined ||
 			options.backgroundConfidence < BACKGROUND_MODEL_LIMITS.minConfidence)

--- a/src/core/detector.ts
+++ b/src/core/detector.ts
@@ -10,6 +10,12 @@ import { extractStrip, posterize } from "./ops";
 type Run = { start: number; length: number; color: [number, number, number] };
 type Segment = { start: number; runs: Run[] };
 
+/**
+ * 自動検出で各軸から抜き取るサンプルストリップの本数。
+ * [Policy] 検出の安定性と速度の釣り合いで決めた固定値。呼び出し側から変える手段は持たない。
+ */
+const DETECTION_STRIP_COUNT = 12;
+
 const quantize = (value: number, step: number): number => {
 	if (step <= 0) {
 		return value;
@@ -139,15 +145,10 @@ export type DetectOptions = {
 	detectionQuantStep?: number;
 	/**
 	 * 自動検出する最大セル数（outW/outH の上限）。
-	 * デフォルトは 128。
+	 * デフォルト: 512
 	 */
 	autoMaxCellsW?: number;
 	autoMaxCellsH?: number;
-	/**
-	 * 自動検出のサンプルストリップ数（各軸）。大きいほど安定するが遅くなる。
-	 * デフォルト: 12
-	 */
-	detectionStrips?: number;
 	/**
 	 * 背景色を推測し、検出前にマスクする（背景ノイズに対応するため）。
 	 * デフォルト: true
@@ -302,7 +303,7 @@ export const detectGrid = (
 		return picked;
 	};
 
-	const stripCount = options.detectionStrips ?? 12;
+	const stripCount = DETECTION_STRIP_COUNT;
 	const shouldMaskBackground = options.backgroundMask ?? true;
 	const backgroundMaskTolerance = Math.min(
 		PROCESS_RANGES.backgroundMaskTolerance.max,

--- a/src/core/detector.ts
+++ b/src/core/detector.ts
@@ -360,11 +360,19 @@ export const detectGrid = (
 
 	// 高解像度対応: 1000px 超の画像では、4〜5px のドットに対して 128 では小さすぎる。
 	// より細かいグリッドに対応するため、デフォルトを 512 に引き上げる。
+	const clampAutoMaxCells = (value: number | undefined): number =>
+		Math.min(
+			PROCESS_RANGES.autoMaxCells.max,
+			Math.max(
+				PROCESS_RANGES.autoMaxCells.min,
+				Math.trunc(value ?? PROCESS_RANGES.autoMaxCells.default),
+			),
+		);
 	const expMinX = Math.min(w, 8);
-	const expMaxX = options.autoMaxCellsW ?? 512;
+	const expMaxX = clampAutoMaxCells(options.autoMaxCellsW);
 	const twX = 2.0;
 	const expMinY = Math.min(h, 8);
-	const expMaxY = options.autoMaxCellsH ?? 512;
+	const expMaxY = clampAutoMaxCells(options.autoMaxCellsH);
 	const twY = 2.0;
 
 	type BoundaryData = { runLengths: number[]; boundaries: number[] };

--- a/src/core/gemini-watermark-preprocessing.ts
+++ b/src/core/gemini-watermark-preprocessing.ts
@@ -55,7 +55,7 @@ export const getGeminiWatermarkDownsampleOptions = (
 	removed: boolean,
 ): ReturnType<typeof getDownsampleOptions> =>
 	getDownsampleOptions(
-		removed && options.watermarkSamplingCompat
+		removed && options.watermarkSamplingCompatEnabled
 			? { ...options, cellSamplingMode: "legacy-median" }
 			: options,
 	);

--- a/src/core/gemini-watermark-preprocessing.ts
+++ b/src/core/gemini-watermark-preprocessing.ts
@@ -9,6 +9,7 @@ import {
 } from "./gemini-watermark";
 import { downsample } from "./image-operations";
 import {
+	getBackgroundBehavior,
 	getDownsampleOptions,
 	type NormalizedProcessOptions,
 } from "./processor-options";
@@ -54,7 +55,7 @@ export const getGeminiWatermarkDownsampleOptions = (
 	removed: boolean,
 ): ReturnType<typeof getDownsampleOptions> =>
 	getDownsampleOptions(
-		removed && options.processingMode === "auto"
+		removed && options.watermarkSamplingCompat
 			? { ...options, cellSamplingMode: "legacy-median" }
 			: options,
 	);
@@ -95,6 +96,7 @@ export const prepareGeminiWatermarkAwareAutoMask = (
 		input.backgroundTargets,
 		input.options.bgExtractionMethod,
 		input.backgroundModel,
+		getBackgroundBehavior(input.options),
 	);
 };
 
@@ -155,6 +157,7 @@ export const prepareGeminiWatermarkGeometry = (
 		backgroundTargets,
 		backgroundMethod,
 		input.backgroundModel,
+		getBackgroundBehavior(input.options),
 	);
 	return { image, working, mask, removed, finish };
 };

--- a/src/core/gemini-watermark.ts
+++ b/src/core/gemini-watermark.ts
@@ -13,7 +13,10 @@ import {
 	type MappedRemovalMode,
 } from "./gemini-watermark-mapping";
 import { cloneImage } from "./image-operations";
-import type { NormalizedProcessOptions } from "./processor-options";
+import {
+	getBackgroundBehavior,
+	type NormalizedProcessOptions,
+} from "./processor-options";
 
 type SearchRegion = {
 	x: number;
@@ -422,7 +425,9 @@ export const createGeminiWatermarkDetectionMask = (
 			options.backgroundTolerance,
 			undefined,
 			options.bgConnectivity,
-			detectBackgroundRamp(inputImage, options.backgroundTolerance),
+			options.backgroundRampFollow
+				? detectBackgroundRamp(inputImage, options.backgroundTolerance)
+				: undefined,
 		);
 		return { image: detectionMask, mode: "background" };
 	}
@@ -434,6 +439,8 @@ export const createGeminiWatermarkDetectionMask = (
 			options.bgConnectivity,
 			getBackgroundTargets(inputImage, method, options.bgRgb),
 			method,
+			undefined,
+			getBackgroundBehavior(options),
 		),
 		// [Intended] 確定出力が不透明なロールバック時は、透明穴ではなく周囲の背景色へ置換する。
 		mode: "background",

--- a/src/core/processor-background.ts
+++ b/src/core/processor-background.ts
@@ -5,7 +5,10 @@ import {
 	estimateBackgroundModel,
 	removeAutomaticBackground,
 } from "./background";
-import type { NormalizedProcessOptions } from "./processor-options";
+import {
+	getBackgroundBehavior,
+	type NormalizedProcessOptions,
+} from "./processor-options";
 
 export const prepareAutomaticBackground = (
 	image: RawImage,
@@ -26,8 +29,9 @@ export const prepareAutomaticBackground = (
 	}
 	// [Intended] 事前除去が無効な場合、除去済み画像は後段で使われず捨てられるため、
 	// 原寸画像に対してはモデル推定だけを行う。
+	const behavior = getBackgroundBehavior(options);
 	if (!options.preRemoveBackground) {
-		const model = estimateBackgroundModel(image);
+		const model = estimateBackgroundModel(image, behavior);
 		return {
 			backgroundModel: model,
 			backgroundDiagnostic: {
@@ -41,6 +45,8 @@ export const prepareAutomaticBackground = (
 		options.backgroundTolerance,
 		options.bgRemovalScope,
 		options.bgConnectivity,
+		undefined,
+		behavior,
 	);
 	return {
 		automaticBackground,

--- a/src/core/processor-behavior-flags.test.ts
+++ b/src/core/processor-behavior-flags.test.ts
@@ -6,7 +6,10 @@ import {
 	removeAutomaticBackground,
 } from "./background";
 import { getBackgroundTargets, removeBackground } from "./background-removal";
+import { removeSmallComponents } from "./components";
+import { resolveProcessingGrid } from "./processor-grid-resolution";
 import { normalizeProcessOptions } from "./processor-options";
+import { getGridSearchFromTrimmedStrategy } from "./trimmed-grid-search";
 
 const createImage = (
 	width: number,
@@ -91,6 +94,83 @@ describe("auto behavior settings", () => {
 				watermarkSamplingCompat: "off",
 			}).watermarkSamplingCompat,
 		).toBe(false);
+	});
+});
+
+/**
+ * セル境界だけが強いエッジで、セル内部には弱い濃淡がある市松画像。
+ *
+ * [Intended] 再構成誤差だけでは正解セルの整数分の 1 を選ぶため、境界コントラストの
+ * 乗り換えが効いているかどうかが出力サイズの違いとして表れる。
+ */
+const createNestedBlockImage = (
+	size: number,
+	cell: number,
+	sub: number,
+	subAmplitude: number,
+): RawImage => {
+	const data = new Uint8ClampedArray(size * size * 4);
+	for (let y = 0; y < size; y += 1) {
+		for (let x = 0; x < size; x += 1) {
+			const base =
+				(Math.floor(x / cell) + Math.floor(y / cell)) % 2 === 0 ? 40 : 216;
+			const subX = Math.floor((x % cell) / sub);
+			const subY = Math.floor((y % cell) / sub);
+			const wobble = (((subX * 3 + subY * 5) % 3) - 1) * subAmplitude;
+			const value = base + (base < 128 ? wobble : -wobble);
+			const offset = (y * size + x) * 4;
+			data[offset] = value;
+			data[offset + 1] = value;
+			data[offset + 2] = value;
+			data[offset + 3] = 255;
+		}
+	}
+	return { width: size, height: size, data };
+};
+
+/** 論理セルごとに明暗が入れ替わる、位相の揃った市松画像。 */
+const createPhaseAlignedGrid = (
+	logicalSize: number,
+	cell: number,
+): RawImage => {
+	const size = logicalSize * cell;
+	return createImage(size, size, (x, y) => {
+		const value =
+			(Math.floor(x / cell) + Math.floor(y / cell)) % 2 === 0 ? 48 : 208;
+		return [value, value, value, 255];
+	});
+};
+
+describe("grid search behavior flags", () => {
+	it("stops using the phase-aware estimate when the search is disabled", () => {
+		const image = createPhaseAlignedGrid(8, 4);
+		const resolve = (phaseAwareGridSearch: boolean) =>
+			resolveProcessingGrid({
+				o: normalizeProcessOptions({ phaseAwareGridSearch }),
+				working: image,
+				geometryImage: image,
+				geometryWorking: image,
+				maskedForDebugOrAuto: image,
+				bgTargets: [],
+				trimAlphaThreshold: 16,
+				watermarkRemovedFromGeometry: false,
+				log: () => {},
+			});
+
+		expect(resolve(true).gridMethod).toBe("phase-aware-grid-search");
+		expect(resolve(false).gridMethod).toBe("trimmed-reconstruction-fast");
+	});
+
+	it("stops switching to the coarser harmonic when the override is disabled", () => {
+		// [Intended] 位置引数で渡しているうえ既定値が true なので、配線が外れても
+		// 型エラーにも既存テストの失敗にもならない。効果の差でだけ検出できる。
+		const image = createNestedBlockImage(192, 24, 8, 30);
+		const strategy = getGridSearchFromTrimmedStrategy(true);
+
+		expect(strategy.search(image, image, 3)?.outH).toBe(8);
+		expect(
+			strategy.search(image, image, 3, undefined, undefined, false)?.outH,
+		).toBe(24);
 	});
 });
 
@@ -216,6 +296,43 @@ describe("background behavior flags", () => {
 		expect(model.confidence).toBeLessThan(0.55);
 		expect(gated.image.data).toEqual(image.data);
 		expect(ungated.image.data).not.toEqual(image.data);
+	});
+
+	it("removes a speck with a low-confidence background once the small-component gate is off", () => {
+		// 主要な塊と、離れた 1 画素の弱い小片。背景モデルの信頼度は下限未満。
+		const main = (x: number, y: number) => x >= 1 && x <= 4 && y >= 2 && y <= 7;
+		const speck = (x: number, y: number) => x === 10 && y === 8;
+		const mask = createImage(12, 10, (x, y) =>
+			main(x, y)
+				? [40, 60, 80, 255]
+				: speck(x, y)
+					? [120, 120, 120, 255]
+					: [0, 0, 0, 0],
+		);
+		const evidence = createImage(12, 10, (x, y) =>
+			main(x, y)
+				? [40, 60, 80, 255]
+				: speck(x, y)
+					? [20, 20, 20, 32]
+					: [0, 0, 0, 0],
+		);
+		const options = {
+			mode: "auto" as const,
+			alphaThreshold: 16,
+			backgroundEnabled: true,
+			automaticBackground: true,
+			backgroundConfidence: 0,
+		};
+		const gated = removeSmallComponents(mask, mask, evidence, options);
+		const ungated = removeSmallComponents(mask, mask, evidence, {
+			...options,
+			backgroundConfidenceGate: false,
+		});
+
+		expect(gated.diagnostic.skippedReason).toBe("low-background-confidence");
+		expect(alphaAt(gated.image, 10, 8)).toBe(255);
+		expect(ungated.diagnostic.applied).toBe(true);
+		expect(alphaAt(ungated.image, 10, 8)).toBe(0);
 	});
 
 	it("estimates colour clusters on a transparent border once the guard is off", () => {

--- a/src/core/processor-behavior-flags.test.ts
+++ b/src/core/processor-behavior-flags.test.ts
@@ -52,19 +52,19 @@ describe("auto behavior settings", () => {
 	it("follows the processing route while the setting stays at auto", () => {
 		expect(
 			normalizeProcessOptions({ processingMode: "auto" })
-				.smallAspectGridAlignment,
+				.smallAspectGridAlignmentEnabled,
 		).toBe(true);
 		expect(
 			normalizeProcessOptions({ processingMode: "refine" })
-				.smallAspectGridAlignment,
+				.smallAspectGridAlignmentEnabled,
 		).toBe(false);
 		expect(
 			normalizeProcessOptions({ processingMode: "auto" })
-				.watermarkSamplingCompat,
+				.watermarkSamplingCompatEnabled,
 		).toBe(true);
 		expect(
 			normalizeProcessOptions({ processingMode: "preserve" })
-				.watermarkSamplingCompat,
+				.watermarkSamplingCompatEnabled,
 		).toBe(false);
 	});
 
@@ -74,25 +74,25 @@ describe("auto behavior settings", () => {
 			normalizeProcessOptions({
 				processingMode: "refine",
 				smallAspectGridAlignment: "on",
-			}).smallAspectGridAlignment,
+			}).smallAspectGridAlignmentEnabled,
 		).toBe(true);
 		expect(
 			normalizeProcessOptions({
 				processingMode: "auto",
 				smallAspectGridAlignment: "off",
-			}).smallAspectGridAlignment,
+			}).smallAspectGridAlignmentEnabled,
 		).toBe(false);
 		expect(
 			normalizeProcessOptions({
 				processingMode: "refine",
 				watermarkSamplingCompat: "on",
-			}).watermarkSamplingCompat,
+			}).watermarkSamplingCompatEnabled,
 		).toBe(true);
 		expect(
 			normalizeProcessOptions({
 				processingMode: "auto",
 				watermarkSamplingCompat: "off",
-			}).watermarkSamplingCompat,
+			}).watermarkSamplingCompatEnabled,
 		).toBe(false);
 	});
 });

--- a/src/core/processor-behavior-flags.test.ts
+++ b/src/core/processor-behavior-flags.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import type { RawImage } from "../shared/types";
+import {
+	DEFAULT_BACKGROUND_BEHAVIOR,
+	estimateBackgroundModel,
+	removeAutomaticBackground,
+} from "./background";
+import { getBackgroundTargets, removeBackground } from "./background-removal";
+import { normalizeProcessOptions } from "./processor-options";
+
+const createImage = (
+	width: number,
+	height: number,
+	pixel: (x: number, y: number) => [number, number, number, number],
+): RawImage => {
+	const data = new Uint8ClampedArray(width * height * 4);
+	for (let y = 0; y < height; y += 1) {
+		for (let x = 0; x < width; x += 1) {
+			const [r, g, b, a] = pixel(x, y);
+			const offset = (y * width + x) * 4;
+			data[offset] = r;
+			data[offset + 1] = g;
+			data[offset + 2] = b;
+			data[offset + 3] = a;
+		}
+	}
+	return { width, height, data };
+};
+
+const alphaAt = (image: RawImage, x: number, y: number): number =>
+	image.data[(y * image.width + x) * 4 + 3];
+
+/** 直線グラデーションのパディングが 32x32 のアートを 8px 囲む構成。 */
+const createGradientPaddedArt = (): RawImage =>
+	createImage(48, 48, (x, y) => {
+		if (x >= 8 && x <= 39 && y >= 8 && y <= 39) {
+			const edge = x === 8 || x === 39 || y === 8 || y === 39;
+			return edge ? [35, 28, 44, 255] : [218, 74, 72, 255];
+		}
+		return [
+			Math.round((x / 47) * 90) + 120,
+			Math.round((y / 47) * 80) + 130,
+			180,
+			255,
+		];
+	});
+
+describe("auto behavior settings", () => {
+	it("follows the processing route while the setting stays at auto", () => {
+		expect(
+			normalizeProcessOptions({ processingMode: "auto" })
+				.smallAspectGridAlignment,
+		).toBe(true);
+		expect(
+			normalizeProcessOptions({ processingMode: "refine" })
+				.smallAspectGridAlignment,
+		).toBe(false);
+		expect(
+			normalizeProcessOptions({ processingMode: "auto" })
+				.watermarkSamplingCompat,
+		).toBe(true);
+		expect(
+			normalizeProcessOptions({ processingMode: "preserve" })
+				.watermarkSamplingCompat,
+		).toBe(false);
+	});
+
+	it("lets an explicit choice win over the processing route", () => {
+		// [Intended] これが「手動 refine で Auto と同じ出力を再現する」ための入口になる。
+		expect(
+			normalizeProcessOptions({
+				processingMode: "refine",
+				smallAspectGridAlignment: "on",
+			}).smallAspectGridAlignment,
+		).toBe(true);
+		expect(
+			normalizeProcessOptions({
+				processingMode: "auto",
+				smallAspectGridAlignment: "off",
+			}).smallAspectGridAlignment,
+		).toBe(false);
+		expect(
+			normalizeProcessOptions({
+				processingMode: "refine",
+				watermarkSamplingCompat: "on",
+			}).watermarkSamplingCompat,
+		).toBe(true);
+		expect(
+			normalizeProcessOptions({
+				processingMode: "auto",
+				watermarkSamplingCompat: "off",
+			}).watermarkSamplingCompat,
+		).toBe(false);
+	});
+});
+
+describe("background behavior flags", () => {
+	it("keeps every automatic judgement enabled by default", () => {
+		const options = normalizeProcessOptions({});
+
+		expect(options.backgroundDehalo).toBe(true);
+		expect(options.backgroundEdgeCleanup).toBe(true);
+		expect(options.backgroundRampFollow).toBe(true);
+		expect(options.backgroundRemovalRollback).toBe(true);
+		expect(options.alphaBorderBackgroundGuard).toBe(true);
+		expect(options.backgroundConfidenceGate).toBe(true);
+		expect(options.smallComponentBackgroundGate).toBe(true);
+		expect(options.phaseAwareGridSearch).toBe(true);
+		expect(options.boundaryContrastOverride).toBe(true);
+	});
+
+	it("stops following a gradient background when the ramp is disabled", () => {
+		const image = createGradientPaddedArt();
+		const targets = getBackgroundTargets(image, "top-left");
+		const withRamp = removeBackground(
+			image,
+			48,
+			"all",
+			"4",
+			targets,
+			"top-left",
+		);
+		const withoutRamp = removeBackground(
+			image,
+			48,
+			"all",
+			"4",
+			targets,
+			"top-left",
+			undefined,
+			{ ...DEFAULT_BACKGROUND_BEHAVIOR, rampFollow: false },
+		);
+
+		// ランプ許容があると反対側の角まで落ちる。切ると開始色から離れた角が残る。
+		expect(alphaAt(withRamp, 47, 47)).toBe(0);
+		expect(alphaAt(withoutRamp, 0, 0)).toBe(0);
+		expect(alphaAt(withoutRamp, 47, 47)).toBe(255);
+	});
+
+	it("leaves the halo untouched when dehalo is disabled", () => {
+		// 背景色と被写体色の中間にあるアンチエイリアス縁を 1 周ぶん持たせる。
+		const image = createImage(24, 24, (x, y) => {
+			const inner = x >= 9 && x <= 14 && y >= 9 && y <= 14;
+			const edge = x >= 8 && x <= 15 && y >= 8 && y <= 15;
+			if (inner) return [40, 60, 200, 255];
+			if (edge) return [150, 160, 220, 255];
+			return [235, 238, 240, 255];
+		});
+		const withDehalo = removeAutomaticBackground(image, 40, "outer", "4");
+		const withoutDehalo = removeAutomaticBackground(
+			image,
+			40,
+			"outer",
+			"4",
+			undefined,
+			{ ...DEFAULT_BACKGROUND_BEHAVIOR, dehalo: false },
+		);
+
+		expect(withDehalo.rolledBack).toBe(false);
+		expect(withoutDehalo.rolledBack).toBe(false);
+		// 補正を切った側は原寸の縁の色がそのまま残る。
+		const edgeOffset = (8 * 24 + 11) * 4;
+		expect(withoutDehalo.image.data[edgeOffset]).toBe(image.data[edgeOffset]);
+		expect(withDehalo.image.data).not.toEqual(withoutDehalo.image.data);
+	});
+
+	it("skips the over-removal rollback when it is disabled", () => {
+		// 全面がなめらかなグラデーションで、被写体との強い境界が無い画像。
+		const image = createImage(48, 48, (x, y) => [
+			Math.round(((x + y) / 94) * 200) + 30,
+			120,
+			180,
+			255,
+		]);
+		const targets = getBackgroundTargets(image, "top-left");
+		const withRollback = removeBackground(
+			image,
+			48,
+			"all",
+			"4",
+			targets,
+			"top-left",
+		);
+		const withoutRollback = removeBackground(
+			image,
+			48,
+			"all",
+			"4",
+			targets,
+			"top-left",
+			undefined,
+			{ ...DEFAULT_BACKGROUND_BEHAVIOR, rollback: false },
+		);
+
+		expect(alphaAt(withRollback, 24, 24)).toBe(255);
+		expect(alphaAt(withoutRollback, 24, 24)).toBe(0);
+	});
+
+	it("removes a low-confidence background once the confidence gate is off", () => {
+		// 境界帯の色がばらつき、信頼度が下限に届かない画像。
+		const image = createImage(32, 32, (x, y) => {
+			if (x >= 12 && x <= 19 && y >= 12 && y <= 19) return [20, 20, 20, 255];
+			return [(x * 37) % 256, (y * 53) % 256, (x * y * 11) % 256, 255];
+		});
+		const model = estimateBackgroundModel(image);
+		const gated = removeAutomaticBackground(image, 32, "outer", "4");
+		const ungated = removeAutomaticBackground(
+			image,
+			32,
+			"outer",
+			"4",
+			undefined,
+			{ ...DEFAULT_BACKGROUND_BEHAVIOR, confidenceGate: false },
+		);
+
+		expect(model.confidence).toBeLessThan(0.55);
+		expect(gated.image.data).toEqual(image.data);
+		expect(ungated.image.data).not.toEqual(image.data);
+	});
+
+	it("estimates colour clusters on a transparent border once the guard is off", () => {
+		// 境界帯の大半が透明で、不透明な外周は被写体の輪郭だけという画像。
+		const image = createImage(32, 32, (x, y) => {
+			const ring = x === 0 || y === 0 || x === 31 || y === 31;
+			if (ring && x >= 12 && x <= 19) return [200, 40, 40, 255];
+			if (ring) return [0, 0, 0, 0];
+			if (x >= 8 && x <= 23 && y >= 8 && y <= 23) return [200, 40, 40, 255];
+			return [0, 0, 0, 0];
+		});
+
+		expect(estimateBackgroundModel(image).clusters).toHaveLength(0);
+		expect(
+			estimateBackgroundModel(image, {
+				...DEFAULT_BACKGROUND_BEHAVIOR,
+				alphaBorderGuard: false,
+			}).clusters.length,
+		).toBeGreaterThan(0);
+	});
+});

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -27,6 +27,7 @@ import {
 } from "./image-operations";
 import { applyOutline } from "./outline";
 import { createProcessingAnalysis } from "./processing-analysis";
+import { getBackgroundBehavior } from "./processor-options";
 import type { SimpleRouteContext } from "./processor-simple-routes";
 
 const gridForCandidate = (
@@ -94,6 +95,7 @@ export const processConvertRoute = (
 		backgroundDiagnostic,
 		backgroundModel,
 	} = context;
+	const behavior = getBackgroundBehavior(o);
 	let smallComponentRemoval = context.smallComponentRemoval;
 	// [Intended] 呼び出し元が同じマスクを算出済みなら再計算しない。
 	// 孤立成分の除去は working を破壊的に書き換えるため、2 度走らせると
@@ -110,6 +112,7 @@ export const processConvertRoute = (
 					bgTargets,
 					o.bgExtractionMethod,
 					backgroundModel,
+					behavior,
 				)
 			: undefined);
 	if (masked && !context.preparedMask && o.floatingMaxPixels > 0) {
@@ -186,6 +189,7 @@ export const processConvertRoute = (
 					bgTargets,
 					o.bgExtractionMethod,
 					backgroundModel,
+					behavior,
 				)
 			: finalResult;
 	const componentResult = removeSmallComponents(
@@ -199,6 +203,7 @@ export const processConvertRoute = (
 				o.bgExtractionMethod !== "none" && o.bgRemovalScope !== "off",
 			automaticBackground: o.bgExtractionMethod === "auto",
 			backgroundConfidence: backgroundDiagnostic?.confidence,
+			backgroundConfidenceGate: o.smallComponentBackgroundGate,
 		},
 	);
 	if (o.smallComponentMode !== "off") {
@@ -215,6 +220,7 @@ export const processConvertRoute = (
 			bgTargets,
 			o.bgExtractionMethod,
 			backgroundModel,
+			behavior,
 			backgroundDiagnostic,
 		);
 	}

--- a/src/core/processor-grid-resolution.ts
+++ b/src/core/processor-grid-resolution.ts
@@ -129,6 +129,9 @@ export const resolveProcessingGrid = ({
 								(selectedEstimate.outH ?? 0) * (b.w / Math.max(1, b.h)),
 							),
 						);
+				// [Intended] この設定は格子の基準領域だけでなく Auto の経路判定にも効く。
+				// 「常に無効」にすると小さな格子が許可されず、refine から preserve へ
+				// フォールバックする場合がある（ツールチップにも同じ注意を書いている）。
 				allowSmallTrimmedGrid = isSmallAspectAdjustedGrid;
 				// [Intended] トリミング領域で推定した格子は、元画像の左上へ投影せず
 				// コンテンツ BBox をそのままサンプリング領域として使う。

--- a/src/core/processor-grid-resolution.ts
+++ b/src/core/processor-grid-resolution.ts
@@ -115,7 +115,7 @@ export const resolveProcessingGrid = ({
 				const selectedEstimate = phaseAwareReliable ? phaseAwareEstimate : est;
 				const isSmallAspectAdjustedGrid =
 					!phaseAwareReliable &&
-					o.smallAspectGridAlignment &&
+					o.smallAspectGridAlignmentEnabled &&
 					o.bgExtractionMethod === "auto" &&
 					o.bgRemovalScope !== "off" &&
 					trimToContent &&

--- a/src/core/processor-grid-resolution.ts
+++ b/src/core/processor-grid-resolution.ts
@@ -13,6 +13,7 @@ import {
 	findOpaqueBounds,
 } from "./image-operations";
 import {
+	getBackgroundBehavior,
 	getDownsampleOptions,
 	type NormalizedProcessOptions,
 } from "./processor-options";
@@ -85,9 +86,18 @@ export const resolveProcessingGrid = ({
 					: undefined;
 			const est = getGridSearchFromTrimmedStrategy(
 				o.fastAutoGridFromTrimmed,
-			).search(cropped, croppedMask, sw, hint, o.gridSignals);
+			).search(
+				cropped,
+				croppedMask,
+				sw,
+				hint,
+				o.gridSignals,
+				o.boundaryContrastOverride,
+			);
 			const phaseAwareEstimate =
-				o.fastAutoGridFromTrimmed && hint === undefined
+				o.fastAutoGridFromTrimmed &&
+				o.phaseAwareGridSearch &&
+				hint === undefined
 					? searchPhaseAwareGrid(cropped, croppedMask, o.gridSignals)
 					: null;
 			log(
@@ -104,7 +114,7 @@ export const resolveProcessingGrid = ({
 				const selectedEstimate = phaseAwareReliable ? phaseAwareEstimate : est;
 				const isSmallAspectAdjustedGrid =
 					!phaseAwareReliable &&
-					o.processingMode === "auto" &&
+					o.smallAspectGridAlignment &&
 					o.bgExtractionMethod === "auto" &&
 					o.bgRemovalScope !== "off" &&
 					trimToContent &&
@@ -135,6 +145,8 @@ export const resolveProcessingGrid = ({
 						o.bgConnectivity,
 						bgTargets,
 						"top-left",
+						undefined,
+						getBackgroundBehavior(o),
 					);
 					const tightBounds = findOpaqueBounds(cornerMask, trimAlphaThreshold);
 					if (

--- a/src/core/processor-grid-resolution.ts
+++ b/src/core/processor-grid-resolution.ts
@@ -1,5 +1,6 @@
 import {
 	GRID_SEARCH_LIMITS,
+	PROCESS_DEFAULTS,
 	TRIMMED_GRID_SEARCH_LIMITS,
 } from "../shared/config";
 import type { PixelGrid, RawImage } from "../shared/types";
@@ -165,10 +166,16 @@ export const resolveProcessingGrid = ({
 							cellW: tightBounds.w / Math.max(1, selectedEstimate.outW),
 							cellH: tightBounds.h / Math.max(1, selectedEstimate.outH),
 						};
-						downsampleOptions = getDownsampleOptions({
-							...o,
-							cellSamplingMode: "legacy-median",
-						});
+						// [Intended] 角シードマスクを基準にすると末尾のセルが痩せるため、
+						// 既定のまま使っている場合だけ互換の中央値サンプラーへ切り替える。
+						// 利用者がサンプリング方式を明示して選んでいるときは上書きしない。
+						downsampleOptions =
+							o.cellSamplingMode === PROCESS_DEFAULTS.cellSamplingMode
+								? getDownsampleOptions({
+										...o,
+										cellSamplingMode: "legacy-median",
+									})
+								: downsampleOptions;
 					}
 				}
 				gridMethod = phaseAwareReliable

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -7,6 +7,7 @@ import {
 	PROCESS_RANGES,
 } from "../shared/config";
 import type {
+	AutoBehaviorSetting,
 	BackgroundRemovalScope,
 	Connectivity,
 	DetailLevel,
@@ -19,6 +20,7 @@ import type {
 	RGB,
 	SmallComponentRemovalMode,
 } from "../shared/types";
+import type { BackgroundBehavior } from "./background";
 import type { CellSamplingMode } from "./cell-sampler";
 import type { DetectOptions } from "./detector";
 import type { DownsampleOptions } from "./image-operations";
@@ -28,8 +30,30 @@ export type ProcessOptions = DetectOptions & {
 	processingMode?: ProcessingMode;
 	/** Convert 経路で採用する論理解像度。 */
 	detailLevel?: DetailLevel;
-	/** グリッド候補の各信号を比較検証するための内部向け切り替え。 */
+	/** グリッド候補の各信号を個別に有効／無効にする。 */
 	gridSignals?: Partial<GridSignalOptions>;
+	/** 縁のにじみ（ハロー）を背景色から遠ざける補正を行う。 */
+	backgroundDehalo?: boolean;
+	/** 縮小後の縁に残った背景色の汚染を、原寸の本来の色へ差し替える。 */
+	backgroundEdgeCleanup?: boolean;
+	/** なめらかなグラデーション背景を段差の連続としてたどる。 */
+	backgroundRampFollow?: boolean;
+	/** 消えすぎを検出したときに背景除去を丸ごと巻き戻す。 */
+	backgroundRemovalRollback?: boolean;
+	/** 境界帯の大半が透明なら、色による背景クラスタ推定を行わない。 */
+	alphaBorderBackgroundGuard?: boolean;
+	/** 背景モデルの信頼度が下限未満なら背景除去を見送る。 */
+	backgroundConfidenceGate?: boolean;
+	/** 背景モデルの信頼度が下限未満なら小成分除去を見送る。 */
+	smallComponentBackgroundGate?: boolean;
+	/** 位相を考慮した格子探索を行い、軸信頼度が十分なら再構成ベースより優先する。 */
+	phaseAwareGridSearch?: boolean;
+	/** 境界コントラストが明確に優る粗い倍音へ採用格子を乗り換える。 */
+	boundaryContrastOverride?: boolean;
+	/** 小さな論理解像度の格子で、角シードマスクの境界を基準領域に使う。 */
+	smallAspectGridAlignment?: AutoBehaviorSetting;
+	/** 透かし除去が成立したとき、末尾行の欠落を防ぐ互換サンプラーへ切り替える。 */
+	watermarkSamplingCompat?: AutoBehaviorSetting;
 	preRemoveBackground?: boolean;
 	postRemoveBackground?: boolean;
 	/**
@@ -173,6 +197,8 @@ export const createDefaultProcessOptions = () =>
 	({
 		detectionQuantStep: PROCESS_RANGES.detectionQuantStep.default,
 		backgroundMaskTolerance: PROCESS_RANGES.backgroundMaskTolerance.default,
+		autoMaxCellsW: PROCESS_RANGES.autoMaxCells.default,
+		autoMaxCellsH: PROCESS_RANGES.autoMaxCells.default,
 		backgroundTolerance: PROCESS_RANGES.backgroundTolerance.default,
 		sampleWindow: PROCESS_RANGES.sampleWindow.default,
 		maxSamplesPerCell: PROCESS_RANGES.maxSamplesPerCell.default,
@@ -195,6 +221,19 @@ export const createDefaultProcessOptions = () =>
 		preserveThinFeatures: PROCESS_DEFAULTS.preserveThinFeatures,
 		smallComponentMode: PROCESS_DEFAULTS.smallComponentMode,
 		geminiWatermarkRemoval: PROCESS_DEFAULTS.geminiWatermarkRemoval,
+		backgroundMask: PROCESS_DEFAULTS.backgroundMask,
+		gridSignals: { ...PROCESS_DEFAULTS.gridSignals },
+		backgroundDehalo: PROCESS_DEFAULTS.backgroundDehalo,
+		backgroundEdgeCleanup: PROCESS_DEFAULTS.backgroundEdgeCleanup,
+		backgroundRampFollow: PROCESS_DEFAULTS.backgroundRampFollow,
+		backgroundRemovalRollback: PROCESS_DEFAULTS.backgroundRemovalRollback,
+		alphaBorderBackgroundGuard: PROCESS_DEFAULTS.alphaBorderBackgroundGuard,
+		backgroundConfidenceGate: PROCESS_DEFAULTS.backgroundConfidenceGate,
+		smallComponentBackgroundGate: PROCESS_DEFAULTS.smallComponentBackgroundGate,
+		phaseAwareGridSearch: PROCESS_DEFAULTS.phaseAwareGridSearch,
+		boundaryContrastOverride: PROCESS_DEFAULTS.boundaryContrastOverride,
+		smallAspectGridAlignment: PROCESS_DEFAULTS.smallAspectGridAlignment,
+		watermarkSamplingCompat: PROCESS_DEFAULTS.watermarkSamplingCompat,
 		reduceColors: PROCESS_DEFAULTS.reduceColors,
 		reduceColorMode: PROCESS_DEFAULTS.reduceColorMode,
 		ditherMode: PROCESS_DEFAULTS.ditherMode,
@@ -247,6 +286,19 @@ export const normalizeProcessOptions = (
 	autoGridFromTrimmed: boolean;
 	fastAutoGridFromTrimmed: boolean;
 	gridSignals: GridSignalOptions;
+	backgroundDehalo: boolean;
+	backgroundEdgeCleanup: boolean;
+	backgroundRampFollow: boolean;
+	backgroundRemovalRollback: boolean;
+	alphaBorderBackgroundGuard: boolean;
+	backgroundConfidenceGate: boolean;
+	smallComponentBackgroundGate: boolean;
+	phaseAwareGridSearch: boolean;
+	boundaryContrastOverride: boolean;
+	/** 経路依存を解決済みの実効値。 */
+	smallAspectGridAlignment: boolean;
+	/** 経路依存を解決済みの実効値。 */
+	watermarkSamplingCompat: boolean;
 	enableGridDetection: boolean;
 	makeSquare: boolean;
 	keepAspectRatio: boolean;
@@ -354,6 +406,23 @@ export const normalizeProcessOptions = (
 		...GRID_SIGNAL_DEFAULTS,
 		...raw.gridSignals,
 	};
+	// [Intended] "auto" は Auto 経路でだけ有効という従来の条件をそのまま表す。
+	// 明示指定された "on" / "off" は経路に関わらず優先する。
+	const resolveAutoBehavior = (
+		setting: AutoBehaviorSetting | undefined,
+		fallback: AutoBehaviorSetting,
+	): boolean => {
+		const value = setting ?? fallback;
+		return value === "auto" ? processingMode === "auto" : value === "on";
+	};
+	const smallAspectGridAlignment = resolveAutoBehavior(
+		raw.smallAspectGridAlignment,
+		PROCESS_DEFAULTS.smallAspectGridAlignment,
+	);
+	const watermarkSamplingCompat = resolveAutoBehavior(
+		raw.watermarkSamplingCompat,
+		PROCESS_DEFAULTS.watermarkSamplingCompat,
+	);
 	const makeSquare = raw.makeSquare ?? PROCESS_DEFAULTS.makeSquare;
 	const keepAspectRatio =
 		raw.keepAspectRatio ?? PROCESS_DEFAULTS.keepAspectRatio;
@@ -417,6 +486,28 @@ export const normalizeProcessOptions = (
 		autoGridFromTrimmed,
 		fastAutoGridFromTrimmed,
 		gridSignals,
+		backgroundDehalo: raw.backgroundDehalo ?? PROCESS_DEFAULTS.backgroundDehalo,
+		backgroundEdgeCleanup:
+			raw.backgroundEdgeCleanup ?? PROCESS_DEFAULTS.backgroundEdgeCleanup,
+		backgroundRampFollow:
+			raw.backgroundRampFollow ?? PROCESS_DEFAULTS.backgroundRampFollow,
+		backgroundRemovalRollback:
+			raw.backgroundRemovalRollback ??
+			PROCESS_DEFAULTS.backgroundRemovalRollback,
+		alphaBorderBackgroundGuard:
+			raw.alphaBorderBackgroundGuard ??
+			PROCESS_DEFAULTS.alphaBorderBackgroundGuard,
+		backgroundConfidenceGate:
+			raw.backgroundConfidenceGate ?? PROCESS_DEFAULTS.backgroundConfidenceGate,
+		smallComponentBackgroundGate:
+			raw.smallComponentBackgroundGate ??
+			PROCESS_DEFAULTS.smallComponentBackgroundGate,
+		phaseAwareGridSearch:
+			raw.phaseAwareGridSearch ?? PROCESS_DEFAULTS.phaseAwareGridSearch,
+		boundaryContrastOverride:
+			raw.boundaryContrastOverride ?? PROCESS_DEFAULTS.boundaryContrastOverride,
+		smallAspectGridAlignment,
+		watermarkSamplingCompat,
 		enableGridDetection,
 		makeSquare,
 		keepAspectRatio,
@@ -440,6 +531,22 @@ export const normalizeProcessOptions = (
 export type NormalizedProcessOptions = ReturnType<
 	typeof normalizeProcessOptions
 >;
+
+/**
+ * 背景処理の自動判定の有効／無効を、背景モジュールが受け取る形へまとめる。
+ *
+ * [Intended] 呼び出し側は正規化済みオプションだけを持ち回れば済むようにする。
+ * 個々のフラグ名を背景モジュールの語彙へ翻訳するのはここ 1 箇所に閉じる。
+ */
+export const getBackgroundBehavior = (
+	options: NormalizedProcessOptions,
+): BackgroundBehavior => ({
+	dehalo: options.backgroundDehalo,
+	rollback: options.backgroundRemovalRollback,
+	confidenceGate: options.backgroundConfidenceGate,
+	alphaBorderGuard: options.alphaBorderBackgroundGuard,
+	rampFollow: options.backgroundRampFollow,
+});
 
 export const getDownsampleOptions = (
 	options: NormalizedProcessOptions,

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -295,10 +295,10 @@ export const normalizeProcessOptions = (
 	smallComponentBackgroundGate: boolean;
 	phaseAwareGridSearch: boolean;
 	boundaryContrastOverride: boolean;
-	/** 経路依存を解決済みの実効値。 */
-	smallAspectGridAlignment: boolean;
-	/** 経路依存を解決済みの実効値。 */
-	watermarkSamplingCompat: boolean;
+	/** 経路依存を解決済みの実効値。生値（3 択）と区別するため名前を分ける。 */
+	smallAspectGridAlignmentEnabled: boolean;
+	/** 経路依存を解決済みの実効値。生値（3 択）と区別するため名前を分ける。 */
+	watermarkSamplingCompatEnabled: boolean;
 	enableGridDetection: boolean;
 	makeSquare: boolean;
 	keepAspectRatio: boolean;
@@ -415,11 +415,11 @@ export const normalizeProcessOptions = (
 		const value = setting ?? fallback;
 		return value === "auto" ? processingMode === "auto" : value === "on";
 	};
-	const smallAspectGridAlignment = resolveAutoBehavior(
+	const smallAspectGridAlignmentEnabled = resolveAutoBehavior(
 		raw.smallAspectGridAlignment,
 		PROCESS_DEFAULTS.smallAspectGridAlignment,
 	);
-	const watermarkSamplingCompat = resolveAutoBehavior(
+	const watermarkSamplingCompatEnabled = resolveAutoBehavior(
 		raw.watermarkSamplingCompat,
 		PROCESS_DEFAULTS.watermarkSamplingCompat,
 	);
@@ -506,8 +506,8 @@ export const normalizeProcessOptions = (
 			raw.phaseAwareGridSearch ?? PROCESS_DEFAULTS.phaseAwareGridSearch,
 		boundaryContrastOverride:
 			raw.boundaryContrastOverride ?? PROCESS_DEFAULTS.boundaryContrastOverride,
-		smallAspectGridAlignment,
-		watermarkSamplingCompat,
+		smallAspectGridAlignmentEnabled,
+		watermarkSamplingCompatEnabled,
 		enableGridDetection,
 		makeSquare,
 		keepAspectRatio,

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -89,7 +89,7 @@ export type ProcessOptions = DetectOptions & {
 	bgConnectivity?: Connectivity;
 	backgroundTolerance?: number;
 	sampleWindow?: number;
-	/** セル色の復元方法。アルゴリズム名は内部比較用で、UIには公開しない。 */
+	/** セル色の復元方法。詳細設定の 3 択として公開している。 */
 	cellSamplingMode?: CellSamplingMode;
 	/** 1セルから決定論的に抽出するサンプル数の上限。 */
 	maxSamplesPerCell?: number;

--- a/src/core/processor-simple-routes.ts
+++ b/src/core/processor-simple-routes.ts
@@ -28,6 +28,7 @@ import {
 import { applyOutline } from "./outline";
 import { createProcessingAnalysis } from "./processing-analysis";
 import {
+	getBackgroundBehavior,
 	getDownsampleOptions,
 	type NormalizedProcessOptions,
 } from "./processor-options";
@@ -83,6 +84,7 @@ export const processForcedRoute = (
 	}
 
 	// force: 指定ピクセルサイズ（W x H）へ強制変換する（自動検出なし）
+	const behavior = getBackgroundBehavior(o);
 	const bgTol = o.backgroundTolerance;
 	// [Intended] 背景マスクはトリミング・浮遊成分除去・デバッグ出力でしか使わない。
 	// トリミングしない強制変換では背景除去 1 回ぶんを丸ごと省く。
@@ -98,6 +100,7 @@ export const processForcedRoute = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
+				behavior,
 			);
 		return maskedCache;
 	};
@@ -196,6 +199,7 @@ export const processForcedRoute = (
 			bgTargets,
 			o.bgExtractionMethod,
 			backgroundModel,
+			behavior,
 		);
 		const componentResult = removeSmallComponents(
 			down2,
@@ -208,6 +212,7 @@ export const processForcedRoute = (
 					o.bgExtractionMethod !== "none" && o.bgRemovalScope !== "off",
 				automaticBackground: o.bgExtractionMethod === "auto",
 				backgroundConfidence: backgroundDiagnostic?.confidence,
+				backgroundConfidenceGate: o.smallComponentBackgroundGate,
 			},
 		);
 		return { cropped, g, sw, down2, compareBeforeSanitized, componentResult };
@@ -308,6 +313,7 @@ export const processForcedRoute = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
+				behavior,
 				backgroundDiagnostic,
 			)
 		: componentResult.image;
@@ -452,6 +458,7 @@ export const processGridDisabledRoute = (
 	}
 
 	// enableGridDetection: グリッド検出とダウンサンプリングを省略する
+	const behavior = getBackgroundBehavior(o);
 	const bgTol = o.backgroundTolerance;
 	// [Intended] 呼び出し元が同じマスクを算出済みなら再計算しない。
 	// 孤立成分の除去は working を破壊的に書き換えるため、2 度走らせると
@@ -466,6 +473,7 @@ export const processGridDisabledRoute = (
 			bgTargets,
 			o.bgExtractionMethod,
 			backgroundModel,
+			behavior,
 		);
 	let smallComponentRemoval = context.smallComponentRemoval;
 	if (!context.preparedMask && o.floatingMaxPixels > 0) {
@@ -490,6 +498,7 @@ export const processGridDisabledRoute = (
 			o.bgExtractionMethod !== "none" && o.bgRemovalScope !== "off",
 		automaticBackground: o.bgExtractionMethod === "auto",
 		backgroundConfidence: backgroundDiagnostic?.confidence,
+		backgroundConfidenceGate: o.smallComponentBackgroundGate,
 	});
 	if (o.smallComponentMode !== "off") {
 		smallComponentRemoval = componentResult.diagnostic;
@@ -505,6 +514,7 @@ export const processGridDisabledRoute = (
 					bgTargets,
 					o.bgExtractionMethod,
 					backgroundModel,
+					behavior,
 					backgroundDiagnostic,
 				)
 			: componentResult.image;

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -43,6 +43,7 @@ import { prepareAutomaticBackground } from "./processor-background";
 import { processConvertRoute } from "./processor-convert-route";
 import { resolveProcessingGrid } from "./processor-grid-resolution";
 import {
+	getBackgroundBehavior,
 	normalizeProcessOptions,
 	type ProcessOptions,
 } from "./processor-options";
@@ -87,6 +88,7 @@ const processImageCore = (
 	options: ProcessOptions = {},
 ): ProcessResult => {
 	const o = normalizeProcessOptions(options);
+	const backgroundBehavior = getBackgroundBehavior(o);
 	const sourceAspectRatio = o.keepAspectRatio ? getAspectRatio(inputImage) : 0;
 	const bgTargetsStart = performance.now();
 	// [Intended] 背景色は加工前の入力画像の角から取得し、後段の加工結果に左右されないようにする。
@@ -117,6 +119,7 @@ const processImageCore = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
+				backgroundBehavior,
 			);
 		}
 		return backgroundMaskedInput;
@@ -135,6 +138,8 @@ const processImageCore = (
 				o.bgConnectivity,
 				bgTargets,
 				o.bgExtractionMethod,
+				undefined,
+				backgroundBehavior,
 			);
 		} else if (o.bgRemovalScope === "selected") {
 			preRemovedInput = removeBackgroundByFloodFillLegacy(
@@ -143,6 +148,7 @@ const processImageCore = (
 				o.bgConnectivity,
 				bgTargets,
 				o.bgExtractionMethod,
+				backgroundBehavior,
 			);
 		} else if (o.bgRemovalScope === "all") {
 			preRemovedInput = removeBackgroundByFloodFillLegacy(
@@ -151,6 +157,7 @@ const processImageCore = (
 				"4",
 				bgTargets,
 				o.bgExtractionMethod,
+				backgroundBehavior,
 			);
 		} else {
 			preRemovedInput = cloneImage(inputImage);
@@ -455,6 +462,7 @@ const processImageCore = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
+				backgroundBehavior,
 			)
 		: down;
 	const componentResult = removeSmallComponents(
@@ -468,6 +476,7 @@ const processImageCore = (
 				o.bgExtractionMethod !== "none" && o.bgRemovalScope !== "off",
 			automaticBackground: o.bgExtractionMethod === "auto",
 			backgroundConfidence: backgroundDiagnostic?.confidence,
+			backgroundConfidenceGate: o.smallComponentBackgroundGate,
 		},
 	);
 	if (o.smallComponentMode !== "off") {
@@ -581,6 +590,7 @@ const processImageCore = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
+				backgroundBehavior,
 				postRemovalOutcome,
 			)
 		: trimmed;
@@ -595,6 +605,7 @@ const processImageCore = (
 	// 角シードや RGB 指定の経路は利用者が背景色を確定させており、手書きの期待値画像と
 	// 完全一致することを前提にしているので触らない。
 	if (
+		o.backgroundEdgeCleanup &&
 		canCleanBackgroundContaminatedEdges(
 			backgroundModel,
 			backgroundDiagnostic?.confidence,

--- a/src/core/trimmed-grid-search.ts
+++ b/src/core/trimmed-grid-search.ts
@@ -38,6 +38,7 @@ interface GridSearchFromTrimmedStrategy {
 		sampleWindow: number,
 		hint?: { outW: number; outH: number },
 		signalOptions?: Partial<GridSignalOptions>,
+		boundaryContrastOverride?: boolean,
 	) => GridEstimateFromTrimmed | null;
 }
 
@@ -431,6 +432,7 @@ export class FastGridSearchFromTrimmed
 		sampleWindow: number,
 		hint?: { outW: number; outH: number },
 		signalOptions?: Partial<GridSignalOptions>,
+		boundaryContrastOverride = true,
 	): GridEstimateFromTrimmed | null {
 		// 比率に基づいて outH を変化させ、outW を決定する（探索空間を制限する）
 		const outHMin = Math.max(
@@ -521,12 +523,11 @@ export class FastGridSearchFromTrimmed
 			boundaryContrast,
 		);
 		const reconEvidence = evidenceAt(evidence, coarse.bestOutH);
-		const harmonicOutH = findCoarserHarmonic(
-			evidence,
-			coarse.bestOutH,
-			reconEvidence,
-			outHMax,
-		);
+		// [Intended] 乗り換えを切っても、曖昧さの判定に使う境界コントラストの値は
+		// そのまま返す。候補選択の提示条件は採用格子の決め方とは別の判断だから。
+		const harmonicOutH = boundaryContrastOverride
+			? findCoarserHarmonic(evidence, coarse.bestOutH, reconEvidence, outHMax)
+			: 0;
 		const refineCenter = harmonicOutH > 0 ? harmonicOutH : coarse.bestOutH;
 		const refineRadius =
 			harmonicOutH > 0 ? BOUNDARY_CONTRAST_LIMITS.refineRadius : outHStep * 2;

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -741,8 +741,8 @@ export const PROCESS_DEFAULTS = {
 	keepAspectRatio: false,
 	// グリッド検出モード（UI 用）
 	gridDetectionMode: "auto",
-	// [Intended] 既定では補間由来の中間 alpha を面積被覆として残さず、
-	// 必要な場合だけ詳細設定から alpha-aware-medoid を有効にする。
+	// [Intended] 既定では補間由来の中間 alpha を面積被覆として残さない。
+	// 必要な場合だけ詳細設定のセル色サンプリングから別の方式を選ぶ。
 	cellSamplingMode: "hard-alpha-medoid",
 	preserveThinFeatures: true,
 	smallComponentMode: "auto",

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -30,6 +30,8 @@ export const PROCESS_RANGES = {
 	colorCount: { min: 2, max: 256, default: 32 } as const,
 	// ディザリング
 	ditherStrength: { min: 0, max: 100, default: 0 } as const,
+	// 検出器: 自動検出する最大セル数（各軸）
+	autoMaxCells: { min: 2, max: 1024, default: 512 } as const,
 	// アウトライン
 	outlineColor: { r: 255, g: 255, b: 255 }, // デフォルトの白
 } as const satisfies Record<string, IntRange | RGB>;
@@ -745,6 +747,35 @@ export const PROCESS_DEFAULTS = {
 	preserveThinFeatures: true,
 	smallComponentMode: "auto",
 	geminiWatermarkRemoval: "auto",
+
+	// [Intended] ここから下は「これまで固定で動いていた自動判定」を明示的に切れるようにした指定。
+	// 既定はいずれも従来の挙動そのままなので、公開しても出力は変わらない。
+	// 縁のにじみ（ハロー）を背景色から遠ざける補正
+	backgroundDehalo: true,
+	// 縮小後の縁に残った背景色の汚染を、原寸の本来の色へ差し替える
+	backgroundEdgeCleanup: true,
+	// なめらかなグラデーション背景を段差の連続としてたどる
+	backgroundRampFollow: true,
+	// 消えすぎを検出したときに背景除去を丸ごと巻き戻す
+	backgroundRemovalRollback: true,
+	// 境界帯の大半が透明なら、色による背景クラスタ推定を行わない
+	alphaBorderBackgroundGuard: true,
+	// 背景モデルの信頼度が下限未満なら背景除去を見送る
+	backgroundConfidenceGate: true,
+	// 背景モデルの信頼度が下限未満なら小成分除去を見送る
+	smallComponentBackgroundGate: true,
+	// 位相を考慮した格子探索を行い、軸信頼度が十分なら再構成ベースより優先する
+	phaseAwareGridSearch: true,
+	// 境界コントラストが明確に優る粗い倍音へ採用格子を乗り換える
+	boundaryContrastOverride: true,
+	// 小さな論理解像度の格子で、角シードマスクの境界を基準領域に使う
+	smallAspectGridAlignment: "auto",
+	// 透かし除去が成立したとき、末尾行の欠落を防ぐ互換サンプラーへ切り替える
+	watermarkSamplingCompat: "auto",
+	// 検出前に背景色を推測してマスクする（検出器フォールバック用）
+	backgroundMask: true,
+	// 格子候補の各信号を個別に有効／無効にする
+	gridSignals: GRID_SIGNAL_DEFAULTS,
 
 	// [Intended] 公開済みの旧オプション用。新しい既定処理には使用しない。
 	floatingMaxPixels: PROCESS_RANGES.floatingMaxPixels.default,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -43,6 +43,15 @@ export type PixelGrid = {
 	gridEvidenceContested?: boolean;
 };
 
+/**
+ * 以前は `processingMode === "auto"` でしか働かなかった挙動の指定。
+ *
+ * [Intended] "auto" は従来どおり Auto 経路でだけ有効になる。"on" / "off" を選ぶと
+ * 経路に関係なく固定できるので、手動 refine でも Auto と同じ出力を再現できる。
+ * 既定を "auto" に置くことで、設定を公開しても既存の出力は変わらない。
+ */
+export type AutoBehaviorSetting = "auto" | "on" | "off";
+
 export type GridSignalOptions = {
 	colorBoundary: boolean;
 	luminanceAlphaGradient: boolean;


### PR DESCRIPTION
## 概要

Auto が内部で固定的に行っていた判定をすべて詳細設定から切り替えられるようにし、手動の処理方法でも Auto と同じ出力を再現できるようにする。

## 変更内容

### UI/UX

- 詳細設定のグリッド検出に、セル色のサンプリング方式（3 択）、細い線の保護、内容からの格子推定、位相考慮探索、境界コントラストでの乗り換え、小さな格子の基準合わせ、格子候補の 5 信号、セルごとの最大サンプル数、セル色のアルファ下限、最大セル数、検出前の背景マスクとその許容差を追加した。
- 詳細設定の背景透過に、縁のにじみ補正、縁の汚染色の差し替え、グラデーション背景の追従、消えすぎの巻き戻し、既存透過の尊重、背景と小成分の信頼度ゲート、透かし除去後のサンプリングを追加した。
- 詳細設定のトリミングに、内容とみなすアルファの下限を追加した。
- 「半透明エッジを保持」のチェックボックスは、同じ内容を含むセル色サンプリングの 3 択へ置き換えた。
  互換の中央値サンプラーも選べるようになった。

### ロジック

- 「小さな格子の基準合わせ」と「透かし除去後のサンプリング」は Auto でしか働かなかったため、処理方法が「ドットを整える」のときに Auto と同じ出力を作れなかった。
  この 2 つを「Auto に従う／常に有効／常に無効」の 3 択にし、常に有効を選べば経路によらず同じ結果を再現できるようにした。
- 既定値はすべて従来の挙動と同じなので、この PR だけでは出力は変わらない。
  品質ケース 70 件が baseline を更新せずに通過することで確認した。

### 開発体験

- どこからも指定されていなかった検出器のサンプルストリップ数の設定を削除し、既定値を検出器内の定数へ移した。

### その他

- 候補選択で「細かめ／粗め」を選ぶと `forcePixels` の経路になるが、この経路はアウトライン・アスペクト比維持・縁の汚染除去を適用しないため、現状でも Auto の結果をサイズ指定で再現できない。
  この是正は後続の PR で行う。
- 非推奨の `floatingMaxPixels` は品質ケースがまだ使用しているため残した。
  削除と期待画像の移行は後続の PR で行う。

## 動作確認

- なし
