### PR TITLE
feat: おまかせの経路とプリセットを対応付け

### DIFF
--- a/src/browser/i18n.test.ts
+++ b/src/browser/i18n.test.ts
@@ -207,6 +207,7 @@ describe("I18nManager", () => {
 		}
 
 		i18n.setLanguage("ja");
+		expect(i18n.t("preset.auto")).toBe("おまかせ");
 		expect(i18n.t("option.quick_processing_refine")).toBe("輪郭をくっきり");
 		expect(i18n.t("option.quick_processing_convert")).toBe(
 			"細部を残してドット化",

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -87,7 +87,7 @@ const resources = {
 		"setting.detail": "細かさ",
 		"setting.background": "背景透過",
 		"setting.dithering": "ディザリング",
-		"preset.auto": "おまかせ仕上げ",
+		"preset.auto": "おまかせ",
 		"preset.crisp_sprite": "くっきりドット",
 		"preset.keep_fine_details": "細部を残す",
 		"preset.transparent_icon": "縁取り透過アイコン",

--- a/src/browser/preset-routes.test.ts
+++ b/src/browser/preset-routes.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { processImage } from "../core/processor";
+import { readPngAsRawImage } from "../core/processor-test-helpers";
+import { createBuiltInPresetOptions } from "./quick-settings";
+
+describe("built-in preset routes", () => {
+	it.each([
+		["quality_nearest_2x.png", "crisp-sprite", "refine"],
+		["quality_reference.png", "keep-fine-details", "preserve"],
+		["quality_continuous_tone.png", "photo-to-pixel", "convert"],
+	] as const)(
+		"reproduces the Auto-selected %s route with %s",
+		async (fileName, presetId, route) => {
+			const image = await readPngAsRawImage(
+				fileURLToPath(
+					new URL(`../../test/fixtures/${fileName}`, import.meta.url),
+				),
+			);
+			const automatic = processImage(image, createBuiltInPresetOptions("auto"));
+			const fixedRoute = processImage(
+				image,
+				createBuiltInPresetOptions(presetId),
+			);
+
+			expect(automatic.analysis.route).toBe(route);
+			expect(fixedRoute.analysis.route).toBe(route);
+			expect(fixedRoute.result).toEqual(automatic.result);
+			expect(fixedRoute.extractedPalette).toEqual(automatic.extractedPalette);
+		},
+	);
+});

--- a/src/browser/quick-settings.test.ts
+++ b/src/browser/quick-settings.test.ts
@@ -136,7 +136,7 @@ describe("quick settings", () => {
 		expect(options.outlineStyle).toBe(PROCESS_DEFAULTS.outlineStyle);
 	});
 
-	it("defines six self-contained built-in presets", () => {
+	it("defines six built-in presets", () => {
 		expect(BUILT_IN_PRESETS.map((preset) => preset.id)).toEqual([
 			"auto",
 			"crisp-sprite",
@@ -152,9 +152,30 @@ describe("quick settings", () => {
 		});
 		expect(createBuiltInPresetOptions("photo-to-pixel")).toMatchObject({
 			processingMode: "convert",
-			colorCount: 32,
-			bgExtractionMethod: "none",
-			trimToContent: false,
+			bgExtractionMethod: "auto",
+			trimToContent: true,
 		});
 	});
+
+	it.each([
+		["crisp-sprite", "refine"],
+		["keep-fine-details", "preserve"],
+		["photo-to-pixel", "convert"],
+	] as const)(
+		"aligns the %s preset with the Auto-selected %s route",
+		(presetId, processingMode) => {
+			const auto = createBuiltInPresetOptions("auto");
+			const routePreset = createBuiltInPresetOptions(presetId);
+
+			expect(routePreset).toEqual({
+				...auto,
+				processingMode,
+				smallAspectGridAlignment: "on",
+				watermarkSamplingCompat: "on",
+			});
+			expect(routePreset).not.toHaveProperty("reduceColors");
+			expect(routePreset).not.toHaveProperty("reduceColorMode");
+			expect(routePreset).not.toHaveProperty("colorCount");
+		},
+	);
 });

--- a/src/browser/quick-settings.ts
+++ b/src/browser/quick-settings.ts
@@ -1,7 +1,11 @@
 import type { ProcessOptions } from "../core/processor";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS } from "../shared/config";
-import type { DetailLevel, ProcessingMode } from "../shared/types";
+import type {
+	DetailLevel,
+	ProcessingMode,
+	ProcessingRoute,
+} from "../shared/types";
 
 export type QuickReductionMode =
 	| "none"
@@ -124,21 +128,38 @@ const withRouteManagedReduction = (options: ProcessOptions): ProcessOptions => {
 	return next;
 };
 
+const AUTO_PRESET_OPTIONS = withRouteManagedReduction(presetOptions({}));
+
+/**
+ * おまかせが選ぶ各経路を、同じ共通設定のまま手動で再現する。
+ *
+ * [Intended] Auto のときだけ有効になる補助判定は、経路を固定すると既定の "auto" では
+ * 無効になる。プリセットでは明示的に有効化し、経路選択後の処理条件を揃える。
+ */
+const autoRoutePresetOptions = (
+	processingMode: ProcessingRoute,
+): ProcessOptions => ({
+	...AUTO_PRESET_OPTIONS,
+	processingMode,
+	smallAspectGridAlignment: "on",
+	watermarkSamplingCompat: "on",
+});
+
 export const BUILT_IN_PRESETS: readonly BuiltInPreset[] = [
 	{
 		id: "auto",
 		labelKey: "preset.auto",
-		options: withRouteManagedReduction(presetOptions({})),
+		options: AUTO_PRESET_OPTIONS,
 	},
 	{
 		id: "crisp-sprite",
 		labelKey: "preset.crisp_sprite",
-		options: presetOptions({ processingMode: "refine" }),
+		options: autoRoutePresetOptions("refine"),
 	},
 	{
 		id: "keep-fine-details",
 		labelKey: "preset.keep_fine_details",
-		options: presetOptions({ detailLevel: "detailed" }),
+		options: autoRoutePresetOptions("preserve"),
 	},
 	{
 		id: "transparent-icon",
@@ -164,14 +185,7 @@ export const BUILT_IN_PRESETS: readonly BuiltInPreset[] = [
 	{
 		id: "photo-to-pixel",
 		labelKey: "preset.photo_to_pixel",
-		options: presetOptions(
-			{
-				processingMode: "convert",
-				background: "keep",
-				dithering: "subtle",
-			},
-			{ reduceColors: true, reduceColorMode: "auto", colorCount: 32 },
-		),
+		options: autoRoutePresetOptions("convert"),
 	},
 ] as const;
 


### PR DESCRIPTION
## 概要

おまかせで選ばれる3つの処理経路を、既存プリセットから同じ結果で明示的に選択できるようにする。

## 変更内容

### UI/UX

- 既定プリセット名を「おまかせ仕上げ」から「おまかせ」へ変更する。

### ロジック

- 「くっきりドット」「細部を残す」「階調を残したドット絵」をそれぞれRefine、Preserve、Convert経路へ対応させ、「おまかせ」と同じ共通条件で処理する。

### 開発体験

- なし

### その他

- 「おまかせ」の分類・経路選択ロジックは変更しない。

## 動作確認

- なし
