### PR TITLE
fix: tmp配下のテストを通常CIから除外

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm exec vite build",
     "preview": "pnpm exec vite preview",
     "test": "pnpm exec vitest run",
-    "test:unit": "pnpm exec vitest run --exclude 'test/quality/shards/**'",
+    "test:unit": "pnpm exec vitest run --exclude 'test/quality/shards/**' --exclude 'tmp/**'",
     "test:watch": "pnpm exec vitest",
     "test:quality": "QUALITY_PROFILE=smoke pnpm exec vitest run test/quality/cases.test.ts test/quality/shards",
     "test:quality:full": "QUALITY_PROFILE=full pnpm exec vitest run test/quality/cases.test.ts test/quality/shards",


### PR DESCRIPTION
## 概要

ローカル生成物に含まれる実験用テストが通常CIへ混入しないようにします。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 通常CIでは `tmp` 配下を単体テスト探索から除外し、ローカルの実験用ファイルに左右されず検証できるようにします。

### その他

- なし

## 動作確認

- なし
