### PR TITLE
fix: 無効な設定を非表示に統一

### DIFF
--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -371,6 +371,8 @@ export const setupSettingsControls = ({
 	};
 
 	applyConfigToUi();
+	// [Intended] HTML の初期値ではなく、適用済みのかんたん設定の既定値で表示状態を決める。
+	updateQuickSettingsDisabledStates(els);
 	syncSliderAndInput(els.quantStepSlider, els.quantStepInput);
 	syncSliderAndInput(els.sampleWindowSlider, els.sampleWindowInput);
 	syncSliderAndInput(els.toleranceSlider, els.toleranceInput);

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -995,16 +995,6 @@ select:focus {
   gap: 20px;
 }
 
-/* [Intended] 詳細設定の disabled は非表示だが、かんたん設定では無効な組み合わせを見せる。 */
-.quick-settings-grid .setting-item.disabled {
-  display: flex;
-  opacity: 0.5;
-}
-
-.quick-settings-grid .setting-item.disabled .help {
-  opacity: 1;
-}
-
 .quick-preset-setting {
   grid-column: 1 / -1;
 }
@@ -1958,7 +1948,7 @@ select:focus {
 }
 
 .batch-shared-palette-settings.disabled {
-  opacity: 0.5;
+  display: none;
 }
 
 .batch-shared-palette-settings .setting-item {


### PR DESCRIPTION
## 概要

無効な設定項目を画面から隠し、選択内容に応じて有効な項目だけを表示します。

## 変更内容

### UI/UX

- かんたん設定と共有パレット設定で、現在の選択では無効な項目を非表示にします。
- 初期表示では背景透過の既定値を反映して、自動トリムを表示します。

### ロジック

- なし

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
