### PR TITLE
fix: Auto処理中のサイズ項目表示を安定化

### DIFF
--- a/src/browser/quick-settings-controls.test.ts
+++ b/src/browser/quick-settings-controls.test.ts
@@ -94,6 +94,24 @@ describe("quick settings controls", () => {
 		expect(triggerAutoProcess).toHaveBeenCalledOnce();
 	});
 
+	it("keeps the confirmed Auto convert state while reprocessing", () => {
+		const els = createElements();
+		setupQuickSettingsControls({
+			els: els as unknown as Elements,
+			triggerAutoProcess: vi.fn(),
+			clearCandidateSelections: vi.fn(),
+		});
+		updateQuickSettingsDisabledStates(els as unknown as Elements, "convert");
+
+		els.quickBackgroundSelect.value = "keep";
+		els.quickBackgroundSelect.dispatchEvent(new Event("change"));
+
+		expect(els.quickDetailLevelSelect.disabled).toBe(false);
+		expect(
+			els.quickDetailLevelSelect.settingItem.classList.contains("disabled"),
+		).toBe(false);
+	});
+
 	it("updates detail immediately for an explicit processing route", () => {
 		const els = createElements();
 		setupQuickSettingsControls({

--- a/src/browser/quick-settings-controls.test.ts
+++ b/src/browser/quick-settings-controls.test.ts
@@ -74,6 +74,41 @@ describe("quick settings controls", () => {
 		expect(els.quickDetailLevelSelect.disabled).toBe(false);
 	});
 
+	it("keeps the confirmed Auto route state while reprocessing", () => {
+		const els = createElements();
+		const triggerAutoProcess = vi.fn();
+		setupQuickSettingsControls({
+			els: els as unknown as Elements,
+			triggerAutoProcess,
+			clearCandidateSelections: vi.fn(),
+		});
+		updateQuickSettingsDisabledStates(els as unknown as Elements, "refine");
+
+		els.quickBackgroundSelect.value = "keep";
+		els.quickBackgroundSelect.dispatchEvent(new Event("change"));
+
+		expect(els.quickDetailLevelSelect.disabled).toBe(true);
+		expect(
+			els.quickDetailLevelSelect.settingItem.classList.contains("disabled"),
+		).toBe(true);
+		expect(triggerAutoProcess).toHaveBeenCalledOnce();
+	});
+
+	it("updates detail immediately for an explicit processing route", () => {
+		const els = createElements();
+		setupQuickSettingsControls({
+			els: els as unknown as Elements,
+			triggerAutoProcess: vi.fn(),
+			clearCandidateSelections: vi.fn(),
+		});
+		updateQuickSettingsDisabledStates(els as unknown as Elements, "refine");
+
+		els.quickProcessingModeSelect.value = "convert";
+		els.quickProcessingModeSelect.dispatchEvent(new Event("change"));
+
+		expect(els.quickDetailLevelSelect.disabled).toBe(false);
+	});
+
 	it("disables dependent controls only", () => {
 		const els = createElements();
 		els.quickBackgroundSelect.value = "keep";

--- a/src/browser/quick-settings-controls.test.ts
+++ b/src/browser/quick-settings-controls.test.ts
@@ -109,6 +109,26 @@ describe("quick settings controls", () => {
 		expect(els.quickDetailLevelSelect.disabled).toBe(false);
 	});
 
+	it("re-enables detail when switching back to Auto", () => {
+		const els = createElements();
+		setupQuickSettingsControls({
+			els: els as unknown as Elements,
+			triggerAutoProcess: vi.fn(),
+			clearCandidateSelections: vi.fn(),
+		});
+		els.quickProcessingModeSelect.value = "refine";
+		els.quickProcessingModeSelect.dispatchEvent(new Event("change"));
+		expect(els.quickDetailLevelSelect.disabled).toBe(true);
+
+		els.quickProcessingModeSelect.value = "auto";
+		els.quickProcessingModeSelect.dispatchEvent(new Event("change"));
+
+		expect(els.quickDetailLevelSelect.disabled).toBe(false);
+		expect(
+			els.quickDetailLevelSelect.settingItem.classList.contains("disabled"),
+		).toBe(false);
+	});
+
 	it("disables dependent controls only", () => {
 		const els = createElements();
 		els.quickBackgroundSelect.value = "keep";

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -22,6 +22,10 @@ export type QuickSettingsControls = {
 	setBackgroundColor: (hex: string) => void;
 };
 
+type QuickSettingsDisabledStateOptions = {
+	preservePendingAutoRoute?: boolean;
+};
+
 const setQuickControlDisabled = (
 	control: HTMLInputElement | HTMLSelectElement,
 	disabled: boolean,
@@ -36,16 +40,25 @@ const setQuickControlDisabled = (
 export const updateQuickSettingsDisabledStates = (
 	els: Elements,
 	activeRoute?: ProcessingRoute,
+	options: QuickSettingsDisabledStateOptions = {},
 ): void => {
 	const processingMode = els.quickProcessingModeSelect.value as ProcessingMode;
 	const effectiveRoute =
 		processingMode === "auto" ? activeRoute : processingMode;
-	// [Intended] Auto は画像ごとに経路が変わるため、処理結果が無い間は選択を許可する。
-	// 結果が出た後は、その画像で実際に採用された経路に合わせて無効状態を示す。
-	setQuickControlDisabled(
-		els.quickDetailLevelSelect,
-		effectiveRoute !== undefined && effectiveRoute !== "convert",
-	);
+	// [Intended] Auto の再処理中は直前に確定した経路の表示状態を維持し、
+	// 新しい処理結果が確定してからサイズ項目を切り替える。
+	if (
+		!(
+			processingMode === "auto" &&
+			options.preservePendingAutoRoute &&
+			activeRoute === undefined
+		)
+	) {
+		setQuickControlDisabled(
+			els.quickDetailLevelSelect,
+			effectiveRoute !== undefined && effectiveRoute !== "convert",
+		);
+	}
 
 	const background = els.quickBackgroundSelect.value as QuickBackground;
 	els.quickBackgroundPicker.style.display =
@@ -93,7 +106,9 @@ export const setupQuickSettingsControls = ({
 	].forEach((control) => {
 		control.addEventListener("change", () => {
 			clearCandidateSelections();
-			updateQuickSettingsDisabledStates(els);
+			updateQuickSettingsDisabledStates(els, undefined, {
+				preservePendingAutoRoute: true,
+			});
 			triggerAutoProcess();
 		});
 	});

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -96,8 +96,22 @@ export const setupQuickSettingsControls = ({
 		els.quickBackgroundColorInput.value = hex;
 	};
 
+	const handleQuickSettingChange = (preservePendingAutoRoute: boolean) => {
+		clearCandidateSelections();
+		updateQuickSettingsDisabledStates(els, undefined, {
+			preservePendingAutoRoute,
+		});
+		triggerAutoProcess();
+	};
+
+	// [Intended] 処理方法自体の変更では直前の表示状態を維持しない。
+	// 維持したいのは Auto のまま他項目を変えたときのちらつきだけで、
+	// 別モードから Auto へ切り替えた時点の表示状態は引き継ぐ対象ではない。
+	els.quickProcessingModeSelect.addEventListener("change", () => {
+		handleQuickSettingChange(false);
+	});
+
 	[
-		els.quickProcessingModeSelect,
 		els.quickDetailLevelSelect,
 		els.quickReductionModeSelect,
 		els.quickBackgroundSelect,
@@ -105,11 +119,7 @@ export const setupQuickSettingsControls = ({
 		els.quickAutoTrimSelect,
 	].forEach((control) => {
 		control.addEventListener("change", () => {
-			clearCandidateSelections();
-			updateQuickSettingsDisabledStates(els, undefined, {
-				preservePendingAutoRoute: true,
-			});
-			triggerAutoProcess();
+			handleQuickSettingChange(true);
 		});
 	});
 

--- a/src/browser/quick-settings-controls.ts
+++ b/src/browser/quick-settings-controls.ts
@@ -46,14 +46,13 @@ export const updateQuickSettingsDisabledStates = (
 	const effectiveRoute =
 		processingMode === "auto" ? activeRoute : processingMode;
 	// [Intended] Auto の再処理中は直前に確定した経路の表示状態を維持し、
-	// 新しい処理結果が確定してからサイズ項目を切り替える。
-	if (
-		!(
-			processingMode === "auto" &&
-			options.preservePendingAutoRoute &&
-			activeRoute === undefined
-		)
-	) {
+	// 新しい処理結果が確定してからサイズ項目を切り替える。維持するのは
+	// activeRoute が未確定のときだけで、確定経路を渡す呼び出しは常に更新する。
+	const keepPendingAutoRoute =
+		processingMode === "auto" &&
+		options.preservePendingAutoRoute === true &&
+		activeRoute === undefined;
+	if (!keepPendingAutoRoute) {
 		setQuickControlDisabled(
 			els.quickDetailLevelSelect,
 			effectiveRoute !== undefined && effectiveRoute !== "convert",

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -73,7 +73,9 @@ export const setupSettingsControls = ({
 		if (processingState.settingsMode === "quick") {
 			setBackgroundColor(hex);
 			els.quickBackgroundSelect.value = "pick";
-			updateQuickSettingsDisabledStates(els);
+			updateQuickSettingsDisabledStates(els, undefined, {
+				preservePendingAutoRoute: true,
+			});
 			imageSession.clearCandidateSelections();
 			return;
 		}


### PR DESCRIPTION
## 概要

Autoの再処理中に、サイズ項目が一時的に表示・非表示へ切り替わらないようにする。

## 変更内容

### UI/UX

- かんたん設定の処理方法がAutoの場合、処理方法以外の項目を変更したときはサイズ項目の表示状態を直前に確定した処理経路のまま維持し、次に処理経路が確定した時点で切り替える。自動処理が無効なときや対象画像が無いときは再処理が走らないため、次に処理経路が確定するまで維持され続ける。
- 処理方法そのものをAutoへ切り替えたときは維持せず、処理経路が未確定の状態としてその場でサイズ項目を切り替える。

### ロジック

- なし

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし

