### PR TITLE
fix: モノトーン系パレットの減色で最暗色が縁に乗るようにする

### DIFF
--- a/src/core/color-reduction.ts
+++ b/src/core/color-reduction.ts
@@ -1,6 +1,7 @@
 import { RETRO_PALETTES } from "../shared/config";
 import type { DitherMode, PixelData, RawImage, RGB } from "../shared/types";
 import { OklabKMeans, PaletteQuantizer } from "./quantizer";
+import { alignPixelsToToneRamp } from "./tone-ramp-mapping";
 
 export const applyColorReduction = (
 	img: RawImage,
@@ -39,7 +40,7 @@ export const applyColorReduction = (
 	if (customPalette) {
 		const quantizer = new PaletteQuantizer(customPalette);
 		reducedPixels = quantizer.applyDithering(
-			workingPixelData,
+			alignPixelsToToneRamp(workingPixelData, customPalette),
 			img.width,
 			img.height,
 			ditherMode,
@@ -69,7 +70,7 @@ export const applyColorReduction = (
 			});
 			const quantizer = new PaletteQuantizer(colors);
 			reducedPixels = quantizer.applyDithering(
-				workingPixelData,
+				alignPixelsToToneRamp(workingPixelData, colors),
 				img.width,
 				img.height,
 				ditherMode,

--- a/src/core/tone-ramp-mapping.test.ts
+++ b/src/core/tone-ramp-mapping.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { RETRO_PALETTES } from "../shared/config";
+import type { PixelData, RGB } from "../shared/types";
+import { rgbToOklab } from "./colorUtils";
+import { PaletteQuantizer } from "./quantizer";
+import {
+	alignPixelsToToneRamp,
+	isToneRampPalette,
+	resolveToneRampMapping,
+} from "./tone-ramp-mapping";
+
+const hexToRgb = (hex: string): RGB => ({
+	r: parseInt(hex.slice(1, 3), 16),
+	g: parseInt(hex.slice(3, 5), 16),
+	b: parseInt(hex.slice(5, 7), 16),
+});
+
+const paletteOf = (key: string): RGB[] =>
+	RETRO_PALETTES[key].colors.map(hexToRgb);
+
+const px = (r: number, g: number, b: number, alpha = 255): PixelData => ({
+	r,
+	g,
+	b,
+	alpha,
+});
+
+/** 各色を count 個ずつ並べた画素列を作る。 */
+const repeat = (colors: RGB[], count: number): PixelData[] =>
+	colors.flatMap((color) =>
+		Array.from({ length: count }, () => px(color.r, color.g, color.b)),
+	);
+
+describe("tone-ramp-mapping.ts", () => {
+	describe("isToneRampPalette", () => {
+		it.each(["gb_pocket", "mono", "gb_legacy", "gb_light"])(
+			"treats %s as a tone ramp",
+			(key) => {
+				expect(isToneRampPalette(paletteOf(key))).toBe(true);
+			},
+		);
+
+		it.each(["pico8", "nes", "pc98", "msx", "c64", "arne16"])(
+			"excludes the multi-hue palette %s",
+			(key) => {
+				expect(isToneRampPalette(paletteOf(key))).toBe(false);
+			},
+		);
+
+		it("excludes palettes whose levels share the same lightness", () => {
+			expect(
+				isToneRampPalette([
+					{ r: 84, g: 84, b: 84 },
+					{ r: 85, g: 85, b: 85 },
+				]),
+			).toBe(false);
+		});
+
+		it("excludes palettes with a single color", () => {
+			expect(isToneRampPalette([{ r: 0, g: 0, b: 0 }])).toBe(false);
+		});
+
+		it("excludes a palette that holds only one chromatic color", () => {
+			expect(
+				isToneRampPalette([
+					{ r: 0, g: 0, b: 0 },
+					{ r: 255, g: 0, b: 0 },
+				]),
+			).toBe(false);
+		});
+
+		it("accepts a ramp built from several colors of one hue", () => {
+			expect(
+				isToneRampPalette([
+					{ r: 0, g: 0, b: 0 },
+					{ r: 96, g: 16, b: 16 },
+					{ r: 180, g: 40, b: 40 },
+					{ r: 255, g: 128, b: 128 },
+				]),
+			).toBe(true);
+		});
+	});
+
+	describe("resolveToneRampMapping", () => {
+		const pocket = paletteOf("gb_pocket");
+
+		it("maps the darkest input grade onto the darkest palette color", () => {
+			// 濃い緑の縁と、明るさの異なる 3 段の緑。gb_pocket の 4 段に対応させる。
+			const pixels = repeat(
+				[
+					{ r: 5, g: 37, b: 24 },
+					{ r: 55, g: 102, b: 60 },
+					{ r: 132, g: 183, b: 97 },
+					{ r: 206, g: 245, b: 193 },
+				],
+				8,
+			);
+			const mapping = resolveToneRampMapping(pixels, pocket);
+			expect(mapping).toBeDefined();
+			if (!mapping) return;
+			expect(mapping.source).toHaveLength(4);
+			expect(mapping.target[0]).toBeCloseTo(0, 5);
+			expect(mapping.target[3]).toBeCloseTo(1, 5);
+			// 入力の各階調が昇順のまま対応している
+			for (let i = 1; i < mapping.source.length; i++) {
+				expect(mapping.source[i]).toBeGreaterThan(mapping.source[i - 1]);
+			}
+		});
+
+		it("falls back to matching only both ends when grades are fewer than palette levels", () => {
+			const pixels = repeat(
+				[
+					{ r: 5, g: 37, b: 24 },
+					{ r: 206, g: 245, b: 193 },
+				],
+				16,
+			);
+			const mapping = resolveToneRampMapping(pixels, pocket);
+			expect(mapping).toBeDefined();
+			expect(mapping?.source).toHaveLength(2);
+			expect(mapping?.target[0]).toBeCloseTo(0, 5);
+			expect(mapping?.target[1]).toBeCloseTo(1, 5);
+		});
+
+		it("returns undefined for a multi-hue palette", () => {
+			const pixels = repeat([{ r: 5, g: 37, b: 24 }], 64);
+			expect(
+				resolveToneRampMapping(pixels, paletteOf("pico8")),
+			).toBeUndefined();
+		});
+
+		it("returns undefined for a continuous-tone input", () => {
+			// なめらかなグラデーションは階調が分かれていないので順序対応の対象外。
+			const pixels = Array.from({ length: 256 }, (_, index) =>
+				px(index, index, index),
+			);
+			expect(resolveToneRampMapping(pixels, pocket)).toBeUndefined();
+		});
+
+		it("returns undefined for a flat input", () => {
+			const pixels = repeat([{ r: 40, g: 40, b: 40 }], 64);
+			expect(resolveToneRampMapping(pixels, pocket)).toBeUndefined();
+		});
+
+		it("returns undefined when there are too few opaque pixels", () => {
+			const pixels = [px(5, 37, 24), px(206, 245, 193), px(0, 0, 0, 0)];
+			expect(resolveToneRampMapping(pixels, pocket)).toBeUndefined();
+		});
+
+		it("ignores transparent pixels when measuring grades", () => {
+			const opaque = repeat(
+				[
+					{ r: 5, g: 37, b: 24 },
+					{ r: 55, g: 102, b: 60 },
+					{ r: 132, g: 183, b: 97 },
+					{ r: 206, g: 245, b: 193 },
+				],
+				8,
+			);
+			const withTransparent = [
+				...opaque,
+				...Array.from({ length: 32 }, () => px(255, 0, 0, 0)),
+			];
+			expect(resolveToneRampMapping(withTransparent, pocket)).toEqual(
+				resolveToneRampMapping(opaque, pocket),
+			);
+		});
+	});
+
+	describe("alignPixelsToToneRamp", () => {
+		it("quantizes each input grade onto its own palette level in order", () => {
+			const pocket = paletteOf("gb_pocket");
+			const grades = [
+				{ r: 5, g: 37, b: 24 },
+				{ r: 55, g: 102, b: 60 },
+				{ r: 132, g: 183, b: 97 },
+				{ r: 206, g: 245, b: 193 },
+			];
+			const pixels = repeat(grades, 8);
+			const quantizer = new PaletteQuantizer(pocket);
+
+			// 揃える前は暗い 2 段がどちらも #545454 に潰れ、最暗色に届かない。
+			const before = quantizer.quantize(pixels);
+			expect(before[0]).toMatchObject({ r: 84, g: 84, b: 84 });
+			expect(before[8]).toMatchObject({ r: 84, g: 84, b: 84 });
+
+			const after = quantizer.quantize(alignPixelsToToneRamp(pixels, pocket));
+			expect(after[0]).toMatchObject({ r: 0, g: 0, b: 0 });
+			expect(after[8]).toMatchObject({ r: 84, g: 84, b: 84 });
+			expect(after[16]).toMatchObject({ r: 168, g: 168, b: 168 });
+			expect(after[24]).toMatchObject({ r: 255, g: 255, b: 255 });
+		});
+
+		it("keeps hue while moving lightness", () => {
+			const legacy = paletteOf("gb_legacy");
+			const pixels = repeat(
+				[
+					{ r: 5, g: 37, b: 24 },
+					{ r: 55, g: 102, b: 60 },
+					{ r: 132, g: 183, b: 97 },
+					{ r: 206, g: 245, b: 193 },
+				],
+				8,
+			);
+			const aligned = alignPixelsToToneRamp(pixels, legacy);
+			const before = rgbToOklab(pixels[0]);
+			const after = rgbToOklab(aligned[0]);
+			const dot = before.a * after.a + before.b * after.b;
+			expect(dot).toBeGreaterThan(0);
+		});
+
+		it("returns the input untouched for a multi-hue palette", () => {
+			const pixels = repeat(
+				[
+					{ r: 5, g: 37, b: 24 },
+					{ r: 206, g: 245, b: 193 },
+				],
+				16,
+			);
+			expect(alignPixelsToToneRamp(pixels, paletteOf("nes"))).toBe(pixels);
+		});
+
+		it("leaves transparent pixels as they are", () => {
+			const pocket = paletteOf("gb_pocket");
+			const pixels = [
+				...repeat(
+					[
+						{ r: 5, g: 37, b: 24 },
+						{ r: 55, g: 102, b: 60 },
+						{ r: 132, g: 183, b: 97 },
+						{ r: 206, g: 245, b: 193 },
+					],
+					8,
+				),
+				px(255, 0, 0, 0),
+			];
+			const aligned = alignPixelsToToneRamp(pixels, pocket);
+			expect(aligned[aligned.length - 1]).toEqual(px(255, 0, 0, 0));
+		});
+	});
+});

--- a/src/core/tone-ramp-mapping.ts
+++ b/src/core/tone-ramp-mapping.ts
@@ -1,0 +1,262 @@
+import { TONE_RAMP_MAPPING } from "../shared/config";
+import type { PixelData, RGB } from "../shared/types";
+import { oklabToRgb, rgbToOklab } from "./colorUtils";
+
+/**
+ * 入力の階調（source）をパレットの階調（target）へ対応させる区分線形写像の制御点。
+ * どちらも昇順で、同じ長さを持つ。
+ */
+export type ToneRampMapping = {
+	source: number[];
+	target: number[];
+};
+
+/** パレットの L を昇順で返す。 */
+const paletteLightness = (palette: RGB[]): number[] =>
+	palette.map((color) => rgbToOklab(color).L).sort((a, b) => a - b);
+
+/**
+ * パレットが単一色相の階調ランプ（モノトーン系）かどうかを判定する。
+ * 無彩色の色は色相の判定から除外し、有彩色だけで色相の揃い方を見る。
+ */
+export const isToneRampPalette = (palette: RGB[]): boolean => {
+	if (palette.length < 2) return false;
+	if (palette.length > TONE_RAMP_MAPPING.maxPaletteColors) return false;
+
+	const lightness = paletteLightness(palette);
+	for (let i = 1; i < lightness.length; i++) {
+		if (
+			lightness[i] - lightness[i - 1] <
+			TONE_RAMP_MAPPING.minPaletteLevelGap
+		) {
+			return false;
+		}
+	}
+
+	// 有彩色の色相ベクトルを平均方向と比べ、ずれが許容内かを見る。
+	const hueA: number[] = [];
+	const hueB: number[] = [];
+	let sumA = 0;
+	let sumB = 0;
+	for (let i = 0; i < palette.length; i++) {
+		const lab = rgbToOklab(palette[i]);
+		const chroma = Math.hypot(lab.a, lab.b);
+		if (chroma < TONE_RAMP_MAPPING.achromaticChroma) continue;
+		const a = lab.a / chroma;
+		const b = lab.b / chroma;
+		hueA.push(a);
+		hueB.push(b);
+		sumA += a;
+		sumB += b;
+	}
+	if (hueA.length === 0) return true;
+	// [Intended] 有彩色が 1 色だけのパレットは、色相が揃っているかを確かめようがなく
+	// 「黒 + 任意の 1 色」のような階調ランプでない指定まで拾ってしまうため対象外にする。
+	if (hueA.length === 1) return false;
+
+	const norm = Math.hypot(sumA, sumB);
+	if (norm < 1e-9) return false;
+	const meanA = sumA / norm;
+	const meanB = sumB / norm;
+	const minCos = Math.cos(
+		(TONE_RAMP_MAPPING.maxHueDeviationDeg * Math.PI) / 180,
+	);
+	for (let i = 0; i < hueA.length; i++) {
+		if (hueA[i] * meanA + hueB[i] * meanB < minCos) return false;
+	}
+	return true;
+};
+
+/**
+ * 各サンプルを最も近い中心へ割り当て、中心ごとの個数と、
+ * クラスタで説明できる分散の割合（1 に近いほど階調が離散的）を返す。
+ */
+const evaluateClusters = (
+	sorted: number[],
+	centers: number[],
+): { counts: number[]; separation: number } => {
+	const counts = new Array<number>(centers.length).fill(0);
+	let sum = 0;
+	for (let i = 0; i < sorted.length; i++) sum += sorted[i];
+	const mean = sum / sorted.length;
+
+	let total = 0;
+	let within = 0;
+	for (let i = 0; i < sorted.length; i++) {
+		const value = sorted[i];
+		total += (value - mean) ** 2;
+		let best = 0;
+		let bestDist = Number.MAX_VALUE;
+		for (let c = 0; c < centers.length; c++) {
+			const dist = Math.abs(value - centers[c]);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = c;
+			}
+		}
+		counts[best] += 1;
+		within += (value - centers[best]) ** 2;
+	}
+	return { counts, separation: total > 0 ? 1 - within / total : 0 };
+};
+
+/** 昇順のサンプル列を k 個の階調へ分ける 1 次元 k-means。 */
+const clusterLightness = (sorted: number[], levels: number): number[] => {
+	const centers = new Array<number>(levels);
+	for (let i = 0; i < levels; i++) {
+		centers[i] = sorted[Math.round(((sorted.length - 1) * i) / (levels - 1))];
+	}
+
+	const sums = new Array<number>(levels);
+	const counts = new Array<number>(levels);
+	for (let iter = 0; iter < TONE_RAMP_MAPPING.kmeansIterations; iter++) {
+		sums.fill(0);
+		counts.fill(0);
+		for (let i = 0; i < sorted.length; i++) {
+			const value = sorted[i];
+			let best = 0;
+			let bestDist = Number.MAX_VALUE;
+			for (let c = 0; c < levels; c++) {
+				const dist = Math.abs(value - centers[c]);
+				if (dist < bestDist) {
+					bestDist = dist;
+					best = c;
+				}
+			}
+			sums[best] += value;
+			counts[best] += 1;
+		}
+		let moved = false;
+		for (let c = 0; c < levels; c++) {
+			if (counts[c] === 0) continue;
+			const next = sums[c] / counts[c];
+			if (Math.abs(next - centers[c]) > 1e-6) moved = true;
+			centers[c] = next;
+		}
+		if (!moved) break;
+	}
+	return centers.sort((a, b) => a - b);
+};
+
+/** 外れ値を落とした両端だけを合わせる写像。階調を分けきれない入力で使う。 */
+const rangeMapping = (
+	sorted: number[],
+	targets: number[],
+): ToneRampMapping | undefined => {
+	const last = sorted.length - 1;
+	const lo = sorted[Math.floor(last * TONE_RAMP_MAPPING.fallbackPercentile)];
+	const hi =
+		sorted[Math.ceil(last * (1 - TONE_RAMP_MAPPING.fallbackPercentile))];
+	if (hi - lo < TONE_RAMP_MAPPING.minSourceRange) return undefined;
+	return {
+		source: [lo, hi],
+		target: [targets[0], targets[targets.length - 1]],
+	};
+};
+
+/**
+ * 入力画素からパレットへの階調順マッピングを求める。
+ * 対象外のパレットや階調を測れない入力では undefined を返す。
+ */
+export const resolveToneRampMapping = (
+	pixels: PixelData[],
+	palette: RGB[],
+): ToneRampMapping | undefined => {
+	if (!isToneRampPalette(palette)) return undefined;
+
+	const targets = paletteLightness(palette);
+	const levels = targets.length;
+	let opaque = 0;
+	for (let i = 0; i < pixels.length; i++) {
+		if (pixels[i].alpha >= TONE_RAMP_MAPPING.alphaThreshold) opaque += 1;
+	}
+	if (opaque < levels * TONE_RAMP_MAPPING.minSamplesPerLevel) return undefined;
+
+	const stride = Math.max(
+		1,
+		Math.ceil(opaque / TONE_RAMP_MAPPING.maxGradeSamples),
+	);
+	const sorted: number[] = [];
+	let seen = 0;
+	for (let i = 0; i < pixels.length; i++) {
+		const pixel = pixels[i];
+		if (pixel.alpha < TONE_RAMP_MAPPING.alphaThreshold) continue;
+		const index = seen;
+		seen += 1;
+		if (index % stride !== 0) continue;
+		sorted.push(rgbToOklab(pixel).L);
+	}
+	sorted.sort((a, b) => a - b);
+
+	const centers = clusterLightness(sorted, levels);
+	const { counts, separation } = evaluateClusters(sorted, centers);
+	// [Intended] 階調が連続的な入力では順位の対応が階調の等化になってしまうので、
+	// 階調が離散的に分かれている入力にだけ順序対応を効かせる。
+	if (separation < TONE_RAMP_MAPPING.minGradeSeparation) return undefined;
+	// [Intended] 入力の階調がパレットより少ないと順位の対応が決まらないので、
+	// 最暗と最明だけを合わせる写像へ退避する。
+	if (counts.some((count) => count === 0)) return rangeMapping(sorted, targets);
+	if (centers[levels - 1] - centers[0] < TONE_RAMP_MAPPING.minSourceRange) {
+		return undefined;
+	}
+	return { source: centers, target: targets };
+};
+
+/** 制御点に沿って L を写像する。制御点の外側は端の値へ丸める。 */
+const mapLightness = (
+	lightness: number,
+	source: number[],
+	target: number[],
+): number => {
+	const last = source.length - 1;
+	if (lightness <= source[0]) return target[0];
+	if (lightness >= source[last]) return target[last];
+	for (let i = 1; i <= last; i++) {
+		if (lightness > source[i]) continue;
+		const span = source[i] - source[i - 1];
+		if (span <= 0) return target[i];
+		const ratio = (lightness - source[i - 1]) / span;
+		return target[i - 1] + (target[i] - target[i - 1]) * ratio;
+	}
+	return target[last];
+};
+
+/**
+ * 写像に従って各画素の L だけを移す。色相と彩度は元の値を保つ。
+ */
+export const applyToneRampMapping = (
+	pixels: PixelData[],
+	mapping: ToneRampMapping,
+): PixelData[] => {
+	const { source, target } = mapping;
+	const out = new Array<PixelData>(pixels.length);
+	for (let i = 0; i < pixels.length; i++) {
+		const pixel = pixels[i];
+		if (pixel.alpha < TONE_RAMP_MAPPING.alphaThreshold) {
+			out[i] = pixel;
+			continue;
+		}
+		const lab = rgbToOklab(pixel);
+		const mapped = mapLightness(lab.L, source, target);
+		if (mapped === lab.L) {
+			out[i] = pixel;
+			continue;
+		}
+		const rgb = oklabToRgb({ L: mapped, a: lab.a, b: lab.b });
+		out[i] = { r: rgb.r, g: rgb.g, b: rgb.b, alpha: pixel.alpha };
+	}
+	return out;
+};
+
+/**
+ * モノトーン系パレット向けに、入力の階調をパレットの階調へ順序どおり合わせる。
+ * 対象外のパレットでは入力をそのまま返す。
+ */
+export const alignPixelsToToneRamp = (
+	pixels: PixelData[],
+	palette: RGB[],
+): PixelData[] => {
+	const mapping = resolveToneRampMapping(pixels, palette);
+	if (!mapping) return pixels;
+	return applyToneRampMapping(pixels, mapping);
+};

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -753,6 +753,54 @@ export const RETRO_PALETTES: Record<
 	},
 };
 
+/**
+ * モノトーン系パレット（単一色相の階調ランプ）での階調順マッピングの条件。
+ *
+ * [Intended] Oklab 距離の最近傍だけでは、入力の最暗色がパレットの最暗色へ届かず
+ * 判定境界の直上に密集して量子化が不安定になる。ゲームボーイ系のように階調が
+ * 一列に並ぶパレットに限り、入力の階調を順序どおりパレットへ対応させる。
+ */
+export const TONE_RAMP_MAPPING = {
+	/** 順序対応の対象にするパレットの最大色数。これを超える多色パレットは対象外。 */
+	maxPaletteColors: 8,
+	/** 色相の判定から除外する彩度の上限（Oklab クロマ）。 */
+	achromaticChroma: 0.02,
+	/**
+	 * 有彩色どうしで許容する色相のずれ（度）。
+	 *
+	 * [Policy] 実測では単一ランプの gb_legacy が 11.2 度、gb_light が 5.1 度に対し、
+	 * 多色相の pico8 や nes は 130 度以上になる。両者を余裕をもって分ける値にする。
+	 */
+	maxHueDeviationDeg: 30,
+	/** 別階調として区別するために必要なパレット L の最小間隔。 */
+	minPaletteLevelGap: 0.01,
+	/** 階調推定に使う不透明画素の、パレット 1 階調あたりの最小数。 */
+	minSamplesPerLevel: 4,
+	/**
+	 * 階調推定に使う画素の上限。これを超える入力は等間隔に間引く。
+	 *
+	 * [Policy] 階調の中心を求めるだけなので全画素を見る必要はない。原寸のまま
+	 * 減色する経路で反復回数と画素数の積が膨らむのを防ぐ。
+	 */
+	maxGradeSamples: 65_536,
+	/** 階調推定に使う 1 次元 k-means の反復回数。 */
+	kmeansIterations: 30,
+	/**
+	 * 階調が分かれていると認めるために必要な、クラスタで説明できる L 分散の割合。
+	 *
+	 * [Policy] 階調が離散的なドット絵は実測で 0.998 に達する一方、連続階調の
+	 * イラストや写真は 0.78〜0.94 にとどまる。順序対応は前者にだけ効かせ、
+	 * 後者では従来どおり最近傍量子化に任せる。
+	 */
+	minGradeSeparation: 0.98,
+	/** 両端合わせへ退避するときに外れ値を落とす分位。 */
+	fallbackPercentile: 0.005,
+	/** 写像を行うために必要な入力 L のレンジ幅。これ未満は平坦とみなす。 */
+	minSourceRange: 0.02,
+	/** 階調推定と写像で不透明とみなす alpha の下限。 */
+	alphaThreshold: 16,
+} as const;
+
 export const PROCESS_DEFAULTS = {
 	processingMode: "auto",
 	detailLevel: CONVERT_DEFAULTS.detailLevel,


### PR DESCRIPTION
## 概要

ゲームボーイ系やモノクロなど階調が一列に並ぶパレットへの減色で、ドット絵の縁が最暗色で塗られるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- 「ゲームボーイ（ポケット / レガシー / ライト）」「モノクロ」の減色モードで、ドット絵の一番濃い縁が最暗色で縁取られるようになる。
- 上記モードで、縁の一部だけが最暗色に落ちて黒い点が散らばる現象が起きなくなる。
- 上記モードで、元画像の暗い縁と影が同じ色に潰れず、別の階調として描き分けられるようになる。
- 写真やイラストのような連続階調の入力では、これまでと同じ結果を保つ。
- カスタムパレットでも、単一色相の階調ランプを指定した場合は同じ扱いになる。

### 開発体験

- なし

### その他

- 多色相のパレット（PICO-8 / NES / C64 など）は対象外で、従来どおりの最近傍量子化のままとする。

## 動作確認

- なし

## 実装上の補足

パレットの各色を Oklab の L で並べ、入力の階調も同じ数のクラスタへ分けたうえで、明るさの順に対応させる区分線形写像を減色の前段に挟む。
階調が離散的に分かれている入力にだけ効かせるため、クラスタで説明できる L 分散の割合を条件に加えた。
