### PR TITLE
feat: かんたん設定のサイズを5段階に拡張

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,29 +638,35 @@
                     </label>
                     <label class="setting-item">
                       <span class="label-text">
-                        <span data-i18n="setting.detail">Detail</span>
+                        <span data-i18n="setting.size">Size</span>
                         <span
                           class="help"
                           data-i18n-attr="data-tooltip:tooltip.help.quick_detail"
-                          data-tooltip="Controls output size on the Convert route without changing color count or other settings. In Auto, it applies only when Convert is selected."
+                          data-tooltip="Selects the approximate output size relative to the automatically calculated reference size (100%) on the Convert route. It does not change color count or other settings. In Auto, it applies only when Convert is selected."
                           >?</span
                         >
                       </span>
                       <select id="quick-detail-level">
-                        <option value="coarse" data-i18n="option.detail_coarse">
-                          Coarse
-                        </option>
                         <option
-                          value="balanced"
-                          data-i18n="option.detail_balanced"
+                          value="smallest"
+                          data-i18n="option.size_smallest"
                         >
-                          Balanced
+                          25%
+                        </option>
+                        <option value="small" data-i18n="option.size_small">
+                          50%
+                        </option>
+                        <option value="coarse" data-i18n="option.size_medium">
+                          65%
+                        </option>
+                        <option value="balanced" data-i18n="option.size_large">
+                          100%
                         </option>
                         <option
                           value="detailed"
-                          data-i18n="option.detail_detailed"
+                          data-i18n="option.size_largest"
                         >
-                          Detailed
+                          150%
                         </option>
                       </select>
                     </label>

--- a/index.html
+++ b/index.html
@@ -642,31 +642,34 @@
                         <span
                           class="help"
                           data-i18n-attr="data-tooltip:tooltip.help.quick_detail"
-                          data-tooltip="Selects the approximate output size relative to the automatically calculated reference size (100%) on the Convert route. It does not change color count or other settings. In Auto, it applies only when Convert is selected."
+                          data-tooltip="Chooses from five output sizes on the Convert route. Standard uses the automatically calculated reference size, and Large never upscales beyond the original image. It does not change color count or other settings. In Auto, it applies only when Convert is selected."
                           >?</span
                         >
                       </span>
                       <select id="quick-detail-level">
                         <option
                           value="smallest"
-                          data-i18n="option.size_smallest"
+                          data-i18n="option.size_very_small"
                         >
-                          25%
+                          Very small
                         </option>
                         <option value="small" data-i18n="option.size_small">
-                          50%
-                        </option>
-                        <option value="coarse" data-i18n="option.size_medium">
-                          65%
-                        </option>
-                        <option value="balanced" data-i18n="option.size_large">
-                          100%
+                          Small
                         </option>
                         <option
-                          value="detailed"
-                          data-i18n="option.size_largest"
+                          value="coarse"
+                          data-i18n="option.size_slightly_small"
                         >
-                          150%
+                          Slightly small
+                        </option>
+                        <option
+                          value="balanced"
+                          data-i18n="option.size_standard"
+                        >
+                          Standard
+                        </option>
+                        <option value="detailed" data-i18n="option.size_large">
+                          Large
                         </option>
                       </select>
                     </label>

