### PR TITLE
fix: 縁とずれた格子でもかんたん設定のままドット単位へ変換する

### DIFF
--- a/src/core/grid-signals/grid-phase.ts
+++ b/src/core/grid-signals/grid-phase.ts
@@ -1,0 +1,95 @@
+import { BOUNDARY_CONTRAST_LIMITS } from "../../shared/config";
+import type { AxisBoundaryContrastEvaluator } from "./boundary-contrast";
+
+/**
+ * 与えたセル寸法のまま、境界がもっとも揃う位相を 1px 刻みで探す。
+ * 位相はコンテンツ BBox の左上を 0 とした画素数で返し、証拠が薄い軸は null を返す。
+ *
+ * [Intended] セル寸法はコンテンツ BBox の幅・高さから割り出すのに、投影は
+ * キャンバス左上を起点にしていたため、BBox 開始位置の端数だけ格子がずれていた。
+ * ずれた格子ではどのセルも隣のドットを食うので、代表色が混色へ寄る（実測:
+ * 20x18 が正解の 1254x1254 生成画像で x が 1/6 セルずれ、輪郭とハイライトが
+ * にじんだ）。倍率を選んだ根拠である境界コントラストは BBox 起点で測っているので、
+ * 位相もその指標で決めて投影と食い違わないようにする。
+ */
+export const findAxisPhase = (
+	contrast: (cell: number, phase?: number) => number,
+	cell: number,
+): number | null => {
+	if (cell < BOUNDARY_CONTRAST_LIMITS.minPhaseCellPixels) return null;
+	let bestPhase = 0;
+	let bestContrast = contrast(cell, 0);
+	// 位相 0 とセル幅ちょうどは同じ格子なので、走査は 1 〜 ceil(cell)-1 で足りる。
+	for (let phase = 1; phase < Math.ceil(cell); phase += 1) {
+		const value = contrast(cell, phase);
+		if (value > bestContrast) {
+			bestContrast = value;
+			bestPhase = phase;
+		}
+	}
+	return bestContrast >= BOUNDARY_CONTRAST_LIMITS.minPhaseEvidence
+		? bestPhase
+		: null;
+};
+
+export type PhaseConfirmedSize = {
+	outW: number;
+	outH: number;
+	cellW: number;
+	cellH: number;
+	phaseX: number;
+	phaseY: number;
+	evidence: number;
+};
+
+/**
+ * 両軸とも位相を読み取れた倍率のうち、境界コントラストがもっとも強いものを返す。
+ *
+ * サイズ走査は位相 0 の再構成誤差だけで倍率を比べるため、格子がキャンバスの縁から
+ * 半端な位置で始まる入力では正解の倍率こそ誤差が悪くなる。位相まで含めて測り直す
+ * 価値のある倍率を、境界コントラストだけを根拠に 1 つ指名する。
+ *
+ * [Intended] 両軸とも位相が読めた倍率だけを見る。片方でも読めない倍率は、格子の
+ * 位置を決める根拠が無く、位相をずらせば誤差が上がるだけなので拾わない。
+ * [Intended] 位相 0 の倍率も対象にする。位相が 0 でも粗い刻みの走査点から外れていれば
+ * 一度も測られていない（実測: 2752x1322 の領域で正解 256x123 は位相 (0,0) だが、
+ * 走査点が 41 から 3 刻みなので 122 と 125 しか見ていない）。
+ * [Policy] 返すのは最強の 1 件だけにする。再構成誤差はセルを細かくするほど下がるので、
+ * 証拠の弱い倍率まで誤差で選べるようにすると過分割へ戻る（実測: 正解セル 24px に 8px の
+ * 濃淡を敷いた合成画像で、3 倍細かい格子が誤差では勝つ）。過分割を退ける指標は
+ * 境界コントラストのほうなので、倍率の指名はそちらだけに決めさせる。
+ * [Policy] 数セルしか無い倍率は対象外にする。境界コントラストが偶然の一致で跳ね上がり、
+ * 誤差比較まで通ってしまう（実測: 24x24・正解セル 4px の fixture で、2 倍粗い 3x3 が
+ * 位相 (4,1) で選ばれた）。しきい値は粗い倍音への乗り換えと同じ minOverrideOutH を使う。
+ */
+export const findPhaseConfirmedSize = (
+	croppedW: number,
+	croppedH: number,
+	outHMin: number,
+	outHMax: number,
+	widthsForHeight: (outH: number) => number[],
+	axes: AxisBoundaryContrastEvaluator,
+): PhaseConfirmedSize | null => {
+	let selected: PhaseConfirmedSize | null = null;
+	for (let outH = outHMin; outH <= outHMax; outH += 1) {
+		if (outH < BOUNDARY_CONTRAST_LIMITS.minOverrideOutH) continue;
+		const cellH = croppedH / outH;
+		const phaseY = findAxisPhase(axes.y, cellH);
+		if (phaseY === null) continue;
+		const widths = widthsForHeight(outH);
+		for (let index = 0; index < widths.length; index += 1) {
+			const outW = widths[index];
+			if (outW < BOUNDARY_CONTRAST_LIMITS.minOverrideOutH) continue;
+			const cellW = croppedW / outW;
+			if (!(cellW > 1 && cellH > 1)) continue;
+			const phaseX = findAxisPhase(axes.x, cellW);
+			if (phaseX === null) continue;
+			const evidence = Math.sqrt(axes.x(cellW, phaseX) * axes.y(cellH, phaseY));
+			// 同値なら粗い側を残す。細かい側は倍音として同じ境界へ乗るだけで、
+			// 証拠が並んだ時点でどちらとも決められない。
+			if (selected !== null && evidence <= selected.evidence) continue;
+			selected = { outW, outH, cellW, cellH, phaseX, phaseY, evidence };
+		}
+	}
+	return selected;
+};

