### PR TITLE
feat: かんたん設定の背景透過と自動トリムを整理

### DIFF
--- a/index.html
+++ b/index.html
@@ -728,20 +728,22 @@
                     </label>
                     <label class="setting-item">
                       <span class="label-text">
-                        <span data-i18n="setting.background">Background</span>
+                        <span data-i18n="setting.background"
+                          >Background Transparency</span
+                        >
                         <span
                           class="help"
                           data-i18n-attr="data-tooltip:tooltip.help.quick_background"
-                          data-tooltip="Chooses whether to keep the background, detect it automatically and make it transparent, or make a selected color transparent."
+                          data-tooltip="Chooses whether to leave the background unchanged, detect it automatically and make it transparent, or make a selected color transparent."
                           >?</span
                         >
                       </span>
                       <select id="quick-background">
                         <option value="keep" data-i18n="option.background_keep">
-                          Keep
+                          None
                         </option>
                         <option value="auto" data-i18n="option.background_auto">
-                          Auto transparent
+                          Auto
                         </option>
                         <option value="pick" data-i18n="option.background_pick">
                           Pick color
@@ -766,34 +768,6 @@
                           ◉
                         </button>
                       </div>
-                    </label>
-                    <label class="setting-item">
-                      <span class="label-text">
-                        <span data-i18n="setting.bg_removal_scope"
-                          >Background Removal Scope</span
-                        >
-                        <span
-                          class="help"
-                          data-i18n-attr="data-tooltip:tooltip.help.quick_bg_removal_scope"
-                          data-tooltip="Range of background to make transparent.&#10;&#10;Auto: Outer background, plus enclosed holes that clearly match the background color.&#10;Outer all: All background connected to the image border.&#10;All: Outer + every inner area matching the background color.&#10;&#10;Unavailable when Background is Keep."
-                          >?</span
-                        >
-                      </span>
-                      <select id="quick-bg-removal-scope">
-                        <option
-                          value="auto"
-                          data-i18n="option.bg_scope_auto"
-                          selected
-                        >
-                          Auto
-                        </option>
-                        <option value="outer" data-i18n="option.bg_scope_outer">
-                          Outer all
-                        </option>
-                        <option value="all" data-i18n="option.bg_scope_all">
-                          All
-                        </option>
-                      </select>
                     </label>
                     <label class="setting-item">
                       <span class="label-text">
@@ -825,40 +799,26 @@
                     </label>
                     <label class="setting-item">
                       <span class="label-text">
-                        <span data-i18n="setting.outline">Outline</span>
-                        <span
-                          class="help"
-                          data-i18n-attr="data-tooltip:tooltip.help.quick_outline"
-                          data-tooltip="Adds a one-pixel outline after processing. Rounded softens corners, while Sharp keeps square corners."
-                          >?</span
-                        >
-                      </span>
-                      <select id="quick-outline-style">
-                        <option value="none" data-i18n="option.outline_none">
-                          Off
-                        </option>
-                        <option
-                          value="rounded"
-                          data-i18n="option.outline_rounded"
-                        >
-                          Rounded
-                        </option>
-                        <option value="sharp" data-i18n="option.outline_sharp">
-                          Sharp
-                        </option>
-                      </select>
-                    </label>
-                    <label class="setting-item quick-checkbox-setting">
-                      <span class="label-text">
                         <span data-i18n="setting.auto_trim">Auto Trim</span>
                         <span
                           class="help"
-                          data-i18n-attr="data-tooltip:tooltip.help.auto_trim"
-                          data-tooltip="Automatically trims the output to the bounds containing visible content. It removes transparent or detected background margins."
+                          data-i18n-attr="data-tooltip:tooltip.help.quick_auto_trim"
+                          data-tooltip="Automatically trims the output to the bounds containing visible content. Unavailable when Background Transparency is None."
                           >?</span
                         >
                       </span>
