### PR TITLE
fix: 出力に透過が残る場合は背景透過の中止を警告しない

### DIFF
--- a/src/core/background-removal.ts
+++ b/src/core/background-removal.ts
@@ -328,8 +328,8 @@ export const removeBackground = (
 		| "bottom-right"
 		| "rgb",
 	automaticModel?: BackgroundModel,
-	// [Intended] 自動除去のロールバックは呼び出し側の診断へ集約する必要があるため、
-	// 戻り値を画像のままにして、この出力引数へ書き戻す。
+	// [Intended] 自動除去のロールバックと除去の有無は呼び出し側の診断へ集約する必要が
+	// あるため、戻り値を画像のままにして、この出力引数へ書き戻す。
 	outcome?: BackgroundRemovalStageOutcome,
 ): RawImage => {
 	if (method === "none") return cloneImage(img);
@@ -342,7 +342,10 @@ export const removeBackground = (
 			bgConnectivity,
 			automaticModel,
 		);
-		if (outcome && automatic.rolledBack) outcome.rolledBack = true;
+		if (outcome) {
+			if (automatic.rolledBack) outcome.rolledBack = true;
+			else if (automatic.removedRatio > 0) outcome.removed = true;
+		}
 		return automatic.image;
 	}
 

--- a/src/core/background-removal.ts
+++ b/src/core/background-removal.ts
@@ -4,6 +4,7 @@ import {
 } from "../shared/config";
 import type {
 	BackgroundRemovalScope,
+	BackgroundRemovalStageOutcome,
 	Connectivity,
 	RawImage,
 } from "../shared/types";
@@ -329,7 +330,7 @@ export const removeBackground = (
 	automaticModel?: BackgroundModel,
 	// [Intended] 自動除去のロールバックは呼び出し側の診断へ集約する必要があるため、
 	// 戻り値を画像のままにして、この出力引数へ書き戻す。
-	outcome?: { removalRolledBack: boolean },
+	outcome?: BackgroundRemovalStageOutcome,
 ): RawImage => {
 	if (method === "none") return cloneImage(img);
 	if (bgRemovalScope === "off") return cloneImage(img);
@@ -341,7 +342,7 @@ export const removeBackground = (
 			bgConnectivity,
 			automaticModel,
 		);
-		if (outcome && automatic.rolledBack) outcome.removalRolledBack = true;
+		if (outcome && automatic.rolledBack) outcome.rolledBack = true;
 		return automatic.image;
 	}
 

--- a/src/core/gemini-watermark.test.ts
+++ b/src/core/gemini-watermark.test.ts
@@ -348,7 +348,11 @@ describe("Gemini watermark removal", () => {
 			}
 		}
 
-		expect(automatic.analysis.warnings).toContain("BACKGROUND_REMOVAL_SKIPPED");
+		// 原寸の事前除去はロールバックするが、出力解像度の事後除去が透過を作るため、
+		// 「透過を中止した」警告は出さない。
+		expect(automatic.analysis.warnings).not.toContain(
+			"BACKGROUND_REMOVAL_SKIPPED",
+		);
 		expect(transparentCells).toBeGreaterThan(0);
 		expect(removedBrightCells).toBeGreaterThan(0);
 	});

--- a/src/core/gemini-watermark.test.ts
+++ b/src/core/gemini-watermark.test.ts
@@ -325,6 +325,15 @@ describe("Gemini watermark removal", () => {
 			...options,
 			geminiWatermarkRemoval: "off",
 		});
