### PR TITLE
feat: UIの視覚階層と配色を整理

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
     <meta name="application-name" content="Pixel Refiner" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" content="#f7f8fc" />
+    <meta name="theme-color" content="#f3f1eb" />
 
     <!-- ファビコン / アイコン -->
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
@@ -213,13 +213,13 @@
     <style>
       html,
       body {
-        background-color: #f7f8fc;
+        background-color: #f3f1eb;
       }
 
       @media (prefers-color-scheme: dark) {
         html:not([data-theme]),
         html:not([data-theme]) body {
-          background-color: #0f1115;
+          background-color: #121416;
         }
       }
 

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -4,8 +4,8 @@
   "description": "Optimize AI-generated pixel art into production-ready sprites.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0f1115",
-  "theme_color": "#0f1115",
+  "background_color": "#121416",
+  "theme_color": "#121416",
   "lang": "en",
   "icons": [
     {

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -22,7 +22,7 @@
   --surface-hover: rgb(32 36 38 / 0.06);
   --surface-hover-strong: rgb(32 36 38 / 0.12);
   --panel-hover-border: #9f988c;
-  --focus-ring: #ffbf47;
+  --focus-ring: #8a5300;
   --loading-overlay: rgb(15 17 21 / 0.82);
   --loading-text: #ffffff;
   --image-list-bg: #eeebe4;
@@ -73,6 +73,7 @@
   --surface-hover: rgb(255 255 255 / 0.05);
   --surface-hover-strong: rgb(255 255 255 / 0.1);
   --panel-hover-border: #596166;
+  --focus-ring: #ffbf47;
   --loading-overlay: rgb(15 17 21 / 0.8);
   --loading-text: #e2e8f0;
   --image-list-bg: #171a1c;

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -99,8 +99,10 @@
     --primary: #82add1;
     --primary-hover: #a1c4df;
     --primary-action: #315f87;
+    --primary-action-hover: #3d7099;
     --accent: #e18a6f;
     --accent-action: #9a402a;
+    --accent-action-hover: #b34c30;
     --text-main: #e6e3dc;
     --text-muted: #aeb5b8;
     --text-dim: #858e92;
@@ -109,6 +111,7 @@
     --surface-hover: rgb(255 255 255 / 0.05);
     --surface-hover-strong: rgb(255 255 255 / 0.1);
     --panel-hover-border: #596166;
+    --focus-ring: #ffbf47;
     --loading-overlay: rgb(15 17 21 / 0.8);
     --loading-text: #e2e8f0;
     --image-list-bg: #171a1c;

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -26,16 +26,16 @@
   --surface-hover-strong: rgb(32 36 38 / 0.12);
   --panel-hover-border: #9f988c;
   --focus-ring: #8a5300;
-  --loading-overlay: rgb(15 17 21 / 0.82);
+  --loading-overlay: rgb(32 36 38 / 0.82);
   --loading-text: #ffffff;
   --image-list-bg: #eeebe4;
   --scrollbar-track: #e9e6de;
   --scrollbar-thumb: #9f988c;
   --thumbnail-bg: #fbfaf7;
   --thumbnail-grid: #d6d0c5;
-  --preview-control-border: rgb(15 23 42 / 0.24);
-  --swatch-border: rgb(15 23 42 / 0.22);
-  --swatch-hover-border: rgb(15 23 42 / 0.65);
+  --preview-control-border: rgb(32 36 38 / 0.24);
+  --swatch-border: rgb(32 36 38 / 0.22);
+  --swatch-hover-border: rgb(32 36 38 / 0.65);
   --footer-icon-filter: invert(1);
 
   /* 文字 */

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -89,6 +89,7 @@
   --swatch-border: rgb(255 255 255 / 0.15);
   --swatch-hover-border: rgb(255 255 255 / 0.8);
   --footer-icon-filter: none;
+  --shadow-sm: 0 1px 1px rgb(0 0 0 / 0.2);
   --shadow-md: 0 2px 8px rgb(0 0 0 / 0.24);
   --shadow-xl: 0 12px 32px rgb(0 0 0 / 0.4);
 }
@@ -128,6 +129,7 @@
     --swatch-border: rgb(255 255 255 / 0.15);
     --swatch-hover-border: rgb(255 255 255 / 0.8);
     --footer-icon-filter: none;
+    --shadow-sm: 0 1px 1px rgb(0 0 0 / 0.2);
     --shadow-md: 0 2px 8px rgb(0 0 0 / 0.24);
     --shadow-xl: 0 12px 32px rgb(0 0 0 / 0.4);
   }

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -634,7 +634,7 @@ canvas {
 }
 
 .view-btn.active {
-  background: var(--primary);
+  background: var(--primary-action);
   color: white;
 }
 
@@ -837,9 +837,9 @@ select:focus {
 }
 
 .icon-button.active {
-  background: var(--primary);
+  background: var(--primary-action);
   color: white;
-  border-color: var(--primary);
+  border-color: var(--primary-action);
 }
 
 /* モーダル */
@@ -1274,7 +1274,7 @@ select:focus {
 	align-self: flex-start;
 	padding: 2px 7px;
 	border-radius: 0;
-	background: var(--primary);
+	background: var(--primary-action);
 	color: #fff;
 	font-size: 0.72rem;
 }