-                      <input id="quick-auto-trim" type="checkbox" checked />
+                      <select id="quick-auto-trim">
+                        <option
+                          value="auto"
+                          data-i18n="option.auto_trim_auto"
+                          selected
+                        >
+                          Auto
+                        </option>
+                        <option value="none" data-i18n="option.auto_trim_none">
+                          None
+                        </option>
+                      </select>
                     </label>
                   </div>
                 </div>

--- a/src/browser/app-elements.ts
+++ b/src/browser/app-elements.ts
@@ -89,13 +89,11 @@ export type Elements = {
 	quickDetailLevelSelect: HTMLSelectElement;
 	quickReductionModeSelect: HTMLSelectElement;
 	quickBackgroundSelect: HTMLSelectElement;
-	quickBgRemovalScopeSelect: HTMLSelectElement;
 	quickBackgroundPicker: HTMLElement;
 	quickBackgroundColorInput: HTMLInputElement;
 	quickEyedropperButton: HTMLButtonElement;
 	quickDitheringSelect: HTMLSelectElement;
-	quickOutlineStyleSelect: HTMLSelectElement;
-	quickAutoTrimCheck: HTMLInputElement;
+	quickAutoTrimSelect: HTMLSelectElement;
 	advancedProcessingModeSelect: HTMLSelectElement;
 	advancedDetailLevelSelect: HTMLSelectElement;
 	advancedBgRemovalScopeSelect: HTMLSelectElement;
@@ -282,13 +280,11 @@ export const getElements = (): Elements => {
 		quickDetailLevelSelect: get<HTMLSelectElement>("quick-detail-level"),
 		quickReductionModeSelect: get<HTMLSelectElement>("quick-reduction-mode"),
 		quickBackgroundSelect: get<HTMLSelectElement>("quick-background"),
-		quickBgRemovalScopeSelect: get<HTMLSelectElement>("quick-bg-removal-scope"),
 		quickBackgroundPicker: get<HTMLElement>("quick-background-picker"),
 		quickBackgroundColorInput: get<HTMLInputElement>("quick-background-color"),
 		quickEyedropperButton: get<HTMLButtonElement>("quick-eyedropper-button"),
 		quickDitheringSelect: get<HTMLSelectElement>("quick-dithering"),
-		quickOutlineStyleSelect: get<HTMLSelectElement>("quick-outline-style"),
-		quickAutoTrimCheck: get<HTMLInputElement>("quick-auto-trim"),
+		quickAutoTrimSelect: get<HTMLSelectElement>("quick-auto-trim"),
 		advancedProcessingModeSelect: get<HTMLSelectElement>(
 			"advanced-processing-mode",
 		),

--- a/src/browser/i18n.test.ts
+++ b/src/browser/i18n.test.ts
@@ -175,10 +175,10 @@ describe("I18nManager", () => {
 				"tooltip.help.quick_detail",
 				"tooltip.help.quick_reduction_mode",
 				"tooltip.help.quick_background",
-				"tooltip.help.quick_bg_removal_scope",
 				"tooltip.help.quick_dithering",
-				"tooltip.help.quick_outline",
-				"tooltip.help.auto_trim",
+				"tooltip.help.quick_auto_trim",
+				"option.auto_trim_auto",
+				"option.auto_trim_none",
 			] as const) {
 				expect(i18n.t(key)).not.toBe(key);
 			}

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -79,7 +79,7 @@ const resources = {
 		"setting.preset": "プリセット",
 		"setting.processing_mode": "処理方法",
 		"setting.detail": "細かさ",
-		"setting.background": "背景",
+		"setting.background": "背景透過",
 		"setting.dithering": "ディザリング",
 		"preset.auto": "Auto",
 		"preset.crisp_sprite": "くっきりスプライト",
@@ -97,9 +97,11 @@ const resources = {
 		"option.colors_8": "8色",
 		"option.colors_16": "16色",
 		"option.colors_32": "32色",
-		"option.background_keep": "維持",
-		"option.background_auto": "自動で透過",
+		"option.background_keep": "なし",
+		"option.background_auto": "自動",
 		"option.background_pick": "色を選択",
+		"option.auto_trim_auto": "自動",
+		"option.auto_trim_none": "なし",
 		"option.dithering_off": "なし",
 		"option.dithering_subtle": "控えめ",
 		"option.dithering_strong": "強め",
@@ -200,11 +202,11 @@ const resources = {
 		"tooltip.help.quick_reduction_mode":
 			"減色しないか、固定色数または標準パレットで減色するかを選びます。任意の色数指定と固定パレットの読み込みは詳細設定で行えます。",
 		"tooltip.help.quick_background":
-			"背景をそのまま残すか、自動判定で透過するか、選んだ色を透過するかを指定します。",
+			"背景透過を行わないか、自動判定で透過するか、選んだ色を透過するかを指定します。",
+		"tooltip.help.quick_auto_trim":
+			"内容が存在する範囲に合わせて出力を自動でトリミングします。背景透過が「なし」のときは使用できません。",
 		"tooltip.help.quick_dithering":
 			"減色時に隣り合う色を模様として混ぜ、中間色を表現します。強くするほどグラデーションを残しやすくなりますが、質感も目立ちます。",
-		"tooltip.help.quick_outline":
-			"処理後の画像に1ピクセルのアウトラインを追加します。「丸め」は角をなだらかにし、「くっきり」は角を四角く保ちます。",
 
 		// ツールチップ
 		"tooltip.help.color_mode":
@@ -293,8 +295,6 @@ const resources = {
 			"処理完了【後】に、背景色を透明に置き換えて出力します。\n\nメリット: 背景透明のPNGとして保存できます。\n注意: グリッド検出処理自体には影響しません。",
 		"tooltip.help.bg_removal_scope":
 			"背景をどこまで透過するかの範囲です。\n\nおまかせ: 外側に加え、背景色そのものだと判断できた内側の閉じた領域だけ透過。\n選択部分のみ: 選択した角から繋がる背景だけ透過。\n外側全部: 画像の外周に繋がる背景をすべて透過。\n全領域: 背景色に近い領域を内側も含めてすべて透過。\n\n背景が「維持」のときは使用しません。",
-		"tooltip.help.quick_bg_removal_scope":
-			"背景をどこまで透過するかの範囲です。\n\nおまかせ: 外側に加え、背景色そのものだと判断できた内側の閉じた領域だけ透過。\n外側全部: 画像の外周に繋がる背景をすべて透過。\n全領域: 背景色に近い領域を内側も含めてすべて透過。\n\n背景が「維持」のときは使用しません。",
 		"tooltip.help.bg_connectivity":
 			"「繋がっている」の判定方法です。\n\n4方向: 斜めを含めない厳しい判定。\n8方向: 斜めも繋がりとみなします。",
 		"tooltip.help.gemini_watermark_removal":
@@ -468,7 +468,7 @@ const resources = {
 		"setting.preset": "预设",
 		"setting.processing_mode": "处理方式",
 		"setting.detail": "细节",
-		"setting.background": "背景",
+		"setting.background": "背景透明",
 		"setting.dithering": "抖动",
 		"preset.auto": "Auto",
 		"preset.crisp_sprite": "清晰精灵",
@@ -486,9 +486,11 @@ const resources = {
 		"option.colors_8": "8色",
 		"option.colors_16": "16色",
 		"option.colors_32": "32色",
-		"option.background_keep": "保留",
-		"option.background_auto": "自动透明",
+		"option.background_keep": "无",
+		"option.background_auto": "自动",
 		"option.background_pick": "选择颜色",
+		"option.auto_trim_auto": "自动",
+		"option.auto_trim_none": "无",
 		"option.dithering_off": "关闭",
 		"option.dithering_subtle": "轻微",
 		"option.dithering_strong": "强烈",
@@ -588,11 +590,11 @@ const resources = {
 		"tooltip.help.quick_reduction_mode":
 			"选择不减色、固定颜色数量或内置标准调色板。任意颜色数量和导入固定调色板可在高级设置中指定。",
 		"tooltip.help.quick_background":
-			"选择保留背景、自动检测并设为透明，或将选定颜色设为透明。",
+			"选择不进行背景透明化、自动检测并透明化背景，或将选定颜色设为透明。",
+		"tooltip.help.quick_auto_trim":
+			"根据内容范围自动裁剪输出。背景透明设为“无”时不可用。",
 		"tooltip.help.quick_dithering":
 			"减色时将相邻颜色混合成图案，以表现中间色调。强度越高越能保留渐变，但纹理也会更明显。",
-		"tooltip.help.quick_outline":
-			"处理后添加1像素描边。“圆润”会柔化拐角，“锐利”会保留方形拐角。",
 
 		// ツールチップ
 		"tooltip.help.color_mode":
@@ -681,8 +683,6 @@ const resources = {
 			"处理完成后将背景色替换为透明。\n\n优点：可以保存为透明背景 PNG。\n注意：不会影响网格检测过程本身。",
 		"tooltip.help.bg_removal_scope":
 			"决定背景透明化的范围。\n\n自动：在外侧的基础上，只透明化可确定为背景色的内部封闭区域。\n仅选中部分：只透明化从所选角落连通的背景。\n外侧全部：透明化所有与图片边缘连通的背景。\n全区域：包括内部在内，透明化所有接近背景色的区域。\n\n背景设为“保留”时不可用。",
-		"tooltip.help.quick_bg_removal_scope":
-			"决定背景透明化的范围。\n\n自动：在外侧的基础上，只透明化可确定为背景色的内部封闭区域。\n外侧全部：透明化所有与图片边缘连通的背景。\n全区域：包括内部在内，透明化所有接近背景色的区域。\n\n背景设为“保留”时不可用。",
 		"tooltip.help.bg_connectivity":
 			"决定相邻区域是否算作连通。\n\n4 方向：更严格，不包含斜向。\n8 方向：包含斜向相邻。",
 		"tooltip.help.gemini_watermark_removal":
@@ -856,7 +856,7 @@ const resources = {
 		"setting.preset": "Preset",
 		"setting.processing_mode": "Processing",
 		"setting.detail": "Detail",
-		"setting.background": "Background",
+		"setting.background": "Background Transparency",
 		"setting.dithering": "Dithering",
 		"preset.auto": "Auto",
 		"preset.crisp_sprite": "Crisp Sprite",
@@ -874,9 +874,11 @@ const resources = {
 		"option.colors_8": "8 colors",
 		"option.colors_16": "16 colors",
 		"option.colors_32": "32 colors",
-		"option.background_keep": "Keep",
-		"option.background_auto": "Auto transparent",
+		"option.background_keep": "None",
+		"option.background_auto": "Auto",
 		"option.background_pick": "Pick color",
+		"option.auto_trim_auto": "Auto",
+		"option.auto_trim_none": "None",
 		"option.dithering_off": "Off",
 		"option.dithering_subtle": "Subtle",
 		"option.dithering_strong": "Strong",
@@ -977,11 +979,11 @@ const resources = {
 		"tooltip.help.quick_reduction_mode":
 			"Selects no color reduction, a fixed color count, or a built-in standard palette. Arbitrary color counts and imported fixed palettes are available in Advanced Settings.",
 		"tooltip.help.quick_background":
-			"Chooses whether to keep the background, detect it automatically and make it transparent, or make a selected color transparent.",
+			"Chooses whether to leave the background unchanged, detect it automatically and make it transparent, or make a selected color transparent.",
+		"tooltip.help.quick_auto_trim":
+			"Automatically trims the output to fit its visible content. Unavailable when Background Transparency is None.",
 		"tooltip.help.quick_dithering":
 			"Mixes neighboring colors into a pattern during color reduction to represent intermediate tones. Stronger settings preserve gradients but add more texture.",
-		"tooltip.help.quick_outline":
-			"Adds a one-pixel outline after processing. Rounded softens corners, while Sharp keeps square corners.",
 
 		// ツールチップ
 		"tooltip.help.color_mode":
@@ -1070,8 +1072,6 @@ const resources = {
 			"Replaces the background color with transparency AFTER processing is complete.\n\nBenefit: Allows saving as a PNG with a transparent background.\nNote: Does not affect the grid detection process itself.",
 		"tooltip.help.bg_removal_scope":
 			"Range of background to make transparent.\n\nAuto: Outer background, plus enclosed holes that clearly match the background color.\nSelected only: Only background connected from the chosen corner.\nOuter all: All background connected to the image border.\nAll: Every area matching the background color, inner ones included.\n\nUnavailable when Background is Keep.",
-		"tooltip.help.quick_bg_removal_scope":
-			"Range of background to make transparent.\n\nAuto: Outer background, plus enclosed holes that clearly match the background color.\nOuter all: All background connected to the image border.\nAll: Every area matching the background color, inner ones included.\n\nUnavailable when Background is Keep.",
 		"tooltip.help.bg_connectivity":
 			"Whether diagonal neighbors are considered connected.\n\n4-way: Strict (no diagonals).\n8-way: Includes diagonals.",
 		"tooltip.help.gemini_watermark_removal":

--- a/src/browser/quick-settings-controls.test.ts
+++ b/src/browser/quick-settings-controls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Elements } from "./app-elements";
 import {
+	readQuickSettings,
 	setupQuickSettingsControls,
 	updateQuickSettingsDisabledStates,
 } from "./quick-settings-controls";
@@ -34,21 +35,17 @@ const createElements = () => {
 		quickDetailLevelSelect: new MockControl(),
 		quickReductionModeSelect: new MockControl(),
 		quickBackgroundSelect: new MockControl(),
-		quickBgRemovalScopeSelect: new MockControl(),
 		quickBackgroundPicker: new MockControl(),
 		quickBackgroundColorInput: new MockControl(),
 		quickDitheringSelect: new MockControl(),
-		quickOutlineStyleSelect: new MockControl(),
-		quickAutoTrimCheck: new MockControl(),
+		quickAutoTrimSelect: new MockControl(),
 	};
 	controls.quickProcessingModeSelect.value = "auto";
 	controls.quickDetailLevelSelect.value = "balanced";
 	controls.quickReductionModeSelect.value = "none";
 	controls.quickBackgroundSelect.value = "auto";
-	controls.quickBgRemovalScopeSelect.value = "auto";
 	controls.quickDitheringSelect.value = "off";
-	controls.quickOutlineStyleSelect.value = "none";
-	controls.quickAutoTrimCheck.checked = true;
+	controls.quickAutoTrimSelect.value = "auto";
 	return controls;
 };
 
@@ -82,14 +79,35 @@ describe("quick settings controls", () => {
 		els.quickBackgroundSelect.value = "keep";
 		els.quickReductionModeSelect.value = "none";
 		updateQuickSettingsDisabledStates(els as unknown as Elements);
-		expect(els.quickBgRemovalScopeSelect.disabled).toBe(true);
+		expect(els.quickAutoTrimSelect.disabled).toBe(true);
+		expect(
+			els.quickAutoTrimSelect.settingItem.classList.contains("disabled"),
+		).toBe(true);
 		expect(els.quickDitheringSelect.disabled).toBe(true);
+		expect(readQuickSettings(els as unknown as Elements).trimToContent).toBe(
+			false,
+		);
 
 		els.quickBackgroundSelect.value = "pick";
 		els.quickReductionModeSelect.value = "gb_pocket";
 		updateQuickSettingsDisabledStates(els as unknown as Elements);
-		expect(els.quickBgRemovalScopeSelect.disabled).toBe(false);
+		expect(els.quickAutoTrimSelect.disabled).toBe(false);
+		expect(
+			els.quickAutoTrimSelect.settingItem.classList.contains("disabled"),
+		).toBe(false);
 		expect(els.quickDitheringSelect.disabled).toBe(false);
 		expect(els.quickBackgroundPicker.style.display).toBe("flex");
+		expect(readQuickSettings(els as unknown as Elements).trimToContent).toBe(
+			true,
+		);
+	});
+
+	it("maps the auto-trim select to a boolean setting", () => {
+		const els = createElements();
+		els.quickAutoTrimSelect.value = "none";
+
+		expect(readQuickSettings(els as unknown as Elements).trimToContent).toBe(
+			false,
+		);
 	});
 });

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -1,13 +1,11 @@
 import type {
 	DetailLevel,
-	OutlineStyle,
 	ProcessingMode,
 	ProcessingRoute,
 } from "../shared/types";
 import type { Elements } from "./app-elements";
 import type {
 	QuickBackground,
-	QuickBackgroundRemovalScope,
 	QuickDithering,
 	QuickReductionMode,
 	QuickSettingsState,
@@ -50,9 +48,11 @@ export const updateQuickSettingsDisabledStates = (
 	);
 
 	const background = els.quickBackgroundSelect.value as QuickBackground;
-	setQuickControlDisabled(els.quickBgRemovalScopeSelect, background === "keep");
 	els.quickBackgroundPicker.style.display =
 		background === "pick" ? "flex" : "none";
+	// [Intended] かんたん設定では背景透過と余白除去を一組として扱い、
+	// 背景透過を行わない場合は自動トリムも処理へ渡さない。
+	setQuickControlDisabled(els.quickAutoTrimSelect, background === "keep");
 
 	const reductionMode = els.quickReductionModeSelect
 		.value as QuickReductionMode;
@@ -71,11 +71,10 @@ export const readQuickSettings = (els: Elements): QuickSettingsState => ({
 	reductionMode: els.quickReductionModeSelect.value as QuickReductionMode,
 	background: els.quickBackgroundSelect.value as QuickBackground,
 	backgroundColor: els.quickBackgroundColorInput.value,
-	bgRemovalScope: els.quickBgRemovalScopeSelect
-		.value as QuickBackgroundRemovalScope,
 	dithering: els.quickDitheringSelect.value as QuickDithering,
-	outlineStyle: els.quickOutlineStyleSelect.value as OutlineStyle,
-	trimToContent: els.quickAutoTrimCheck.checked,
+	trimToContent:
+		els.quickBackgroundSelect.value !== "keep" &&
+		els.quickAutoTrimSelect.value === "auto",
 });
 
 export const setupQuickSettingsControls = ({
@@ -94,10 +93,8 @@ export const setupQuickSettingsControls = ({
 		els.quickDetailLevelSelect,
 		els.quickReductionModeSelect,
 		els.quickBackgroundSelect,
-		els.quickBgRemovalScopeSelect,
 		els.quickDitheringSelect,
-		els.quickOutlineStyleSelect,
-		els.quickAutoTrimCheck,
+		els.quickAutoTrimSelect,
 	].forEach((control) => {
 		control.addEventListener("change", () => {
 			clearCandidateSelections();

--- a/src/browser/quick-settings.test.ts
+++ b/src/browser/quick-settings.test.ts
@@ -14,7 +14,6 @@ describe("quick settings", () => {
 			processingMode: PROCESS_DEFAULTS.processingMode,
 			detailLevel: PROCESS_DEFAULTS.detailLevel,
 			reductionMode: "none",
-			outlineStyle: PROCESS_DEFAULTS.outlineStyle,
 			trimToContent: PROCESS_DEFAULTS.trimToContent,
 		});
 	});
@@ -108,21 +107,19 @@ describe("quick settings", () => {
 		expect(options).toMatchObject({
 			bgExtractionMethod: "rgb",
 			bgRgb: "#123456",
+			bgRemovalScope: PROCESS_DEFAULTS.bgRemovalScope,
+			outlineStyle: PROCESS_DEFAULTS.outlineStyle,
 			ditherMode: "floyd-steinberg",
 			ditherStrength: 60,
 		});
 	});
 
-	it.each(["auto", "outer", "all"] as const)(
-		"maps the %s background scope directly",
-		(bgRemovalScope) => {
-			const options = createQuickProcessOptions({
-				...QUICK_SETTINGS_DEFAULTS,
-				bgRemovalScope,
-			});
-			expect(options.bgRemovalScope).toBe(bgRemovalScope);
-		},
-	);
+	it("keeps hidden background scope and outline at their shared defaults", () => {
+		const options = createQuickProcessOptions(QUICK_SETTINGS_DEFAULTS);
+
+		expect(options.bgRemovalScope).toBe(PROCESS_DEFAULTS.bgRemovalScope);
+		expect(options.outlineStyle).toBe(PROCESS_DEFAULTS.outlineStyle);
+	});
 
 	it("defines six self-contained built-in presets", () => {
 		expect(BUILT_IN_PRESETS.map((preset) => preset.id)).toEqual([

--- a/src/browser/quick-settings.ts
+++ b/src/browser/quick-settings.ts
@@ -1,11 +1,7 @@
 import type { ProcessOptions } from "../core/processor";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS } from "../shared/config";
-import type {
-	DetailLevel,
-	OutlineStyle,
-	ProcessingMode,
-} from "../shared/types";
+import type { DetailLevel, ProcessingMode } from "../shared/types";
 
 export type QuickReductionMode =
 	| "none"
@@ -25,7 +21,6 @@ export type QuickReductionMode =
 	| "sfc_sprite"
 	| "sfc_bg";
 export type QuickBackground = "keep" | "auto" | "pick";
-export type QuickBackgroundRemovalScope = "auto" | "outer" | "all";
 export type QuickDithering = "off" | "subtle" | "strong";
 
 export type QuickSettingsState = {
@@ -33,9 +28,7 @@ export type QuickSettingsState = {
 	detailLevel: DetailLevel;
 	reductionMode: QuickReductionMode;
 	background: QuickBackground;
-	bgRemovalScope: QuickBackgroundRemovalScope;
 	dithering: QuickDithering;
-	outlineStyle: OutlineStyle;
 	trimToContent: boolean;
 	backgroundColor?: string;
 };
@@ -51,9 +44,7 @@ export const QUICK_SETTINGS_DEFAULTS: QuickSettingsState = {
 	detailLevel: PROCESS_DEFAULTS.detailLevel,
 	reductionMode: "none",
 	background: "auto",
-	bgRemovalScope: PROCESS_DEFAULTS.bgRemovalScope,
 	dithering: "off",
-	outlineStyle: PROCESS_DEFAULTS.outlineStyle,
 	trimToContent: PROCESS_DEFAULTS.trimToContent,
 };
 
@@ -74,7 +65,7 @@ export const createQuickProcessOptions = (
 		...createDefaultProcessOptions(),
 		processingMode: quick.processingMode,
 		detailLevel: quick.detailLevel,
-		outlineStyle: quick.outlineStyle,
+		outlineStyle: PROCESS_DEFAULTS.outlineStyle,
 		trimToContent: quick.trimToContent,
 		reduceColors: quick.reductionMode !== "none",
 		reduceColorMode:
@@ -91,7 +82,7 @@ export const createQuickProcessOptions = (
 	} else {
 		const method = quick.background === "auto" ? "auto" : "rgb";
 		options.bgExtractionMethod = method;
-		options.bgRemovalScope = quick.bgRemovalScope;
+		options.bgRemovalScope = PROCESS_DEFAULTS.bgRemovalScope;
 		options.preRemoveBackground = true;
 		options.postRemoveBackground = true;
 		if (method === "rgb") options.bgRgb = quick.backgroundColor;
@@ -153,8 +144,13 @@ export const BUILT_IN_PRESETS: readonly BuiltInPreset[] = [
 		id: "transparent-icon",
 		labelKey: "preset.transparent_icon",
 		options: presetOptions(
-			{ outlineStyle: "rounded" },
-			{ reduceColors: true, reduceColorMode: "auto", colorCount: 32 },
+			{},
+			{
+				reduceColors: true,
+				reduceColorMode: "auto",
+				colorCount: 32,
+				outlineStyle: "rounded",
+			},
 		),
 	},
 	{

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -267,7 +267,6 @@ export const setupSettingsControls = ({
 
 		els.preRemoveCheck.checked = defaults.preRemoveBackground;
 		els.postRemoveCheck.checked = defaults.postRemoveBackground;
-		els.quickBgRemovalScopeSelect.value = defaults.bgRemovalScope;
 		els.advancedBgRemovalScopeSelect.value = defaults.bgRemovalScope;
 		els.bgConnectivitySelect.value = defaults.bgConnectivity;
 		els.smallComponentModeSelect.value = defaults.smallComponentMode;
@@ -292,8 +291,9 @@ export const setupSettingsControls = ({
 		els.quickReductionModeSelect.value = QUICK_SETTINGS_DEFAULTS.reductionMode;
 		els.quickBackgroundSelect.value = QUICK_SETTINGS_DEFAULTS.background;
 		els.quickDitheringSelect.value = QUICK_SETTINGS_DEFAULTS.dithering;
-		els.quickOutlineStyleSelect.value = QUICK_SETTINGS_DEFAULTS.outlineStyle;
-		els.quickAutoTrimCheck.checked = QUICK_SETTINGS_DEFAULTS.trimToContent;
+		els.quickAutoTrimSelect.value = QUICK_SETTINGS_DEFAULTS.trimToContent
+			? "auto"
+			: "none";
 		els.builtInPresetSelect.value = "auto";
 
 		// 言語切替ボタンのイベントリスナー

--- a/src/browser/settings-options.test.ts
+++ b/src/browser/settings-options.test.ts
@@ -14,10 +14,8 @@ const quickElements = (): Elements =>
 		quickReductionModeSelect: select("pico8"),
 		quickBackgroundSelect: select("keep"),
 		quickBackgroundColorInput: input("#abcdef"),
-		quickBgRemovalScopeSelect: select("all"),
 		quickDitheringSelect: select("strong"),
-		quickOutlineStyleSelect: select("sharp"),
-		quickAutoTrimCheck: input("", true),
+		quickAutoTrimSelect: select("auto"),
 	}) as Elements;
 
 describe("settings mode options", () => {
@@ -48,6 +46,7 @@ describe("settings mode options", () => {
 			detailLevel: "detailed",
 			reduceColorMode: "pico8",
 			bgExtractionMethod: "none",
+			trimToContent: false,
 			ditherMode: "floyd-steinberg",
 		});
 		expect(options.fixedPalette).toBeUndefined();

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -1009,10 +1009,6 @@ select:focus {
   grid-column: 1 / -1;
 }
 
-.quick-checkbox-setting input {
-  align-self: flex-start;
-}
-
 .quick-background-picker {
   display: none;
   gap: 8px;


### PR DESCRIPTION
## 概要

かんたん設定の背景透過と後処理項目を、用途が分かりやすい選択肢へ整理します。

## 変更内容

### UI/UX

- かんたん設定で「背景」を「背景透過」に改め、選択肢を「なし」「自動」と簡潔に表現します。
- 背景透過の範囲とアウトラインを詳細設定に集約し、自動トリムを「自動／なし」のセレクトに変更します。

### ロジック

- かんたん設定では背景透過範囲を「おまかせ」、アウトラインを「なし」に固定し、背景透過「なし」のときは自動トリムも無効にします。

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