+		// 事後除去を止めた場合は中止の警告が出る。原寸の事前除去がロールバックするという
+		// このテストの前提が崩れていないことを固定する。
+		const preRemovalOnly = processImage(image, {
+			...options,
+			postRemoveBackground: false,
+		});
+		expect(preRemovalOnly.analysis.warnings).toContain(
+			"BACKGROUND_REMOVAL_SKIPPED",
+		);
 		let removedBrightCells = 0;
 		let transparentCells = 0;
 		for (

--- a/src/core/processing-analysis.ts
+++ b/src/core/processing-analysis.ts
@@ -247,6 +247,7 @@ export const createProcessingAnalysis = (
 	}
 	// [Intended] ロールバック時は背景が透過されなかっただけで内容は失われていないため、
 	// CONTENT_LOSS_RISK ではなく専用の警告で「背景透過を中止した」ことを伝える。
+	// removalRolledBack は段階をまとめた結論なので、出力に透過が残る場合はここへ来ない。
 	if (backgroundDiagnostic?.removalRolledBack) {
 		warnings.push("BACKGROUND_REMOVAL_SKIPPED");
 	}

--- a/src/core/processing-analysis.ts
+++ b/src/core/processing-analysis.ts
@@ -14,6 +14,7 @@ import type {
 	RawImage,
 	SmallComponentRemovalDiagnostic,
 } from "../shared/types";
+import { hasSkippedBackgroundRemoval } from "./processor-background";
 
 const clampUnit = (value: number): number => Math.min(1, Math.max(0, value));
 
@@ -247,8 +248,11 @@ export const createProcessingAnalysis = (
 	}
 	// [Intended] ロールバック時は背景が透過されなかっただけで内容は失われていないため、
 	// CONTENT_LOSS_RISK ではなく専用の警告で「背景透過を中止した」ことを伝える。
-	// removalRolledBack は段階をまとめた結論なので、出力に透過が残る場合はここへ来ない。
-	if (backgroundDiagnostic?.removalRolledBack) {
+	// 判定は段階ごとの結果をまとめた結論なので、出力に透過が残る場合はここへ来ない。
+	if (
+		backgroundDiagnostic &&
+		hasSkippedBackgroundRemoval(backgroundDiagnostic)
+	) {
 		warnings.push("BACKGROUND_REMOVAL_SKIPPED");
 	}
 	if (before === 0) warnings.push("NO_CONTENT");

--- a/src/core/processor-background.test.ts
+++ b/src/core/processor-background.test.ts
@@ -3,7 +3,10 @@ import type {
 	BackgroundDiagnostic,
 	BackgroundRemovalStageOutcome,
 } from "../shared/types";
-import { applyPostRemovalOutcome } from "./processor-background";
+import {
+	applyPostRemovalOutcome,
+	hasSkippedBackgroundRemoval,
+} from "./processor-background";
 
 const notApplied: BackgroundRemovalStageOutcome = {
 	attempted: false,
@@ -26,66 +29,61 @@ const removedNothing: BackgroundRemovalStageOutcome = {
 	removed: false,
 };
 
-const diagnostic = (
+const skippedAfter = (
 	preRemoval: BackgroundRemovalStageOutcome,
-): BackgroundDiagnostic => ({
-	confidence: 0.9,
-	removalRolledBack: preRemoval.rolledBack,
-	preRemoval,
-});
+	postRemoval: BackgroundRemovalStageOutcome,
+): boolean => {
+	const diagnostic: BackgroundDiagnostic = { confidence: 0.9, preRemoval };
+	applyPostRemovalOutcome(diagnostic, postRemoval);
 
-describe("applyPostRemovalOutcome", () => {
+	expect(diagnostic.postRemoval).toBe(postRemoval);
+	return hasSkippedBackgroundRemoval(diagnostic);
+};
+
+describe("hasSkippedBackgroundRemoval", () => {
 	it("reports a rollback only when every applied stage rolled back", () => {
-		const both = diagnostic(rolledBack);
-		applyPostRemovalOutcome(both, rolledBack);
-
-		expect(both.removalRolledBack).toBe(true);
+		expect(skippedAfter(rolledBack, rolledBack)).toBe(true);
 	});
 
 	it("clears a full-resolution rollback when the post-processing removal succeeds", () => {
-		const preOnly = diagnostic(rolledBack);
-		applyPostRemovalOutcome(preOnly, madeTransparency);
-
-		expect(preOnly.removalRolledBack).toBe(false);
+		expect(skippedAfter(rolledBack, madeTransparency)).toBe(false);
 	});
 
 	it("keeps the transparency made by the pre-processing removal out of the warning", () => {
-		const postOnly = diagnostic(madeTransparency);
-		applyPostRemovalOutcome(postOnly, rolledBack);
-
-		expect(postOnly.removalRolledBack).toBe(false);
+		expect(skippedAfter(madeTransparency, rolledBack)).toBe(false);
 	});
 
 	it("keeps the rollback when the remaining stage removed nothing", () => {
-		const nothingLeft = diagnostic(rolledBack);
-		applyPostRemovalOutcome(nothingLeft, removedNothing);
-
-		expect(nothingLeft.removalRolledBack).toBe(true);
+		expect(skippedAfter(rolledBack, removedNothing)).toBe(true);
 	});
 
 	it("uses the remaining stage when the pre-processing removal is disabled", () => {
-		const skipped = diagnostic(notApplied);
-		applyPostRemovalOutcome(skipped, rolledBack);
-
-		expect(skipped.removalRolledBack).toBe(true);
-
-		const removed = diagnostic(notApplied);
-		applyPostRemovalOutcome(removed, madeTransparency);
-
-		expect(removed.removalRolledBack).toBe(false);
+		expect(skippedAfter(notApplied, rolledBack)).toBe(true);
+		expect(skippedAfter(notApplied, madeTransparency)).toBe(false);
 	});
 
 	it("reports no rollback when a stage removed nothing without rolling back", () => {
-		const idle = diagnostic(removedNothing);
-		applyPostRemovalOutcome(idle, notApplied);
-
-		expect(idle.removalRolledBack).toBe(false);
+		expect(skippedAfter(removedNothing, notApplied)).toBe(false);
 	});
 
 	it("reports no rollback when no removal stage runs", () => {
-		const none = diagnostic(notApplied);
-		applyPostRemovalOutcome(none, notApplied);
+		expect(skippedAfter(notApplied, notApplied)).toBe(false);
+	});
 
-		expect(none.removalRolledBack).toBe(false);
+	it("judges by the pre-processing stage alone while the post-processing stage is unrecorded", () => {
+		// [Intended] 結論を欄として持たず段階から導くため、事後除去を記録しない経路では
+		// 事前除去の結果だけで判定される。古い結論が残ったまま警告になることはない。
+		expect(
+			hasSkippedBackgroundRemoval({
+				confidence: 0.9,
+				preRemoval: rolledBack,
+			}),
+		).toBe(true);
+		expect(
+			hasSkippedBackgroundRemoval({
+				confidence: 0.9,
+				preRemoval: madeTransparency,
+			}),
+		).toBe(false);
 	});
 });

--- a/src/core/processor-background.test.ts
+++ b/src/core/processor-background.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type {
+	BackgroundDiagnostic,
+	BackgroundRemovalStageOutcome,
+} from "../shared/types";
+import { applyPostRemovalOutcome } from "./processor-background";
+
+const diagnostic = (
+	preRemoval: BackgroundRemovalStageOutcome,
+): BackgroundDiagnostic => ({
+	confidence: 0.9,
+	removalRolledBack: preRemoval.rolledBack,
+	preRemoval,
+});
+
+describe("applyPostRemovalOutcome", () => {
+	it("reports a rollback only when every applied stage rolled back", () => {
+		const both = diagnostic({ attempted: true, rolledBack: true });
+		applyPostRemovalOutcome(both, { attempted: true, rolledBack: true });
+
+		expect(both.removalRolledBack).toBe(true);
+	});
+
+	it("clears a full-resolution rollback when the post-processing removal succeeds", () => {
+		const preOnly = diagnostic({ attempted: true, rolledBack: true });
+		applyPostRemovalOutcome(preOnly, { attempted: true, rolledBack: false });
+
+		expect(preOnly.removalRolledBack).toBe(false);
+	});
+
+	it("keeps the transparency made by the pre-processing removal out of the warning", () => {
+		const postOnly = diagnostic({ attempted: true, rolledBack: false });
+		applyPostRemovalOutcome(postOnly, { attempted: true, rolledBack: true });
+
+		expect(postOnly.removalRolledBack).toBe(false);
+	});
+
+	it("uses the remaining stage when the pre-processing removal is disabled", () => {
+		const rolledBack = diagnostic({ attempted: false, rolledBack: false });
+		applyPostRemovalOutcome(rolledBack, { attempted: true, rolledBack: true });
+
+		expect(rolledBack.removalRolledBack).toBe(true);
+
+		const removed = diagnostic({ attempted: false, rolledBack: false });
+		applyPostRemovalOutcome(removed, { attempted: true, rolledBack: false });
+
+		expect(removed.removalRolledBack).toBe(false);
+	});
+
+	it("reports no rollback when no removal stage runs", () => {
+		const none = diagnostic({ attempted: false, rolledBack: false });
+		applyPostRemovalOutcome(none, { attempted: false, rolledBack: false });
+
+		expect(none.removalRolledBack).toBe(false);
+	});
+});

--- a/src/core/processor-background.test.ts
+++ b/src/core/processor-background.test.ts
@@ -5,6 +5,27 @@ import type {
 } from "../shared/types";
 import { applyPostRemovalOutcome } from "./processor-background";
 
+const notApplied: BackgroundRemovalStageOutcome = {
+	attempted: false,
+	rolledBack: false,
+	removed: false,
+};
+const rolledBack: BackgroundRemovalStageOutcome = {
+	attempted: true,
+	rolledBack: true,
+	removed: false,
+};
+const madeTransparency: BackgroundRemovalStageOutcome = {
+	attempted: true,
+	rolledBack: false,
+	removed: true,
+};
+const removedNothing: BackgroundRemovalStageOutcome = {
+	attempted: true,
+	rolledBack: false,
+	removed: false,
+};
+
 const diagnostic = (
 	preRemoval: BackgroundRemovalStageOutcome,
 ): BackgroundDiagnostic => ({
@@ -15,41 +36,55 @@ const diagnostic = (
 
 describe("applyPostRemovalOutcome", () => {
 	it("reports a rollback only when every applied stage rolled back", () => {
-		const both = diagnostic({ attempted: true, rolledBack: true });
-		applyPostRemovalOutcome(both, { attempted: true, rolledBack: true });
+		const both = diagnostic(rolledBack);
+		applyPostRemovalOutcome(both, rolledBack);
 
 		expect(both.removalRolledBack).toBe(true);
 	});
 
 	it("clears a full-resolution rollback when the post-processing removal succeeds", () => {
-		const preOnly = diagnostic({ attempted: true, rolledBack: true });
-		applyPostRemovalOutcome(preOnly, { attempted: true, rolledBack: false });
+		const preOnly = diagnostic(rolledBack);
+		applyPostRemovalOutcome(preOnly, madeTransparency);
 
 		expect(preOnly.removalRolledBack).toBe(false);
 	});
 
 	it("keeps the transparency made by the pre-processing removal out of the warning", () => {
-		const postOnly = diagnostic({ attempted: true, rolledBack: false });
-		applyPostRemovalOutcome(postOnly, { attempted: true, rolledBack: true });
+		const postOnly = diagnostic(madeTransparency);
+		applyPostRemovalOutcome(postOnly, rolledBack);
 
 		expect(postOnly.removalRolledBack).toBe(false);
 	});
 
+	it("keeps the rollback when the remaining stage removed nothing", () => {
+		const nothingLeft = diagnostic(rolledBack);
+		applyPostRemovalOutcome(nothingLeft, removedNothing);
+
+		expect(nothingLeft.removalRolledBack).toBe(true);
+	});
+
 	it("uses the remaining stage when the pre-processing removal is disabled", () => {
-		const rolledBack = diagnostic({ attempted: false, rolledBack: false });
-		applyPostRemovalOutcome(rolledBack, { attempted: true, rolledBack: true });
+		const skipped = diagnostic(notApplied);
+		applyPostRemovalOutcome(skipped, rolledBack);
 
-		expect(rolledBack.removalRolledBack).toBe(true);
+		expect(skipped.removalRolledBack).toBe(true);
 
-		const removed = diagnostic({ attempted: false, rolledBack: false });
-		applyPostRemovalOutcome(removed, { attempted: true, rolledBack: false });
+		const removed = diagnostic(notApplied);
+		applyPostRemovalOutcome(removed, madeTransparency);
 
 		expect(removed.removalRolledBack).toBe(false);
 	});
 
+	it("reports no rollback when a stage removed nothing without rolling back", () => {
+		const idle = diagnostic(removedNothing);
+		applyPostRemovalOutcome(idle, notApplied);
+
+		expect(idle.removalRolledBack).toBe(false);
+	});
+
 	it("reports no rollback when no removal stage runs", () => {
-		const none = diagnostic({ attempted: false, rolledBack: false });
-		applyPostRemovalOutcome(none, { attempted: false, rolledBack: false });
+		const none = diagnostic(notApplied);
+		applyPostRemovalOutcome(none, notApplied);
 
 		expect(none.removalRolledBack).toBe(false);
 	});

--- a/src/core/processor-background.ts
+++ b/src/core/processor-background.ts
@@ -37,7 +37,7 @@ export const prepareAutomaticBackground = (
 			backgroundDiagnostic: {
 				confidence: model.confidence,
 				removalRolledBack: false,
-				preRemoval: { attempted: false, rolledBack: false },
+				preRemoval: { attempted: false, rolledBack: false, removed: false },
 			},
 		};
 	}
@@ -56,6 +56,9 @@ export const prepareAutomaticBackground = (
 			preRemoval: {
 				attempted: true,
 				rolledBack: automaticBackground.rolledBack,
+				removed:
+					!automaticBackground.rolledBack &&
+					automaticBackground.removedRatio > 0,
 			},
 		},
 	};
@@ -66,8 +69,10 @@ export const prepareAutomaticBackground = (
  *
  * [Intended] 事前除去は原寸、事後除去は出力解像度で別々に消えすぎ判定を行うため、
  * 片方だけがロールバックすることがある。ロールバックした段階は入力をそのまま返すだけなので、
- * もう一方が成功していれば出力には背景の透過が残る。「透過を中止した」と伝えてよいのは、
- * 実施した段階がすべてロールバックしたときに限る。
+ * もう一方が透過を作っていれば出力には背景の透過が残る。「透過を中止した」と伝えてよいのは、
+ * どこかの段階が消えすぎで巻き戻り、かつどの段階も透過を作らなかったときに限る。
+ * ロールバックしなかった段階を成功と見なすと、除去対象が無くて何も消さなかった段階が
+ * 巻き戻りを打ち消し、透過が一切ない出力でも中止を伝えられなくなる。
  */
 export const applyPostRemovalOutcome = (
 	diagnostic: BackgroundDiagnostic | undefined,
@@ -77,5 +82,6 @@ export const applyPostRemovalOutcome = (
 	const stages = [diagnostic.preRemoval, postRemoval];
 	const attempted = stages.filter((stage) => stage.attempted);
 	diagnostic.removalRolledBack =
-		attempted.length > 0 && attempted.every((stage) => stage.rolledBack);
+		attempted.some((stage) => stage.rolledBack) &&
+		!attempted.some((stage) => stage.removed);
 };

--- a/src/core/processor-background.ts
+++ b/src/core/processor-background.ts
@@ -36,7 +36,6 @@ export const prepareAutomaticBackground = (
 			backgroundModel: model,
 			backgroundDiagnostic: {
 				confidence: model.confidence,
-				removalRolledBack: false,
 				preRemoval: { attempted: false, rolledBack: false, removed: false },
 			},
 		};
@@ -52,7 +51,6 @@ export const prepareAutomaticBackground = (
 		backgroundModel: automaticBackground.model,
 		backgroundDiagnostic: {
 			confidence: automaticBackground.model.confidence,
-			removalRolledBack: automaticBackground.rolledBack,
 			preRemoval: {
 				attempted: true,
 				rolledBack: automaticBackground.rolledBack,
@@ -64,24 +62,34 @@ export const prepareAutomaticBackground = (
 	};
 };
 
-/**
- * 事後除去の結果を診断へ合流させ、出力向けのロールバック判定を確定する。
- *
- * [Intended] 事前除去は原寸、事後除去は出力解像度で別々に消えすぎ判定を行うため、
- * 片方だけがロールバックすることがある。ロールバックした段階は入力をそのまま返すだけなので、
- * もう一方が透過を作っていれば出力には背景の透過が残る。「透過を中止した」と伝えてよいのは、
- * どこかの段階が消えすぎで巻き戻り、かつどの段階も透過を作らなかったときに限る。
- * ロールバックしなかった段階を成功と見なすと、除去対象が無くて何も消さなかった段階が
- * 巻き戻りを打ち消し、透過が一切ない出力でも中止を伝えられなくなる。
- */
+/** 事後除去の実施結果を診断へ記録する。 */
 export const applyPostRemovalOutcome = (
 	diagnostic: BackgroundDiagnostic | undefined,
 	postRemoval: BackgroundRemovalStageOutcome,
 ): void => {
 	if (!diagnostic) return;
-	const stages = [diagnostic.preRemoval, postRemoval];
-	const attempted = stages.filter((stage) => stage.attempted);
-	diagnostic.removalRolledBack =
-		attempted.some((stage) => stage.rolledBack) &&
-		!attempted.some((stage) => stage.removed);
+	diagnostic.postRemoval = postRemoval;
+};
+
+/**
+ * 利用者へ「背景の透過を中止した」と伝えてよいかを、段階ごとの結果から判定する。
+ *
+ * [Intended] 事前除去は原寸、事後除去は出力解像度で別々に消えすぎ判定を行うため、
+ * 片方だけがロールバックすることがある。ロールバックした段階は入力をそのまま返すだけなので、
+ * もう一方が透過を作っていれば出力には背景の透過が残る。中止を伝えてよいのは、
+ * どこかの段階が消えすぎで巻き戻り、かつどの段階も透過を作らなかったときに限る。
+ * ロールバックしなかった段階を成功と見なすと、除去対象が無くて何も消さなかった段階が
+ * 巻き戻りを打ち消し、透過が一切ない出力でも中止を伝えられなくなる。
+ */
+export const hasSkippedBackgroundRemoval = (
+	diagnostic: BackgroundDiagnostic,
+): boolean => {
+	const stages = [diagnostic.preRemoval, diagnostic.postRemoval];
+	let rolledBack = false;
+	for (const stage of stages) {
+		if (stage === undefined || !stage.attempted) continue;
+		if (stage.removed) return false;
+		if (stage.rolledBack) rolledBack = true;
+	}
+	return rolledBack;
 };

--- a/src/core/processor-background.ts
+++ b/src/core/processor-background.ts
@@ -1,4 +1,8 @@
-import type { BackgroundDiagnostic, RawImage } from "../shared/types";
+import type {
+	BackgroundDiagnostic,
+	BackgroundRemovalStageOutcome,
+	RawImage,
+} from "../shared/types";
 import {
 	type AutomaticBackgroundResult,
 	type BackgroundModel,
@@ -33,6 +37,7 @@ export const prepareAutomaticBackground = (
 			backgroundDiagnostic: {
 				confidence: model.confidence,
 				removalRolledBack: false,
+				preRemoval: { attempted: false, rolledBack: false },
 			},
 		};
 	}
@@ -48,6 +53,29 @@ export const prepareAutomaticBackground = (
 		backgroundDiagnostic: {
 			confidence: automaticBackground.model.confidence,
 			removalRolledBack: automaticBackground.rolledBack,
+			preRemoval: {
+				attempted: true,
+				rolledBack: automaticBackground.rolledBack,
+			},
 		},
 	};
+};
+
+/**
+ * 事後除去の結果を診断へ合流させ、出力向けのロールバック判定を確定する。
+ *
+ * [Intended] 事前除去は原寸、事後除去は出力解像度で別々に消えすぎ判定を行うため、
+ * 片方だけがロールバックすることがある。ロールバックした段階は入力をそのまま返すだけなので、
+ * もう一方が成功していれば出力には背景の透過が残る。「透過を中止した」と伝えてよいのは、
+ * 実施した段階がすべてロールバックしたときに限る。
+ */
+export const applyPostRemovalOutcome = (
+	diagnostic: BackgroundDiagnostic | undefined,
+	postRemoval: BackgroundRemovalStageOutcome,
+): void => {
+	if (!diagnostic) return;
+	const stages = [diagnostic.preRemoval, postRemoval];
+	const attempted = stages.filter((stage) => stage.attempted);
+	diagnostic.removalRolledBack =
+		attempted.length > 0 && attempted.every((stage) => stage.rolledBack);
 };

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -212,7 +212,7 @@ export const processConvertRoute = (
 		rolledBack: false,
 		removed: false,
 	};
-	if (o.postRemoveBackground) {
+	if (postRemoval.attempted) {
 		finalResult = removeBackground(
 			finalResult,
 			o.backgroundTolerance,

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -210,6 +210,7 @@ export const processConvertRoute = (
 	const postRemoval = {
 		attempted: o.postRemoveBackground,
 		rolledBack: false,
+		removed: false,
 	};
 	if (o.postRemoveBackground) {
 		finalResult = removeBackground(

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -27,6 +27,7 @@ import {
 } from "./image-operations";
 import { applyOutline } from "./outline";
 import { createProcessingAnalysis } from "./processing-analysis";
+import { applyPostRemovalOutcome } from "./processor-background";
 import type { SimpleRouteContext } from "./processor-simple-routes";
 
 const gridForCandidate = (
@@ -206,6 +207,10 @@ export const processConvertRoute = (
 	}
 	finalResult = componentResult.image;
 
+	const postRemoval = {
+		attempted: o.postRemoveBackground,
+		rolledBack: false,
+	};
 	if (o.postRemoveBackground) {
 		finalResult = removeBackground(
 			finalResult,
@@ -215,9 +220,10 @@ export const processConvertRoute = (
 			bgTargets,
 			o.bgExtractionMethod,
 			backgroundModel,
-			backgroundDiagnostic,
+			postRemoval,
 		);
 	}
+	applyPostRemovalOutcome(backgroundDiagnostic, postRemoval);
 	if (o.convertReduceColors || o.fixedPalette) {
 		finalResult = applyColorReduction(
 			finalResult,

--- a/src/core/processor-simple-routes.ts
+++ b/src/core/processor-simple-routes.ts
@@ -303,6 +303,7 @@ export const processForcedRoute = (
 	const postRemoval = {
 		attempted: o.postRemoveBackground,
 		rolledBack: false,
+		removed: false,
 	};
 	const result2 = o.postRemoveBackground
 		? removeBackground(
@@ -505,6 +506,7 @@ export const processGridDisabledRoute = (
 		attempted:
 			(context.applyFinalAdjustments ?? false) && o.postRemoveBackground,
 		rolledBack: false,
+		removed: false,
 	};
 	const base = postRemoval.attempted
 		? removeBackground(

--- a/src/core/processor-simple-routes.ts
+++ b/src/core/processor-simple-routes.ts
@@ -27,6 +27,7 @@ import {
 } from "./image-operations";
 import { applyOutline } from "./outline";
 import { createProcessingAnalysis } from "./processing-analysis";
+import { applyPostRemovalOutcome } from "./processor-background";
 import {
 	getDownsampleOptions,
 	type NormalizedProcessOptions,
@@ -299,6 +300,10 @@ export const processForcedRoute = (
 
 	// 3. 後処理の透明化（背景除去）
 	const postBgStart = performance.now();
+	const postRemoval = {
+		attempted: o.postRemoveBackground,
+		rolledBack: false,
+	};
 	const result2 = o.postRemoveBackground
 		? removeBackground(
 				componentResult.image,
@@ -308,9 +313,10 @@ export const processForcedRoute = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
-				backgroundDiagnostic,
+				postRemoval,
 			)
 		: componentResult.image;
+	applyPostRemovalOutcome(backgroundDiagnostic, postRemoval);
 	log(
 		`Post-background removal done in ${(performance.now() - postBgStart).toFixed(2)}ms`,
 	);
@@ -495,19 +501,24 @@ export const processGridDisabledRoute = (
 		smallComponentRemoval = componentResult.diagnostic;
 	}
 
-	const base =
-		context.applyFinalAdjustments && o.postRemoveBackground
-			? removeBackground(
-					componentResult.image,
-					bgTol,
-					o.bgRemovalScope,
-					o.bgConnectivity,
-					bgTargets,
-					o.bgExtractionMethod,
-					backgroundModel,
-					backgroundDiagnostic,
-				)
-			: componentResult.image;
+	const postRemoval = {
+		attempted:
+			(context.applyFinalAdjustments ?? false) && o.postRemoveBackground,
+		rolledBack: false,
+	};
+	const base = postRemoval.attempted
+		? removeBackground(
+				componentResult.image,
+				bgTol,
+				o.bgRemovalScope,
+				o.bgConnectivity,
+				bgTargets,
+				o.bgExtractionMethod,
+				backgroundModel,
+				postRemoval,
+			)
+		: componentResult.image;
+	applyPostRemovalOutcome(backgroundDiagnostic, postRemoval);
 
 	let finalResult = base;
 	let compareBefore = img;

--- a/src/core/processor-simple-routes.ts
+++ b/src/core/processor-simple-routes.ts
@@ -305,7 +305,7 @@ export const processForcedRoute = (
 		rolledBack: false,
 		removed: false,
 	};
-	const result2 = o.postRemoveBackground
+	const result2 = postRemoval.attempted
 		? removeBackground(
 				componentResult.image,
 				o.backgroundTolerance,

--- a/src/core/processor.test.ts
+++ b/src/core/processor.test.ts
@@ -8,8 +8,8 @@ import {
 	expectSameImageExcept,
 	getExpectPath,
 	makeDebugHook,
-	readPngAsRawImage,
 	RESIZE_WITH_TRIMMING_AUTO_EDGE_PIXELS,
+	readPngAsRawImage,
 	UPDATE_EXPECT,
 	writeRawImageAsPngSync,
 } from "./processor-test-helpers";
@@ -359,7 +359,11 @@ describe("processImage", () => {
 			expect(grid.outH).toBe(13);
 			// Auto は縁の背景色の汚染を落とすため、期待値画像にわずかな緑が残る 2 画素だけ
 			// 色が変わる。変わる画素を固定し、それ以外は完全一致を要求する。
-			expectSameImageExcept(result, expected, RESIZE_WITH_TRIMMING_AUTO_EDGE_PIXELS);
+			expectSameImageExcept(
+				result,
+				expected,
+				RESIZE_WITH_TRIMMING_AUTO_EDGE_PIXELS,
+			);
 		});
 	});
 
@@ -571,6 +575,20 @@ describe("processImage", () => {
 			expect(grid.outH).toBe(expected.height);
 
 			expectSameImage(result, expected, getExpectPath("no_trimming"));
+		});
+
+		it("should not report a skipped background removal while the output is transparent", () => {
+			// [Intended] 余白が広い入力では原寸の事前除去だけが消えすぎ判定に当たってロールバック
+			// するが、トリミング後の出力解像度で行う事後除去は成立する。出力に背景の透過が
+			// 入っている状態で「透過を中止した」と伝えないことを固定する。
+			const { result, analysis } = processImage(img, {});
+
+			let transparent = 0;
+			for (let i = 3; i < result.data.length; i += 4) {
+				if (result.data[i] === 0) transparent += 1;
+			}
+			expect(transparent).toBeGreaterThan(0);
+			expect(analysis.warnings).not.toContain("BACKGROUND_REMOVAL_SKIPPED");
 		});
 	});
 

--- a/src/core/processor.test.ts
+++ b/src/core/processor.test.ts
@@ -581,6 +581,15 @@ describe("processImage", () => {
 			// [Intended] 余白が広い入力では原寸の事前除去だけが消えすぎ判定に当たってロールバック
 			// するが、トリミング後の出力解像度で行う事後除去は成立する。出力に背景の透過が
 			// 入っている状態で「透過を中止した」と伝えないことを固定する。
+			// 事後除去を止めると中止の警告が出ることで、事前除去がロールバックするという
+			// 前提が崩れていない（この検証が空回りしていない）ことも同時に固定する。
+			const preRemovalOnly = processImage(img, {
+				postRemoveBackground: false,
+			});
+			expect(preRemovalOnly.analysis.warnings).toContain(
+				"BACKGROUND_REMOVAL_SKIPPED",
+			);
+
 			const { result, analysis } = processImage(img, {});
 
 			let transparent = 0;

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -576,6 +576,7 @@ const processImageCore = (
 	const postRemoval = {
 		attempted: o.postRemoveBackground,
 		rolledBack: false,
+		removed: false,
 	};
 	const result = o.postRemoveBackground
 		? removeBackground(

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -39,7 +39,10 @@ import {
 	detectedGridConfidenceWarnings,
 	findCandidateIndexForGrid,
 } from "./processing-analysis";
-import { prepareAutomaticBackground } from "./processor-background";
+import {
+	applyPostRemovalOutcome,
+	prepareAutomaticBackground,
+} from "./processor-background";
 import { processConvertRoute } from "./processor-convert-route";
 import { resolveProcessingGrid } from "./processor-grid-resolution";
 import {
@@ -569,9 +572,11 @@ const processImageCore = (
 
 	const postBgStart = performance.now();
 	// [Intended] 縁の汚染除去は「補正する画像の透過を作った除去」が成立したかだけを見たい。
-	// backgroundDiagnostic は原寸の事前除去のロールバックも保持するため、後段除去の結果を
-	// 別の受け皿で取り、診断へは従来どおり合流させる。
-	const postRemovalOutcome = { removalRolledBack: false };
+	// 診断は段階をまとめた結論を持つため、後段除去の結果は別の受け皿で取る。
+	const postRemoval = {
+		attempted: o.postRemoveBackground,
+		rolledBack: false,
+	};
 	const result = o.postRemoveBackground
 		? removeBackground(
 				trimmed,
@@ -581,12 +586,10 @@ const processImageCore = (
 				bgTargets,
 				o.bgExtractionMethod,
 				backgroundModel,
-				postRemovalOutcome,
+				postRemoval,
 			)
 		: trimmed;
-	if (postRemovalOutcome.removalRolledBack && backgroundDiagnostic) {
-		backgroundDiagnostic.removalRolledBack = true;
-	}
+	applyPostRemovalOutcome(backgroundDiagnostic, postRemoval);
 	log(
 		`Post-background removal done in ${(performance.now() - postBgStart).toFixed(2)}ms`,
 	);
@@ -599,7 +602,7 @@ const processImageCore = (
 			backgroundModel,
 			backgroundDiagnostic?.confidence,
 			o.postRemoveBackground
-				? postRemovalOutcome.removalRolledBack
+				? postRemoval.rolledBack
 				: (automaticBackground?.rolledBack ?? false),
 			o.postRemoveBackground || preBackgroundRemoved,
 		)

--- a/src/core/processor.ts
+++ b/src/core/processor.ts
@@ -578,7 +578,7 @@ const processImageCore = (
 		rolledBack: false,
 		removed: false,
 	};
-	const result = o.postRemoveBackground
+	const result = postRemoval.attempted
 		? removeBackground(
 				trimmed,
 				o.backgroundTolerance,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -225,17 +225,17 @@ export type BackgroundRemovalStageOutcome = {
 export type BackgroundDiagnostic = {
 	confidence: number;
 	/**
-	 * 消えすぎ検出により、出力へ背景の透過が一切入らなかったか。
-	 * [Intended] 段階ごとの生の結果ではなく、利用者へ「透過を中止した」と伝えてよいかを表す。
-	 * 事後除去の結果が出るまでは事前除去の結果を暫定値として持つ。
-	 */
-	removalRolledBack: boolean;
-	/**
 	 * 原寸に対する事前除去の実施結果。
 	 * [Intended] 事前除去と事後除去は解像度が違うため消えすぎ判定も別々に出る。
 	 * 出力向けの結論を出すには段階ごとの結果を残しておく必要がある。
 	 */
 	preRemoval: BackgroundRemovalStageOutcome;
+	/**
+	 * 出力解像度に対する事後除去の実施結果。事後除去の段階を通る前は未設定。
+	 * [Intended] 「透過を中止した」と伝えてよいかは段階ごとの結果から導く。結論を欄として
+	 * 持たせると、書き換えを忘れた経路で古い結論がそのまま警告になる。
+	 */
+	postRemoval?: BackgroundRemovalStageOutcome;
 };
 
 export type ProcessingAnalysis = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -207,14 +207,29 @@ export type GridCandidateReport = {
 	subscores?: Partial<GridCandidateSubscores>;
 };
 
+/** 背景除去 1 段階の実施結果。 */
+export type BackgroundRemovalStageOutcome = {
+	/** その段階の除去を実行したか。 */
+	attempted: boolean;
+	/** 消えすぎ検出により入力をそのまま返したか。 */
+	rolledBack: boolean;
+};
+
 /** 自動背景モデルの診断情報。手動背景指定では省略する。 */
 export type BackgroundDiagnostic = {
 	confidence: number;
 	/**
-	 * 消えすぎ検出により背景除去を中止したか。
-	 * [Intended] 出力へ適用された各段階の結果を集約するため、処理中に書き換える。
+	 * 消えすぎ検出により、出力へ背景の透過が一切入らなかったか。
+	 * [Intended] 段階ごとの生の結果ではなく、利用者へ「透過を中止した」と伝えてよいかを表す。
+	 * 事後除去の結果が出るまでは事前除去の結果を暫定値として持つ。
 	 */
 	removalRolledBack: boolean;
+	/**
+	 * 原寸に対する事前除去の実施結果。
+	 * [Intended] 事前除去と事後除去は解像度が違うため消えすぎ判定も別々に出る。
+	 * 出力向けの結論を出すには段階ごとの結果を残しておく必要がある。
+	 */
+	preRemoval: BackgroundRemovalStageOutcome;
 };
 
 export type ProcessingAnalysis = {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -213,6 +213,12 @@ export type BackgroundRemovalStageOutcome = {
 	attempted: boolean;
 	/** 消えすぎ検出により入力をそのまま返したか。 */
 	rolledBack: boolean;
+	/**
+	 * その段階が実際に背景の透過を作ったか。
+	 * [Intended] ロールバックしていないことは透過を作ったことを意味しない。背景モデルが
+	 * 立たない場合や除去対象が 1 画素も無い場合も、入力をそのまま返して巻き戻しにはならない。
+	 */
+	removed: boolean;
 };
 
 /** 自動背景モデルの診断情報。手動背景指定では省略する。 */


### PR DESCRIPTION
## 概要

背景が透過された結果を出しているのに「背景の透過を中止した」と警告していた食い違いを解消する。

## 変更内容

### UI/UX

- 余白の広い画像を処理したとき、背景が透過されているのに「背景が消えすぎると判定したため、背景の透過を中止しました。」の注意が出ることがなくなる。

### ロジック

- 背景透過の中止判定を、実施した段階のどれかが消えすぎで巻き戻り、かつどの段階も透過を作らなかった場合だけに限定した。
原寸に対する事前除去と出力解像度に対する事後除去は消えすぎ判定を別々に行うため、片方だけがロールバックしても出力には透過が残る。除去対象が 1 画素も無かった段階はロールバックしないが透過も作らないので、巻き戻りを打ち消す成功としては数えない。
- 中止判定を診断の欄として持たせるのをやめ、事前除去・事後除去それぞれの実施結果から導出するようにした。

### 開発体験

- なし

### その他

- 縁の汚染除去の可否は従来どおり「補正する画像の透過を作った除去」の結果だけで判断しており、今回の集約とは条件が別になっている。

## 動作確認

- なし