--- a/src/core/trimmed-grid-search.test.ts
+++ b/src/core/trimmed-grid-search.test.ts
@@ -160,6 +160,36 @@ describe("fast grid search from trimmed", () => {
 		expect(estimate?.outH).toBe(75);
 	});
 
+	it("位相がずれて誤差では谷にならない倍率を、境界コントラストから拾う", () => {
+		// [Intended] 310x310・セル 10px を 4px ずらした入力（出力 31x31）。サイズ走査は
+		// どの倍率も位相 0 で誤差を測るため、正解の倍率こそ各セルが隣のドットを食って
+		// 誤差が悪くなり、山の再走査でも拾えない。位相を読み取れた倍率として指名し、
+		// 位相込みの誤差で測り直してはじめて選べる。
+		const shiftedGrid = createShiftedGridImage(310, 10, 4);
+		const estimate = strategy.search(shiftedGrid, shiftedGrid, 3);
+		expect(estimate).not.toBeNull();
+		expect(estimate?.outW).toBe(31);
+		expect(estimate?.outH).toBe(31);
+		expect(estimate?.offsetX).toBe(4);
+		expect(estimate?.offsetY).toBe(4);
+	});
+
+	it("境界コントラストの乗り換えを切ると、位相込みの拾い直しもしない", () => {
+		// [Intended] 位相を根拠に倍率を動かすのも境界コントラストによる乗り換えなので、
+		// 乗り換えを切った経路では働かせない。再構成だけの過分割が返る。
+		const shiftedGrid = createShiftedGridImage(310, 10, 4);
+		const estimate = strategy.search(
+			shiftedGrid,
+			shiftedGrid,
+			3,
+			undefined,
+			undefined,
+			false,
+		);
+		expect(estimate).not.toBeNull();
+		expect(estimate?.outH).toBe(76);
+	});
+
 	it("格子が BBox の縁で合っている入力では、位相 0 を実測済みとして返す", () => {
 		// [Intended] 位相 0 は「ずれていない」という実測結果なので、投影は BBox 起点へ
 		// 寄せたままにする。位相未測定と同じ扱いにするとキャンバス起点へ戻ってしまう。

--- a/src/core/trimmed-grid-search.ts
+++ b/src/core/trimmed-grid-search.ts
@@ -16,6 +16,10 @@ import {
 	findSkippedEvidencePeaks,
 	scanBoundaryEvidence,
 } from "./grid-signals/boundary-evidence";
+import {
+	findAxisPhase,
+	findPhaseConfirmedSize,
+} from "./grid-signals/grid-phase";
 import { downsample } from "./image-operations";
 
 type GridEstimateFromTrimmed = {
@@ -88,37 +92,6 @@ const harmonicOutHeights = (outH: number): number[] => {
 		heights.push(outH * factors[index]);
 	}
 	return heights;
-};
-
-/**
- * 採用したセル寸法のまま、境界がもっとも揃う位相を 1px 刻みで探す。
- * 位相はコンテンツ BBox の左上を 0 とした画素数で返し、証拠が薄い軸は null を返す。
- *
- * [Intended] セル寸法はコンテンツ BBox の幅・高さから割り出すのに、投影は
- * キャンバス左上を起点にしていたため、BBox 開始位置の端数だけ格子がずれていた。
- * ずれた格子ではどのセルも隣のドットを食うので、代表色が混色へ寄る（実測:
- * 20x18 が正解の 1254x1254 生成画像で x が 1/6 セルずれ、輪郭とハイライトが
- * にじんだ）。倍率を選んだ根拠である境界コントラストは BBox 起点で測っているので、
- * 位相もその指標で決めて投影と食い違わないようにする。
- */
-const findAxisPhase = (
-	contrast: (cell: number, phase?: number) => number,
-	cell: number,
-): number | null => {
-	if (cell < BOUNDARY_CONTRAST_LIMITS.minPhaseCellPixels) return null;
-	let bestPhase = 0;
-	let bestContrast = contrast(cell, 0);
-	// 位相 0 とセル幅ちょうどは同じ格子なので、走査は 1 〜 ceil(cell)-1 で足りる。
-	for (let phase = 1; phase < Math.ceil(cell); phase += 1) {
-		const value = contrast(cell, phase);
-		if (value > bestContrast) {
-			bestContrast = value;
-			bestPhase = phase;
-		}
-	}
-	return bestContrast >= BOUNDARY_CONTRAST_LIMITS.minPhaseEvidence
-		? bestPhase
-		: null;
 };
 
 /**
@@ -245,6 +218,15 @@ const outputWidthsForHeight = (outH: number, ratio: number): number[] => {
 		? [rounded]
 		: [rounded, roundedUp];
 };
+
+/** 再構成誤差に、セル数へ比例する複雑度ペナルティを足した採用スコア。 */
+const gridSizeScore = (
+	reconstructionError: number,
+	outW: number,
+	outH: number,
+): number =>
+	reconstructionError +
+	TRIMMED_GRID_SEARCH_WEIGHTS.complexityPenalty * Math.sqrt(outW * outH);
 
 /**
  * 候補サイズをある程度「分散」させるため、outH の範囲をバケットに分け、各バケットから最良候補を選ぶ。
@@ -410,10 +392,7 @@ export class FastGridSearchFromTrimmed
 
 				// 再構成誤差は過分割で単調に下がりやすいため、セル数に比例するペナルティを加える。
 				// 低解像度（少ないセル）と高解像度（多いセル）のバランスを取るため、平方根オーダーを使用する。
-				const complexityPenalty =
-					TRIMMED_GRID_SEARCH_WEIGHTS.complexityPenalty *
-					Math.sqrt(outW * outH);
-				const score = reconErr + complexityPenalty;
+				const score = gridSizeScore(reconErr, outW, outH);
 				allResults.push({ outH, outW, score });
 			}
 		}
@@ -630,6 +609,84 @@ export class FastGridSearchFromTrimmed
 				) {
 					best = atPeak.est;
 				}
+			}
+		}
+		const reconstructionErrorAtPhase = (
+			cellW: number,
+			cellH: number,
+			phaseX: number,
+			phaseY: number,
+		): { score: number; outW: number; outH: number } | null => {
+			const grid = gridForPhase(
+				cropped.width,
+				cropped.height,
+				cellW,
+				cellH,
+				phaseX,
+				phaseY,
+			);
+			const error = measureReconstructionError(
+				cropped,
+				mask,
+				grid,
+				sampleWindow,
+				finePixelStride,
+			);
+			if (error === null) return null;
+			const outW = grid.outW ?? 1;
+			const outH = grid.outH ?? 1;
+			return { score: gridSizeScore(error, outW, outH), outW, outH };
+		};
+		// [Intended] ここまでの走査は、どの倍率も位相 0 の再構成誤差だけで比べている。
+		// 格子がキャンバスの縁から半端な位置で始まる入力では、正解の倍率こそセルが
+		// 隣のドットを食い、誤差が最悪の部類になって選ばれない（実測: 2752x1536 の
+		// 生成画像でセル 10.75px・位相 6 が正解だが、位相 0 の誤差 35.7 は隣の倍率
+		// 25.0 より悪く、採用は 3 倍粗い 93x52 まで流れた）。位相を読み取れた倍率
+		// だけを拾い直し、同じ位相込みの尺度で採否を決める。
+		// [Policy] 乗り換えを切った経路では働かせない。境界コントラストを根拠に倍率を
+		// 動かす点は、粗い倍音への乗り換えや山の再走査と同じ性質の判断になる。
+		const phaseConfirmed = boundaryContrastOverride
+			? findPhaseConfirmedSize(
+					cropped.width,
+					cropped.height,
+					outHMin,
+					outHMax,
+					(outH) => outputWidthsForHeight(outH, ratio),
+					axisContrast,
+				)
+			: null;
+		if (phaseConfirmed) {
+			// [Policy] 比較条件を揃えるため、採用格子も位相込みで測り直す。位相 0 の
+			// スコアと比べると、位相を測った倍率が一方的に有利になる。
+			const bestPhased = reconstructionErrorAtPhase(
+				best.cellW,
+				best.cellH,
+				findAxisPhase(axisContrast.x, best.cellW) ?? 0,
+				findAxisPhase(axisContrast.y, best.cellH) ?? 0,
+			);
+			const bestScore = Math.min(
+				best.score ?? Number.POSITIVE_INFINITY,
+				bestPhased?.score ?? Number.POSITIVE_INFINITY,
+			);
+			const scored = reconstructionErrorAtPhase(
+				phaseConfirmed.cellW,
+				phaseConfirmed.cellH,
+				phaseConfirmed.phaseX,
+				phaseConfirmed.phaseY,
+			);
+			// [Policy] 採否は再構成誤差に決めさせる。境界コントラストは走査から漏れた
+			// 倍率を教えるだけで、そこまでの最良より誤差が下がらなければ乗り換えない。
+			if (scored && scored.score < bestScore) {
+				best = {
+					outW: phaseConfirmed.outW,
+					outH: phaseConfirmed.outH,
+					cellW: phaseConfirmed.cellW,
+					cellH: phaseConfirmed.cellH,
+					offsetX: phaseConfirmed.phaseX,
+					offsetY: phaseConfirmed.phaseY,
+					score: scored.score,
+					phaseMeasured: true,
+				};
 			}
 		}
 		// [Intended] 採用した倍率と、境界がもっとも揃う倍率が食い違っているなら、


### PR DESCRIPTION
## 概要

ドット絵の格子が画像の縁から半端な位置で始まる入力でも、かんたん設定のまま元のドット単位へ変換できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- 生成された背景イラストのように格子が画像の縁とずれている入力で、かんたん設定のまま元のドット単位へ変換できるようにした。
- 倍率を取り違えていた入力で「グリッドの信頼度が低い」警告が出なくなり、候補から選び直す手間がなくなる。

### 開発体験

- なし

### その他

- 格子の位相を扱う処理を `src/core/grid-signals/grid-phase.ts` へ分離した。
- 実装上の補足: 倍率の指名は境界コントラストだけに決めさせ、採否は位相込みの再構成誤差に決めさせる二段構えにしている。

## 動作確認

- なし