--- a/src/browser/i18n.test.ts
+++ b/src/browser/i18n.test.ts
@@ -170,6 +170,7 @@ describe("I18nManager", () => {
 			i18n.setLanguage(lang);
 			expect(i18n.t("preset.photo_to_pixel")).not.toBe("preset.photo_to_pixel");
 			for (const key of [
+				"setting.size",
 				"tooltip.help.quick_preset",
 				"tooltip.help.quick_processing_mode",
 				"tooltip.help.quick_detail",
@@ -179,6 +180,11 @@ describe("I18nManager", () => {
 				"tooltip.help.quick_auto_trim",
 				"option.auto_trim_auto",
 				"option.auto_trim_none",
+				"option.size_smallest",
+				"option.size_small",
+				"option.size_medium",
+				"option.size_large",
+				"option.size_largest",
 			] as const) {
 				expect(i18n.t(key)).not.toBe(key);
 			}

--- a/src/browser/i18n.test.ts
+++ b/src/browser/i18n.test.ts
@@ -180,11 +180,11 @@ describe("I18nManager", () => {
 				"tooltip.help.quick_auto_trim",
 				"option.auto_trim_auto",
 				"option.auto_trim_none",
-				"option.size_smallest",
+				"option.size_very_small",
 				"option.size_small",
-				"option.size_medium",
+				"option.size_slightly_small",
+				"option.size_standard",
 				"option.size_large",
-				"option.size_largest",
 			] as const) {
 				expect(i18n.t(key)).not.toBe(key);
 			}

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -1,3 +1,7 @@
+import { CONVERT_DETAIL_SCALES } from "../shared/config";
+
+const asPercentage = (scale: number): string => `${String(scale * 100)}%`;
+
 export type Language = "ja" | "en" | "zh-CN";
 
 const isLanguage = (value: string | null): value is Language =>
@@ -78,6 +82,7 @@ const resources = {
 		"setting.quick": "かんたん設定",
 		"setting.preset": "プリセット",
 		"setting.processing_mode": "処理方法",
+		"setting.size": "サイズ",
 		"setting.detail": "細かさ",
 		"setting.background": "背景透過",
 		"setting.dithering": "ディザリング",
@@ -91,6 +96,11 @@ const resources = {
 		"option.processing_refine": "ドットを整える",
 		"option.processing_convert": "ドット絵へ変換",
 		"option.processing_preserve": "原寸を維持",
+		"option.size_smallest": `最小（${asPercentage(CONVERT_DETAIL_SCALES.smallest)}）`,
+		"option.size_small": `小（${asPercentage(CONVERT_DETAIL_SCALES.small)}）`,
+		"option.size_medium": `中（${asPercentage(CONVERT_DETAIL_SCALES.coarse)}）`,
+		"option.size_large": `大（${asPercentage(CONVERT_DETAIL_SCALES.balanced)}）`,
+		"option.size_largest": `最大（${asPercentage(CONVERT_DETAIL_SCALES.detailed)}）`,
 		"option.detail_coarse": "粗め",
 		"option.detail_balanced": "バランス",
 		"option.detail_detailed": "細かめ",
@@ -198,7 +208,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"画像の処理方法を選びます。\n\nAuto: 画像を解析して処理経路を自動選択。\nドットを整える: 拡大・補間されたドット絵を復元。\nドット絵へ変換: 通常画像をドット絵化。\n原寸を維持: 縮小せずに仕上げます。",
 		"tooltip.help.quick_detail":
-			"「ドット絵へ変換」で使う出力サイズを調整します。色数など、ほかの設定には影響しません。\n\nAutoでは「ドット絵へ変換」が選ばれた画像にだけ適用されます。",
+			"「ドット絵へ変換」で、自動算出した基準サイズ（100%）に対する出力サイズの目安を選びます。色数など、ほかの設定には影響しません。\n\nAutoでは「ドット絵へ変換」が選ばれた画像にだけ適用されます。",
 		"tooltip.help.quick_reduction_mode":
 			"減色しないか、固定色数または標準パレットで減色するかを選びます。任意の色数指定と固定パレットの読み込みは詳細設定で行えます。",
 		"tooltip.help.quick_background":
@@ -467,6 +477,7 @@ const resources = {
 		"setting.quick": "快速设置",
 		"setting.preset": "预设",
 		"setting.processing_mode": "处理方式",
+		"setting.size": "尺寸",
 		"setting.detail": "细节",
 		"setting.background": "背景透明",
 		"setting.dithering": "抖动",
@@ -480,6 +491,11 @@ const resources = {
 		"option.processing_refine": "优化像素",
 		"option.processing_convert": "转换为像素画",
 		"option.processing_preserve": "保持原尺寸",
+		"option.size_smallest": `最小（${asPercentage(CONVERT_DETAIL_SCALES.smallest)}）`,
+		"option.size_small": `小（${asPercentage(CONVERT_DETAIL_SCALES.small)}）`,
+		"option.size_medium": `中（${asPercentage(CONVERT_DETAIL_SCALES.coarse)}）`,
+		"option.size_large": `大（${asPercentage(CONVERT_DETAIL_SCALES.balanced)}）`,
+		"option.size_largest": `最大（${asPercentage(CONVERT_DETAIL_SCALES.detailed)}）`,
 		"option.detail_coarse": "粗略",
 		"option.detail_balanced": "平衡",
 		"option.detail_detailed": "精细",
@@ -586,7 +602,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"选择图像的处理方式。\n\nAuto：分析图像并自动选择处理路径。\n优化像素：还原放大或插值后的像素画。\n转换为像素画：把普通图像转换为像素画。\n保持原尺寸：不缩小图像。",
 		"tooltip.help.quick_detail":
-			"调整“转换为像素画”路径的输出尺寸，不影响颜色数量等其他设置。\n\n在Auto中，仅当图像选择了转换路径时生效。",
+			"在“转换为像素画”路径中，选择相对于自动计算的基准尺寸（100%）的近似输出尺寸，不影响颜色数量等其他设置。\n\n在Auto中，仅当图像选择了转换路径时生效。",
 		"tooltip.help.quick_reduction_mode":
 			"选择不减色、固定颜色数量或内置标准调色板。任意颜色数量和导入固定调色板可在高级设置中指定。",
 		"tooltip.help.quick_background":
@@ -855,6 +871,7 @@ const resources = {
 		"setting.quick": "Quick Settings",
 		"setting.preset": "Preset",
 		"setting.processing_mode": "Processing",
+		"setting.size": "Size",
 		"setting.detail": "Detail",
 		"setting.background": "Background Transparency",
 		"setting.dithering": "Dithering",
@@ -868,6 +885,11 @@ const resources = {
 		"option.processing_refine": "Refine Pixels",
 		"option.processing_convert": "Convert to Pixel Art",
 		"option.processing_preserve": "Preserve Original Size",
+		"option.size_smallest": `Smallest (${asPercentage(CONVERT_DETAIL_SCALES.smallest)})`,
+		"option.size_small": `Small (${asPercentage(CONVERT_DETAIL_SCALES.small)})`,
+		"option.size_medium": `Medium (${asPercentage(CONVERT_DETAIL_SCALES.coarse)})`,
+		"option.size_large": `Large (${asPercentage(CONVERT_DETAIL_SCALES.balanced)})`,
+		"option.size_largest": `Largest (${asPercentage(CONVERT_DETAIL_SCALES.detailed)})`,
 		"option.detail_coarse": "Coarse",
 		"option.detail_balanced": "Balanced",
 		"option.detail_detailed": "Detailed",
@@ -975,7 +997,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"Chooses how the image is processed.\n\nAuto: Analyzes the image and selects a route.\nRefine: Restores enlarged or interpolated pixel art.\nConvert: Turns a regular image into pixel art.\nPreserve: Avoids downscaling.",
 		"tooltip.help.quick_detail":
-			"Controls output size on the Convert route without changing color count or other settings.\n\nIn Auto, it applies only to images assigned to Convert.",
+			"Selects the approximate output size relative to the automatically calculated reference size (100%) on the Convert route. It does not change color count or other settings.\n\nIn Auto, it applies only to images assigned to Convert.",
 		"tooltip.help.quick_reduction_mode":
 			"Selects no color reduction, a fixed color count, or a built-in standard palette. Arbitrary color counts and imported fixed palettes are available in Advanced Settings.",
 		"tooltip.help.quick_background":

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -1,7 +1,3 @@
-import { CONVERT_DETAIL_SCALES } from "../shared/config";
-
-const asPercentage = (scale: number): string => `${String(scale * 100)}%`;
-
 export type Language = "ja" | "en" | "zh-CN";
 
 const isLanguage = (value: string | null): value is Language =>
@@ -96,11 +92,11 @@ const resources = {
 		"option.processing_refine": "ドットを整える",
 		"option.processing_convert": "ドット絵へ変換",
 		"option.processing_preserve": "原寸を維持",
-		"option.size_smallest": `最小（${asPercentage(CONVERT_DETAIL_SCALES.smallest)}）`,
-		"option.size_small": `小（${asPercentage(CONVERT_DETAIL_SCALES.small)}）`,
-		"option.size_medium": `中（${asPercentage(CONVERT_DETAIL_SCALES.coarse)}）`,
-		"option.size_large": `大（${asPercentage(CONVERT_DETAIL_SCALES.balanced)}）`,
-		"option.size_largest": `最大（${asPercentage(CONVERT_DETAIL_SCALES.detailed)}）`,
+		"option.size_very_small": "とても小さい",
+		"option.size_small": "小さい",
+		"option.size_slightly_small": "やや小さい",
+		"option.size_standard": "標準",
+		"option.size_large": "大きい",
 		"option.detail_coarse": "粗め",
 		"option.detail_balanced": "バランス",
 		"option.detail_detailed": "細かめ",
@@ -208,7 +204,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"画像の処理方法を選びます。\n\nAuto: 画像を解析して処理経路を自動選択。\nドットを整える: 拡大・補間されたドット絵を復元。\nドット絵へ変換: 通常画像をドット絵化。\n原寸を維持: 縮小せずに仕上げます。",
 		"tooltip.help.quick_detail":
-			"「ドット絵へ変換」で、自動算出した基準サイズ（100%）に対する出力サイズの目安を選びます。色数など、ほかの設定には影響しません。\n\nAutoでは「ドット絵へ変換」が選ばれた画像にだけ適用されます。",
+			"「ドット絵へ変換」で使う出力サイズを5段階から選びます。「標準」は自動算出した基準サイズで、「大きい」も元画像を超えて拡大しません。色数など、ほかの設定には影響しません。\n\nAutoでは「ドット絵へ変換」が選ばれた画像にだけ適用されます。",
 		"tooltip.help.quick_reduction_mode":
 			"減色しないか、固定色数または標準パレットで減色するかを選びます。任意の色数指定と固定パレットの読み込みは詳細設定で行えます。",
 		"tooltip.help.quick_background":
@@ -491,11 +487,11 @@ const resources = {
 		"option.processing_refine": "优化像素",
 		"option.processing_convert": "转换为像素画",
 		"option.processing_preserve": "保持原尺寸",
-		"option.size_smallest": `最小（${asPercentage(CONVERT_DETAIL_SCALES.smallest)}）`,
-		"option.size_small": `小（${asPercentage(CONVERT_DETAIL_SCALES.small)}）`,
-		"option.size_medium": `中（${asPercentage(CONVERT_DETAIL_SCALES.coarse)}）`,
-		"option.size_large": `大（${asPercentage(CONVERT_DETAIL_SCALES.balanced)}）`,
-		"option.size_largest": `最大（${asPercentage(CONVERT_DETAIL_SCALES.detailed)}）`,
+		"option.size_very_small": "非常小",
+		"option.size_small": "小",
+		"option.size_slightly_small": "较小",
+		"option.size_standard": "标准",
+		"option.size_large": "大",
 		"option.detail_coarse": "粗略",
 		"option.detail_balanced": "平衡",
 		"option.detail_detailed": "精细",
@@ -602,7 +598,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"选择图像的处理方式。\n\nAuto：分析图像并自动选择处理路径。\n优化像素：还原放大或插值后的像素画。\n转换为像素画：把普通图像转换为像素画。\n保持原尺寸：不缩小图像。",
 		"tooltip.help.quick_detail":
-			"在“转换为像素画”路径中，选择相对于自动计算的基准尺寸（100%）的近似输出尺寸，不影响颜色数量等其他设置。\n\n在Auto中，仅当图像选择了转换路径时生效。",
+			"在“转换为像素画”路径中，从五档输出尺寸中进行选择。“标准”使用自动计算的基准尺寸，“大”也不会放大到超过原图尺寸。不影响颜色数量等其他设置。\n\n在Auto中，仅当图像选择了转换路径时生效。",
 		"tooltip.help.quick_reduction_mode":
 			"选择不减色、固定颜色数量或内置标准调色板。任意颜色数量和导入固定调色板可在高级设置中指定。",
 		"tooltip.help.quick_background":
@@ -885,11 +881,11 @@ const resources = {
 		"option.processing_refine": "Refine Pixels",
 		"option.processing_convert": "Convert to Pixel Art",
 		"option.processing_preserve": "Preserve Original Size",
-		"option.size_smallest": `Smallest (${asPercentage(CONVERT_DETAIL_SCALES.smallest)})`,
-		"option.size_small": `Small (${asPercentage(CONVERT_DETAIL_SCALES.small)})`,
-		"option.size_medium": `Medium (${asPercentage(CONVERT_DETAIL_SCALES.coarse)})`,
-		"option.size_large": `Large (${asPercentage(CONVERT_DETAIL_SCALES.balanced)})`,
-		"option.size_largest": `Largest (${asPercentage(CONVERT_DETAIL_SCALES.detailed)})`,
+		"option.size_very_small": "Very small",
+		"option.size_small": "Small",
+		"option.size_slightly_small": "Slightly small",
+		"option.size_standard": "Standard",
+		"option.size_large": "Large",
 		"option.detail_coarse": "Coarse",
 		"option.detail_balanced": "Balanced",
 		"option.detail_detailed": "Detailed",
@@ -997,7 +993,7 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"Chooses how the image is processed.\n\nAuto: Analyzes the image and selects a route.\nRefine: Restores enlarged or interpolated pixel art.\nConvert: Turns a regular image into pixel art.\nPreserve: Avoids downscaling.",
 		"tooltip.help.quick_detail":
-			"Selects the approximate output size relative to the automatically calculated reference size (100%) on the Convert route. It does not change color count or other settings.\n\nIn Auto, it applies only to images assigned to Convert.",
+			"Chooses from five output sizes on the Convert route. Standard uses the automatically calculated reference size, and Large never upscales beyond the original image. It does not change color count or other settings.\n\nIn Auto, it applies only to images assigned to Convert.",
 		"tooltip.help.quick_reduction_mode":
 			"Selects no color reduction, a fixed color count, or a built-in standard palette. Arbitrary color counts and imported fixed palettes are available in Advanced Settings.",
 		"tooltip.help.quick_background":

--- a/src/browser/quick-settings.test.ts
+++ b/src/browser/quick-settings.test.ts
@@ -68,10 +68,10 @@ describe("quick settings", () => {
 		},
 	);
 
-	it("changes only size-related settings when detail changes", () => {
-		const coarse = createQuickProcessOptions({
+	it("changes only the size level across the full five-step range", () => {
+		const smallest = createQuickProcessOptions({
 			...QUICK_SETTINGS_DEFAULTS,
-			detailLevel: "coarse",
+			detailLevel: "smallest",
 			reductionMode: "pico8",
 			dithering: "strong",
 		});
@@ -82,13 +82,13 @@ describe("quick settings", () => {
 			dithering: "strong",
 		});
 
-		expect(coarse.detailLevel).toBe("coarse");
+		expect(smallest.detailLevel).toBe("smallest");
 		expect(detailed.detailLevel).toBe("detailed");
 		expect({
-			mode: coarse.reduceColorMode,
-			count: coarse.colorCount,
-			dither: coarse.ditherMode,
-			strength: coarse.ditherStrength,
+			mode: smallest.reduceColorMode,
+			count: smallest.colorCount,
+			dither: smallest.ditherMode,
+			strength: smallest.ditherStrength,
 		}).toEqual({
 			mode: detailed.reduceColorMode,
 			count: detailed.colorCount,

--- a/src/core/converter.test.ts
+++ b/src/core/converter.test.ts
@@ -18,16 +18,20 @@ const createIllustration = (width = 96, height = 64): RawImage => {
 };
 
 describe("continuous image converter", () => {
-	it("creates three aspect-aware and visually distinct detail candidates", () => {
+	it("creates five aspect-aware size candidates in ascending order", () => {
 		const candidates = createConvertCandidates(createIllustration());
 
 		expect(candidates.map((candidate) => candidate.label)).toEqual([
+			"smallest",
+			"small",
 			"coarse",
 			"balanced",
 			"detailed",
 		]);
-		expect(candidates[0].outW).toBeLessThan(candidates[1].outW);
-		expect(candidates[1].outW).toBeLessThan(candidates[2].outW);
+		for (let i = 1; i < candidates.length; i += 1) {
+			expect(candidates[i - 1].outW).toBeLessThan(candidates[i].outW);
+			expect(candidates[i - 1].outH).toBeLessThan(candidates[i].outH);
+		}
 		for (const candidate of candidates) {
 			expect(candidate.outW).toBeGreaterThan(1);
 			expect(candidate.outH).toBeGreaterThan(1);
@@ -139,7 +143,7 @@ describe("continuous image converter", () => {
 			data: new Uint8ClampedArray([123, 45, 67, 0]),
 		};
 
-		expect(createConvertCandidates(transparent)).toHaveLength(3);
+		expect(createConvertCandidates(transparent)).toHaveLength(5);
 		expect(edgeAwareAreaResample(transparent, 1, 1).data).toEqual(
 			new Uint8ClampedArray(4),
 		);

--- a/src/core/converter.ts
+++ b/src/core/converter.ts
@@ -1,7 +1,7 @@
 import { CONVERT_DETAIL_SCALES, CONVERT_LIMITS } from "../shared/config";
 import type { ConvertCandidate, DetailLevel, RawImage } from "../shared/types";
 
-const LABELS = ["coarse", "balanced", "detailed"] as const;
+const LABELS = ["smallest", "small", "coarse", "balanced", "detailed"] as const;
 
 const clamp = (value: number, min: number, max: number): number =>
 	Math.min(max, Math.max(min, value));

--- a/src/core/processor-routing.test.ts
+++ b/src/core/processor-routing.test.ts
@@ -75,25 +75,33 @@ describe("processing router", () => {
 		expect(processed.analysis.route).toBe("convert");
 		expect(processed.result.width).toBeLessThan(image.width);
 		expect(processed.result.height).toBeLessThan(image.height);
-		expect(processed.analysis.gridCandidates).toHaveLength(3);
+		expect(processed.analysis.gridCandidates).toHaveLength(5);
 		expect(processed.extractedPalette.length).toBeLessThanOrEqual(24);
 	});
 
-	it("selects visibly different convert sizes from the detail level", () => {
+	it("selects visibly different convert sizes from all five size levels", () => {
 		const image = createContinuousImage();
-		const coarse = processImage(image, {
-			...safeOptions,
-			processingMode: "convert",
-			detailLevel: "coarse",
-		});
-		const detailed = processImage(image, {
-			...safeOptions,
-			processingMode: "convert",
-			detailLevel: "detailed",
-		});
+		const detailLevels = [
+			"smallest",
+			"small",
+			"coarse",
+			"balanced",
+			"detailed",
+		] as const;
+		const results = detailLevels.map((detailLevel) =>
+			processImage(image, {
+				...safeOptions,
+				processingMode: "convert",
+				detailLevel,
+			}),
+		);
 
-		expect(coarse.result.width).toBeLessThan(detailed.result.width);
-		expect(coarse.result.height).toBeLessThan(detailed.result.height);
+		for (let i = 1; i < results.length; i += 1) {
+			expect(results[i - 1].result.width).toBeLessThan(results[i].result.width);
+			expect(results[i - 1].result.height).toBeLessThan(
+				results[i].result.height,
+			);
+		}
 	});
 
 	it.each([
@@ -182,7 +190,7 @@ describe("processing router", () => {
 			detailLevel: "detailed",
 		});
 
-		expect(processed.analysis.selectedCandidateIndex).toBe(2);
+		expect(processed.analysis.selectedCandidateIndex).toBe(4);
 		expect(
 			processed.analysis.gridCandidates[
 				processed.analysis.selectedCandidateIndex ?? -1

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -231,6 +231,8 @@ export const CONVERT_LIMITS = {
 } as const;
 
 export const CONVERT_DETAIL_SCALES = {
+	smallest: 0.25,
+	small: 0.5,
 	coarse: 0.65,
 	balanced: 1,
 	detailed: 1.5,
@@ -241,7 +243,7 @@ export const CONVERT_DEFAULTS = {
 	reduceColors: true,
 	reduceColorMode: "auto",
 	ditherMode: "ordered",
-	// [Intended] 細かさは出力サイズだけを変える。色数とディザ強度は独立した既定値にする。
+	// [Intended] サイズは出力寸法だけを変える。色数とディザ強度は独立した既定値にする。
 	colorCount: 24,
 	ditherStrength: 20,
 } as const;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -118,7 +118,12 @@ export type ProcessingRoute = "refine" | "convert" | "preserve";
 
 export type ProcessingMode = "auto" | ProcessingRoute;
 
-export type DetailLevel = "coarse" | "balanced" | "detailed";
+export type DetailLevel =
+	| "smallest"
+	| "small"
+	| "coarse"
+	| "balanced"
+	| "detailed";
 
 export type SmallComponentRemovalMode = "off" | "light" | "auto" | "strong";
 


### PR DESCRIPTION
## 概要

かんたん設定でドット絵変換時の出力サイズを、誤解のない相対表現の5段階から選択できるようにします。

## 変更内容

### UI/UX

- かんたん設定の「細かさ」を「サイズ」に変更し、「とても小さい」から「大きい」までの5段階を日本語・英語・中国語で表示します。

### ロジック

- ドット絵変換で従来より小さい出力候補を2段階追加し、「大きい」を選んでも元画像を超えて拡大しないようにします。

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