@@ -1298,7 +1298,7 @@ select:focus {
   bottom: 32px;
   left: 50%;
   transform: translateX(-50%) translateY(100px);
-  background: var(--accent);
+  background: var(--accent-action);
   color: white;
   padding: 12px 24px;
   border-radius: var(--radius-sm);

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -177,7 +177,6 @@ h1 {
 }
 
 .header-top {
-  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -185,7 +184,6 @@ h1 {
 }
 
 .header-actions {
-  position: static;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -250,10 +248,6 @@ h1 {
     flex-direction: column;
     align-items: flex-start;
     gap: 16px;
-  }
-
-  .header-actions {
-    position: static;
   }
 }
 

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -311,7 +311,6 @@ h2::before {
   width: 8px;
   height: 8px;
   background: var(--accent);
-  border-radius: 0;
 }
 
 main {
@@ -360,7 +359,6 @@ main {
   width: 6px;
   height: 6px;
   background: var(--primary);
-  border-radius: 0;
 }
 
 .panel:hover {
@@ -782,7 +780,6 @@ input[type="text"] {
 input[type="number"]:focus,
 input[type="text"]:focus {
   border-color: var(--primary);
-  box-shadow: none;
 }
 
 input[type="checkbox"] {
@@ -805,7 +802,6 @@ select {
 
 select:focus {
   border-color: var(--primary);
-  box-shadow: none;
 }
 
 .rgb-input-group {
@@ -989,7 +985,6 @@ select:focus {
   border-bottom-color: var(--accent);
   background: transparent;
   color: var(--text-main);
-  box-shadow: none;
 }
 
 .settings-tab-panel[hidden] {
@@ -1043,7 +1038,6 @@ select:focus {
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: background-color 0.15s, border-color 0.15s;
-  box-shadow: none;
   letter-spacing: 0.01em;
   display: flex;
   align-items: center;
@@ -1054,27 +1048,23 @@ select:focus {
 
 .action-button.download-button {
   background: var(--accent-action);
-  box-shadow: none;
 }
 
 /* [Intended] 塗り面のホバーは前景用の --primary / --accent ではなく塗り面用トークンを使う。
    白文字とのコントラストがダークテーマでAAを割るため。 */
 .action-button:hover:not(:disabled) {
   background: var(--primary-action-hover);
-  box-shadow: none;
 }
 
 .action-button.download-button:hover:not(:disabled),
 .action-button.download-dropdown-button:hover:not(:disabled) {
   background: var(--accent-action-hover);
-  box-shadow: none;
 }
 
 .action-button:disabled {
   background: var(--bg-panel);
   color: var(--text-dim);
   cursor: not-allowed;
-  box-shadow: none;
   border: 1px solid var(--border-color);
   opacity: 0.6;
 }
@@ -1235,7 +1225,6 @@ select:focus {
 	justify-content: center;
 	min-height: 156px;
 	overflow: hidden;
-	border-radius: 0;
 	background-color: #fff;
 	background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
 		linear-gradient(-45deg, #ccc 25%, transparent 25%),
@@ -1273,7 +1262,6 @@ select:focus {
 .candidate-recommended {
 	align-self: flex-start;
 	padding: 2px 7px;
-	border-radius: 0;
 	background: var(--primary-action);
 	color: #fff;
 	font-size: 0.72rem;
@@ -1730,7 +1718,6 @@ select:focus {
   border-radius: 4px;
   border: 1px solid var(--swatch-border);
   cursor: pointer;
-  box-shadow: none;
   transition: border-color 0.15s, outline-color 0.15s;
   position: relative;
 }
@@ -1759,12 +1746,10 @@ select:focus {
   background: transparent;
   border: 1px solid var(--primary);
   color: var(--primary);
-  box-shadow: none;
 }
 
 .outline-button:hover:not(:disabled) {
   background: color-mix(in srgb, var(--primary) 10%, transparent);
-  box-shadow: none;
 }
 
 .accent-outline-button {
@@ -1774,7 +1759,6 @@ select:focus {
 
 .accent-outline-button:hover:not(:disabled) {
   background: color-mix(in srgb, var(--accent) 10%, transparent);
-  box-shadow: none;
 }
 
 

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -1,47 +1,50 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Pixelify+Sans:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600;700&family=Pixelify+Sans:wght@400;500;600;700&display=swap');
 
 :root {
   /* 色 */
   color-scheme: light;
-  --bg-app: #f7f8fc;
-  --bg-panel: #ffffff;
-  --bg-input: #eef2f7;
-  --border-color: #d8dee9;
-  --primary: #4f46e5;
-  /* インディゴ */
-  --primary-hover: #4338ca;
-  --accent: #0e7490;
-  /* シアン */
-  --text-main: #172033;
-  --text-muted: #526077;
-  --text-dim: #687386;
-  --heading-start: #111827;
-  --logo-start: #60a5fa;
-  --logo-end: #1d4ed8;
-  --surface-hover: rgb(15 23 42 / 0.05);
-  --surface-hover-strong: rgb(15 23 42 / 0.1);
-  --panel-hover-border: #aeb7c5;
+  --bg-app: #f3f1eb;
+  --bg-panel: #fbfaf7;
+  --bg-input: #e9e6de;
+  --border-color: #cfc9bd;
+  --primary: #285d88;
+  --primary-hover: #1f496c;
+  --primary-action: #285d88;
+  --accent: #a3442c;
+  --accent-action: #983e28;
+  --text-main: #202426;
+  --text-muted: #525b60;
+  --text-dim: #687176;
+  --heading-start: #202426;
+  --logo-start: #285d88;
+  --surface-hover: rgb(32 36 38 / 0.06);
+  --surface-hover-strong: rgb(32 36 38 / 0.12);
+  --panel-hover-border: #9f988c;
+  --focus-ring: #ffbf47;
   --loading-overlay: rgb(15 17 21 / 0.82);
   --loading-text: #ffffff;
-  --image-list-bg: #f0f3f8;
-  --scrollbar-track: #eef2f7;
-  --scrollbar-thumb: #aeb7c5;
-  --thumbnail-bg: #ffffff;
-  --thumbnail-grid: #d8dee9;
+  --image-list-bg: #eeebe4;
+  --scrollbar-track: #e9e6de;
+  --scrollbar-thumb: #9f988c;
+  --thumbnail-bg: #fbfaf7;
+  --thumbnail-grid: #d6d0c5;
   --preview-control-border: rgb(15 23 42 / 0.24);
   --swatch-border: rgb(15 23 42 / 0.22);
   --swatch-hover-border: rgb(15 23 42 / 0.65);
   --footer-icon-filter: invert(1);
 
   /* 効果 */
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow-md: 0 8px 20px -12px rgb(15 23 42 / 0.25), 0 2px 6px -2px rgb(15 23 42 / 0.16);
-  --shadow-glow: 0 0 15px rgba(99, 102, 241, 0.3);
+  --shadow-sm: 0 1px 1px rgb(32 36 38 / 0.08);
+  --shadow-md: 0 2px 8px rgb(32 36 38 / 0.1);
+  --shadow-xl: 0 12px 32px rgb(32 36 38 / 0.2);
 
   /* レイアウト */
-  --radius-sm: 6px;
-  --radius-md: 12px;
-  --radius-lg: 16px;
+  --radius-sm: 2px;
+  --radius-md: 4px;
+  --radius-lg: 6px;
+
+  --font-mono: 'IBM Plex Mono', monospace;
+  --text-secondary: var(--text-muted);
 
   /* 市松模様の背景 */
   --bg-checkered-color: #d0d0d0;
@@ -49,67 +52,71 @@
 
 :root[data-theme="dark"] {
   color-scheme: dark;
-  --bg-app: #0f1115;
-  --bg-panel: #181b21;
-  --bg-input: #0f1115;
-  --border-color: #2a2e37;
-  --primary: #6366f1;
-  --primary-hover: #4f46e5;
-  --accent: #06b6d4;
-  --text-main: #e2e8f0;
-  --text-muted: #94a3b8;
-  --text-dim: #64748b;
-  --heading-start: #ffffff;
-  --logo-start: #dbeafe;
-  --logo-end: #3b82f6;
+  --bg-app: #121416;
+  --bg-panel: #1b1e20;
+  --bg-input: #101214;
+  --border-color: #353a3d;
+  --primary: #82add1;
+  --primary-hover: #a1c4df;
+  --primary-action: #315f87;
+  --accent: #e18a6f;
+  --accent-action: #9a402a;
+  --text-main: #e6e3dc;
+  --text-muted: #aeb5b8;
+  --text-dim: #858e92;
+  --heading-start: #e6e3dc;
+  --logo-start: #8bb6dc;
   --surface-hover: rgb(255 255 255 / 0.05);
   --surface-hover-strong: rgb(255 255 255 / 0.1);
-  --panel-hover-border: #3f4451;
+  --panel-hover-border: #596166;
   --loading-overlay: rgb(15 17 21 / 0.8);
   --loading-text: #e2e8f0;
-  --image-list-bg: #1a1d23;
-  --scrollbar-track: #1a1d23;
-  --scrollbar-thumb: #4a4e55;
-  --thumbnail-bg: #0f1115;
-  --thumbnail-grid: #1a1d23;
+  --image-list-bg: #171a1c;
+  --scrollbar-track: #171a1c;
+  --scrollbar-thumb: #596166;
+  --thumbnail-bg: #101214;
+  --thumbnail-grid: #272c2f;
   --preview-control-border: rgb(255 255 255 / 0.14);
   --swatch-border: rgb(255 255 255 / 0.15);
   --swatch-hover-border: rgb(255 255 255 / 0.8);
   --footer-icon-filter: none;
-  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+  --shadow-md: 0 2px 8px rgb(0 0 0 / 0.24);
+  --shadow-xl: 0 12px 32px rgb(0 0 0 / 0.4);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
     color-scheme: dark;
-    --bg-app: #0f1115;
-    --bg-panel: #181b21;
-    --bg-input: #0f1115;
-    --border-color: #2a2e37;
-    --primary: #6366f1;
-    --primary-hover: #4f46e5;
-    --accent: #06b6d4;
-    --text-main: #e2e8f0;
-    --text-muted: #94a3b8;
-    --text-dim: #64748b;
-    --heading-start: #ffffff;
-    --logo-start: #dbeafe;
-    --logo-end: #3b82f6;
+    --bg-app: #121416;
+    --bg-panel: #1b1e20;
+    --bg-input: #101214;
+    --border-color: #353a3d;
+    --primary: #82add1;
+    --primary-hover: #a1c4df;
+    --primary-action: #315f87;
+    --accent: #e18a6f;
+    --accent-action: #9a402a;
+    --text-main: #e6e3dc;
+    --text-muted: #aeb5b8;
+    --text-dim: #858e92;
+    --heading-start: #e6e3dc;
+    --logo-start: #8bb6dc;
     --surface-hover: rgb(255 255 255 / 0.05);
     --surface-hover-strong: rgb(255 255 255 / 0.1);
-    --panel-hover-border: #3f4451;
+    --panel-hover-border: #596166;
     --loading-overlay: rgb(15 17 21 / 0.8);
     --loading-text: #e2e8f0;
-    --image-list-bg: #1a1d23;
-    --scrollbar-track: #1a1d23;
-    --scrollbar-thumb: #4a4e55;
-    --thumbnail-bg: #0f1115;
-    --thumbnail-grid: #1a1d23;
+    --image-list-bg: #171a1c;
+    --scrollbar-track: #171a1c;
+    --scrollbar-thumb: #596166;
+    --thumbnail-bg: #101214;
+    --thumbnail-grid: #272c2f;
     --preview-control-border: rgb(255 255 255 / 0.14);
     --swatch-border: rgb(255 255 255 / 0.15);
     --swatch-hover-border: rgb(255 255 255 / 0.8);
     --footer-icon-filter: none;
-    --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+    --shadow-md: 0 2px 8px rgb(0 0 0 / 0.24);
+    --shadow-xl: 0 12px 32px rgb(0 0 0 / 0.4);
   }
 }
 
@@ -121,7 +128,7 @@ body {
   margin: 0;
   background-color: var(--bg-app);
   color: var(--text-main);
-  font-family: 'Inter', system-ui, sans-serif;
+  font-family: 'IBM Plex Sans', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
   line-height: 1.5;
 }
@@ -131,47 +138,41 @@ body.modal-open {
 }
 
 .app {
-  max-width: 1400px;
+  max-width: 1320px;
   margin: 0 auto;
-  padding: 40px 24px;
+  padding: 32px 24px;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 28px;
+  width: 100%;
+  min-width: 0;
 }
 
 /* ヘッダー */
 h1 {
   font-family: 'Pixelify Sans', sans-serif;
-  font-size: 3.5rem;
+  font-size: clamp(2.35rem, 6vw, 3.1rem);
   font-weight: 700;
   letter-spacing: 0.02em;
   margin: 0;
-  background: linear-gradient(135deg, var(--heading-start) 0%, var(--text-muted) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  text-align: center;
-  margin-bottom: 4px;
+  color: var(--heading-start);
+  text-align: left;
 }
 
 .logo-p {
-  background: linear-gradient(135deg, var(--logo-start) 0%, var(--logo-end) 100%);
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  color: var(--logo-start);
 }
 
 .header-top {
   position: relative;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   width: 100%;
 }
 
 .header-actions {
-  position: absolute;
-  right: 0;
+  position: static;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -192,7 +193,7 @@ h1 {
   cursor: pointer;
   padding: 2px 4px;
   border-radius: var(--radius-sm);
-  transition: all 0.2s;
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .lang-btn:hover {
@@ -202,7 +203,7 @@ h1 {
 
 .lang-btn.active {
   color: var(--accent);
-  background: rgba(6, 182, 212, 0.1);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .theme-toggle {
@@ -215,7 +216,7 @@ h1 {
   color: var(--text-muted);
   background: var(--bg-panel);
   border: 1px solid var(--border-color);
-  border-radius: 50%;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   box-shadow: var(--shadow-sm);
   transition: color 0.2s, border-color 0.2s, background 0.2s;
@@ -239,7 +240,8 @@ h1 {
 @media (max-width: 760px) {
   .header-top {
     flex-direction: column;
-    gap: 12px;
+    align-items: flex-start;
+    gap: 16px;
   }
 
   .header-actions {
@@ -248,12 +250,13 @@ h1 {
 }
 
 .app-description {
-  text-align: center;
+  text-align: left;
   color: var(--text-muted);
-  margin: 0 auto 32px;
+  margin: 12px 0 0;
   max-width: 700px;
-  font-size: 1.15rem;
-  line-height: 1.6;
+  font-size: 1rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .badge-container {
@@ -268,15 +271,15 @@ h1 {
   display: inline-flex;
   align-items: center;
   padding: 6px 16px;
-  background: rgba(99, 102, 241, 0.1);
-  border: 1px solid rgba(99, 102, 241, 0.2);
-  border-radius: 9999px;
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 24%, transparent);
+  border-radius: var(--radius-sm);
   color: var(--primary);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.05em;
   text-transform: uppercase;
-  box-shadow: 0 0 20px rgba(99, 102, 241, 0.15);
+  box-shadow: none;
   white-space: nowrap;
   /* テキストの折り返しを防ぐ */
 }
@@ -284,14 +287,13 @@ h1 {
 .text-highlight {
   color: var(--text-main);
   font-weight: 500;
-  border-bottom: 1px solid rgba(99, 102, 241, 0.3);
+  border-bottom: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
 }
 
 h2 {
   font-size: 1rem;
   font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
   color: var(--text-muted);
   margin: 0 0 16px 0;
   display: flex;
@@ -302,17 +304,16 @@ h2 {
 h2::before {
   content: '';
   display: block;
-  width: 4px;
-  height: 16px;
+  width: 8px;
+  height: 8px;
   background: var(--accent);
-  border-radius: 2px;
-  box-shadow: 0 0 8px var(--accent);
+  border-radius: 0;
 }
 
 main {
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 24px;
 }
 
 /* パネル */
@@ -320,8 +321,8 @@ main {
   background: var(--bg-panel);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  padding: 32px;
-  box-shadow: var(--shadow-md);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
   transition: border-color 0.2s;
   display: flex;
   flex-direction: column;
@@ -352,10 +353,10 @@ main {
 .settings-group-title::before {
   content: '';
   display: block;
-  width: 3px;
-  height: 12px;
+  width: 6px;
+  height: 6px;
   background: var(--primary);
-  border-radius: 1px;
+  border-radius: 0;
 }
 
 .panel:hover {
@@ -366,14 +367,21 @@ main {
 
 .input-panel.drag-over {
   border-color: var(--primary);
-  background: rgba(99, 102, 241, 0.05);
+  background: color-mix(in srgb, var(--primary) 7%, var(--bg-panel));
 }
 
 /* レイアウトヘルパー */
 .app-grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 40px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 20px;
+}
+
+.col-main,
+.col-preview,
+.panel,
+.quick-settings {
+  min-width: 0;
 }
 
 @media (min-width: 900px) {
@@ -424,7 +432,7 @@ main {
   flex: 1;
   height: 6px;
   background: var(--bg-input);
-  border-radius: 3px;
+  border-radius: 0;
   accent-color: var(--primary);
   cursor: pointer;
 }
@@ -452,6 +460,7 @@ main {
   height: 400px;
   background: var(--bg-input);
   border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -461,6 +470,7 @@ main {
 
 #input-canvas-container {
   cursor: pointer;
+  border-style: dashed;
 }
 
 canvas {
@@ -597,7 +607,7 @@ canvas {
 .view-controls {
   display: flex;
   background: var(--bg-input);
-  padding: 4px;
+  padding: 0;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border-color);
   margin-right: 12px;
@@ -611,8 +621,8 @@ canvas {
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  border-radius: 4px;
-  transition: all 0.2s;
+  border-radius: 0;
+  transition: color 0.15s, background-color 0.15s;
 }
 
 .view-btn:hover {
@@ -762,14 +772,13 @@ input[type="text"] {
   border-radius: var(--radius-sm);
   font-family: inherit;
   font-size: 0.9rem;
-  transition: all 0.2s;
+  transition: border-color 0.15s, background-color 0.15s;
 }
 
 input[type="number"]:focus,
 input[type="text"]:focus {
-  outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow: none;
 }
 
 input[type="checkbox"] {
@@ -786,14 +795,13 @@ select {
   border-radius: var(--radius-sm);
   font-family: inherit;
   font-size: 0.9rem;
-  transition: all 0.2s;
+  transition: border-color 0.15s, background-color 0.15s;
   cursor: pointer;
 }
 
 select:focus {
-  outline: none;
   border-color: var(--primary);
-  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.2);
+  box-shadow: none;
 }
 
 .rgb-input-group {
@@ -816,7 +824,7 @@ select:focus {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
 }
 
 .icon-button:hover {
@@ -842,7 +850,6 @@ select:focus {
   align-items: center;
   justify-content: center;
   z-index: 2000;
-  backdrop-filter: blur(4px);
 }
 
 .modal .modal-content {
@@ -942,26 +949,26 @@ select:focus {
   background: var(--bg-panel);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md);
-  padding: 32px;
-  box-shadow: var(--shadow-md);
-  margin-top: 40px;
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+  margin-top: 20px;
 }
 
 .settings-tabs {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 4px;
-  margin-bottom: 28px;
-  padding: 4px;
-  border-radius: var(--radius-md);
-  background: var(--bg-main);
+  gap: 0;
+  margin-bottom: 24px;
+  padding: 0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .settings-tab {
   min-width: 0;
-  padding: 10px 12px;
-  border: 1px solid transparent;
-  border-radius: calc(var(--radius-md) - 2px);
+  padding: 10px 12px 9px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
@@ -975,10 +982,10 @@ select:focus {
 }
 
 .settings-tab.is-active {
-  border-color: var(--border-color);
-  background: var(--bg-panel);
+  border-bottom-color: var(--accent);
+  background: transparent;
   color: var(--text-main);
-  box-shadow: var(--shadow-sm);
+  box-shadow: none;
 }
 
 .settings-tab-panel[hidden] {
@@ -1023,18 +1030,17 @@ select:focus {
 /* ボタン */
 .action-button {
   flex: 1;
-  background: linear-gradient(135deg, var(--primary) 0%, #4f46e5 100%);
+  background: var(--primary-action);
   color: white;
   border: none;
   padding: 16px;
   font-size: 1.1rem;
   font-weight: 700;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: all 0.2s;
-  box-shadow: 0 4px 6px -1px rgba(99, 102, 241, 0.4);
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  transition: background-color 0.15s, border-color 0.15s;
+  box-shadow: none;
+  letter-spacing: 0.01em;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1043,17 +1049,18 @@ select:focus {
 }
 
 .action-button.download-button {
-  background: linear-gradient(135deg, var(--accent) 0%, #0891b2 100%);
-  box-shadow: 0 4px 6px -1px rgba(6, 182, 212, 0.4);
+  background: var(--accent-action);
+  box-shadow: none;
 }
 
 .action-button:hover:not(:disabled) {
-  /* transform: translateY(-2px); */
-  box-shadow: 0 8px 12px -1px rgba(99, 102, 241, 0.5);
+  background: var(--primary-hover);
+  box-shadow: none;
 }
 
 .action-button.download-button:hover:not(:disabled) {
-  box-shadow: 0 8px 12px -1px rgba(6, 182, 212, 0.5);
+  background: var(--accent);
+  box-shadow: none;
 }
 
 .action-button:disabled {
@@ -1083,7 +1090,7 @@ select:focus {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-left: 1px solid rgba(255, 255, 255, 0.1) !important;
-  background: linear-gradient(135deg, var(--accent) 0%, #0891b2 100%);
+  background: var(--accent-action);
   padding: 0 !important;
   min-width: 50px;
 }
@@ -1147,7 +1154,7 @@ select:focus {
   /* 赤-500 */
   color: white;
   padding: 12px 24px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
   z-index: 1000;
   font-weight: 600;
@@ -1202,7 +1209,7 @@ select:focus {
 	min-height: 180px;
 	padding: 12px;
 	border: 1px solid var(--border-color);
-	border-radius: 10px;
+	border-radius: var(--radius-sm);
 	background: var(--bg-panel);
 	color: var(--text-main);
 	text-align: left;
@@ -1221,7 +1228,7 @@ select:focus {
 	justify-content: center;
 	min-height: 156px;
 	overflow: hidden;
-	border-radius: 6px;
+	border-radius: 0;
 	background-color: #fff;
 	background-image: linear-gradient(45deg, #ccc 25%, transparent 25%),
 		linear-gradient(-45deg, #ccc 25%, transparent 25%),
@@ -1259,7 +1266,7 @@ select:focus {
 .candidate-recommended {
 	align-self: flex-start;
 	padding: 2px 7px;
-	border-radius: 999px;
+	border-radius: 0;
 	background: var(--primary);
 	color: #fff;
 	font-size: 0.72rem;
@@ -1287,7 +1294,7 @@ select:focus {
   background: var(--accent);
   color: white;
   padding: 12px 24px;
-  border-radius: var(--radius-md);
+  border-radius: var(--radius-sm);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.4);
   z-index: 1000;
   font-weight: 600;
@@ -1308,7 +1315,7 @@ select:focus {
 .status-text {
   font-size: 0.85rem;
   color: var(--text-dim);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
 }
 
 .status-bar {
@@ -1376,11 +1383,10 @@ select:focus {
   border: 1px solid var(--preview-control-border);
   cursor: pointer;
   padding: 0;
-  transition: all 0.2s;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 
 .bg-btn:hover {
-  transform: scale(1.1);
   border-color: var(--text-muted);
 }
 
@@ -1540,7 +1546,7 @@ select:focus {
 .spinner {
   width: 40px;
   height: 40px;
-  border: 4px solid rgba(99, 102, 241, 0.1);
+  border: 4px solid color-mix(in srgb, var(--primary) 14%, transparent);
   border-top-color: var(--primary);
   border-radius: 50%;
   animation: spin 1s linear infinite;
@@ -1564,7 +1570,7 @@ select:focus {
   justify-content: center;
   cursor: pointer;
   color: var(--text-dim);
-  transition: all 0.2s;
+  transition: color 0.15s, background-color 0.15s;
   padding: 4px;
   border-radius: var(--radius-sm);
 }
@@ -1580,7 +1586,7 @@ select:focus {
 
 .zoom-toggle:has(input:checked) {
   color: var(--accent);
-  background: rgba(6, 182, 212, 0.1);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 /* ツールチップ */
@@ -1672,7 +1678,7 @@ select:focus {
 }
 
 .app-version {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--text-dim);
   background: var(--surface-hover);
@@ -1719,16 +1725,15 @@ select:focus {
   border-radius: 4px;
   border: 1px solid var(--swatch-border);
   cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  transition: all 0.15s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+  box-shadow: none;
+  transition: border-color 0.15s, outline-color 0.15s;
   position: relative;
 }
 
 .color-swatch:hover {
-  transform: scale(1.2) translateY(-2px);
   z-index: 10;
   border-color: var(--swatch-hover-border);
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  outline: 2px solid var(--bg-panel);
 }
 
 
@@ -1753,8 +1758,8 @@ select:focus {
 }
 
 .outline-button:hover:not(:disabled) {
-  background: rgba(99, 102, 241, 0.1);
-  box-shadow: 0 4px 6px -1px rgba(99, 102, 241, 0.2);
+  background: color-mix(in srgb, var(--primary) 10%, transparent);
+  box-shadow: none;
 }
 
 .accent-outline-button {
@@ -1763,8 +1768,8 @@ select:focus {
 }
 
 .accent-outline-button:hover:not(:disabled) {
-  background: rgba(6, 182, 212, 0.1);
-  box-shadow: 0 4px 6px -1px rgba(6, 182, 212, 0.2);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  box-shadow: none;
 }
 
 
@@ -1793,7 +1798,6 @@ select:focus {
   align-items: center;
   justify-content: center;
   z-index: 3000;
-  backdrop-filter: blur(4px);
 }
 
 .modal-overlay .modal-content {
@@ -1901,7 +1905,7 @@ select:focus {
   margin-top: 1rem;
   padding: 1rem;
   background-color: var(--image-list-bg);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border-color);
 }
 
@@ -2062,7 +2066,8 @@ select:focus {
   z-index: 10;
 }
 
-.image-item:hover .remove-btn {
+.image-item:hover .remove-btn,
+.image-item:focus-within .remove-btn {
   opacity: 1;
 }
 
@@ -2096,4 +2101,54 @@ select:focus {
   0% { transform: scale(1); opacity: 1; }
   50% { transform: scale(1.2); opacity: 0.7; }
   100% { transform: scale(1); opacity: 1; }
+}
+
+:where(button, a, input, select, [tabindex]):focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: 24px 16px;
+    gap: 24px;
+  }
+
+  .panel,
+  .quick-settings {
+    padding: 18px;
+  }
+
+  #input-canvas-container,
+  .js-result-canvas-container {
+    height: clamp(280px, 90vw, 400px);
+    min-height: 280px;
+  }
+
+  .settings-tabs {
+    display: flex;
+    overflow-x: auto;
+  }
+
+  .settings-tab {
+    flex: 1 0 max-content;
+  }
+
+  .image-list-header,
+  .batch-controls,
+  .status-bar,
+  .result-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
 }

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -7,6 +7,9 @@
   --bg-panel: #fbfaf7;
   --bg-input: #e9e6de;
   --border-color: #cfc9bd;
+  /* [Intended] 入力部品の枠は隣接するパネル背景に対して3:1以上を確保するため、
+     区切り線用の --border-color とは別に定義する。 */
+  --input-border: #8a8172;
   --primary: #285d88;
   --primary-hover: #1f496c;
   --primary-action: #285d88;
@@ -58,6 +61,7 @@
   --bg-panel: #1b1e20;
   --bg-input: #101214;
   --border-color: #353a3d;
+  --input-border: #666f74;
   --primary: #82add1;
   --primary-hover: #a1c4df;
   --primary-action: #315f87;
@@ -96,6 +100,7 @@
     --bg-panel: #1b1e20;
     --bg-input: #101214;
     --border-color: #353a3d;
+    --input-border: #666f74;
     --primary: #82add1;
     --primary-hover: #a1c4df;
     --primary-action: #315f87;
@@ -774,7 +779,7 @@ label {
 input[type="number"],
 input[type="text"] {
   background: var(--bg-input);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--input-border);
   color: var(--text-main);
   padding: 8px 12px;
   border-radius: var(--radius-sm);
@@ -797,7 +802,7 @@ input[type="checkbox"] {
 
 select {
   background: var(--bg-input);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--input-border);
   color: var(--text-main);
   padding: 8px 12px;
   border-radius: var(--radius-sm);

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -19,7 +19,7 @@
   --accent-action-hover: #7d3320;
   --text-main: #202426;
   --text-muted: #525b60;
-  --text-dim: #687176;
+  --text-dim: #5f676b;
   --heading-start: #202426;
   --logo-start: #285d88;
   --surface-hover: rgb(32 36 38 / 0.06);

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -38,6 +38,9 @@
   --swatch-hover-border: rgb(15 23 42 / 0.65);
   --footer-icon-filter: invert(1);
 
+  /* 文字 */
+  --font-mono: 'IBM Plex Mono', monospace;
+
   /* 効果 */
   --shadow-sm: 0 1px 1px rgb(32 36 38 / 0.08);
   --shadow-md: 0 2px 8px rgb(32 36 38 / 0.1);
@@ -47,9 +50,6 @@
   --radius-sm: 2px;
   --radius-md: 4px;
   --radius-lg: 6px;
-
-  --font-mono: 'IBM Plex Mono', monospace;
-  --text-secondary: var(--text-muted);
 
   /* 市松模様の背景 */
   --bg-checkered-color: #d0d0d0;
@@ -1667,7 +1667,7 @@ select:focus {
 .js-output-size {
   font-family: var(--font-mono);
   font-size: 0.85rem;
-  color: var(--text-secondary);
+  color: var(--text-muted);
 }
 
 .app-version {

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -1651,7 +1651,7 @@ select:focus {
   color: var(--text-dim);
   background: var(--surface-hover);
   padding: 2px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   margin-left: 8px;
   vertical-align: middle;
 }
@@ -1690,7 +1690,7 @@ select:focus {
 .color-swatch {
   width: 28px;
   height: 28px;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--swatch-border);
   cursor: pointer;
   transition: border-color 0.15s, outline-color 0.15s;
@@ -1943,7 +1943,7 @@ select:focus {
   cursor: pointer;
   font-size: 0.875rem;
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 .text-button:hover {
   background-color: var(--surface-hover);
@@ -1973,7 +1973,7 @@ select:focus {
 }
 .image-list-container::-webkit-scrollbar-thumb {
   background-color: var(--scrollbar-thumb);
-  border-radius: 4px;
+  border-radius: var(--radius-md);
 }
 
 .image-item {
@@ -1981,7 +1981,7 @@ select:focus {
   flex: 0 0 80px;
   width: 80px;
   height: 84px;
-  border-radius: 6px;
+  border-radius: var(--radius-lg);
   border: 2px solid transparent;
   background-color: var(--thumbnail-bg);
   cursor: pointer;

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -263,31 +263,6 @@ h1 {
   overflow-wrap: anywhere;
 }
 
-.badge-container {
-  display: flex;
-  justify-content: center;
-  margin-bottom: 12px;
-  position: relative;
-  /* 必要に応じて追加する */
-}
-
-.hero-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 6px 16px;
-  background: color-mix(in srgb, var(--primary) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--primary) 24%, transparent);
-  border-radius: var(--radius-sm);
-  color: var(--primary);
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  box-shadow: none;
-  white-space: nowrap;
-  /* テキストの折り返しを防ぐ */
-}
-
 .text-highlight {
   color: var(--text-main);
   font-weight: 500;

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -1058,7 +1058,8 @@ select:focus {
   box-shadow: none;
 }
 
-.action-button.download-button:hover:not(:disabled) {
+.action-button.download-button:hover:not(:disabled),
+.action-button.download-dropdown-button:hover:not(:disabled) {
   background: var(--accent);
   box-shadow: none;
 }

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -10,8 +10,10 @@
   --primary: #285d88;
   --primary-hover: #1f496c;
   --primary-action: #285d88;
+  --primary-action-hover: #1f496c;
   --accent: #a3442c;
   --accent-action: #983e28;
+  --accent-action-hover: #7d3320;
   --text-main: #202426;
   --text-muted: #525b60;
   --text-dim: #687176;
@@ -59,8 +61,10 @@
   --primary: #82add1;
   --primary-hover: #a1c4df;
   --primary-action: #315f87;
+  --primary-action-hover: #3d7099;
   --accent: #e18a6f;
   --accent-action: #9a402a;
+  --accent-action-hover: #b34c30;
   --text-main: #e6e3dc;
   --text-muted: #aeb5b8;
   --text-dim: #858e92;
@@ -1053,14 +1057,16 @@ select:focus {
   box-shadow: none;
 }
 
+/* [Intended] 塗り面のホバーは前景用の --primary / --accent ではなく塗り面用トークンを使う。
+   白文字とのコントラストがダークテーマでAAを割るため。 */
 .action-button:hover:not(:disabled) {
-  background: var(--primary-hover);
+  background: var(--primary-action-hover);
   box-shadow: none;
 }
 
 .action-button.download-button:hover:not(:disabled),
 .action-button.download-dropdown-button:hover:not(:disabled) {
-  background: var(--accent);
+  background: var(--accent-action-hover);
   box-shadow: none;
 }
 

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -241,11 +241,6 @@ h1 {
   background: var(--surface-hover);
 }
 
-.theme-toggle:focus-visible {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-}
-
 .theme-toggle [hidden] {
   display: none;
 }
@@ -1364,8 +1359,6 @@ select:focus {
 
 .processing-warning:focus-visible {
   border-radius: 2px;
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 .controls-right {

--- a/src/browser/theme.ts
+++ b/src/browser/theme.ts
@@ -7,8 +7,8 @@ import {
 } from "../shared/theme";
 
 const THEME_COLORS: Record<ColorTheme, string> = {
-	light: "#f7f8fc",
-	dark: "#0f1115",
+	light: "#f3f1eb",
+	dark: "#121416",
 };
 
 const readSavedTheme = (): ColorTheme | null => {


### PR DESCRIPTION
## 概要

汎用的な装飾を抑え、画像編集ツールとしての情報階層を保ちながら固有性のある UI に整える。

## 変更内容

### UI/UX

- ヘッダーと主要パネルで中央寄せヒーロー、発光、大きな丸角と影を抑え、作業の読む順序と操作の強弱を明確にした。
- ライト・ダーク両テーマで紙とグラファイトを基調とする配色へ改め、文字と主要操作の WCAG AA コントラストを確保した。
- 390px 幅でもロゴ、説明、パネルが画面内に収まり、設定タブは横スクロールで参照できるようにして操作領域の階層を維持した。
- キーボードフォーカスの表示を共通化し、動きを減らす OS 設定では装飾的な遷移を抑えるようにした。

### ロジック

- なし

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし

