### PR TITLE
feat: 詳細設定でConvertの出力サイズ指定を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -881,6 +881,70 @@
                         Pixel Only takes priority, so Processing is not used.
                       </p>
                       <label
+                        id="advanced-convert-size-mode-setting"
+                        class="setting-item"
+                        hidden
+                      >
+                        <span class="label-text">
+                          <span data-i18n="setting.convert_output_size"
+                            >Output Size</span
+                          >
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_size"
+                            data-tooltip="Choose one of five detail levels, or specify the Convert resampling width, height, or both. When only one dimension is specified, the other follows the image aspect ratio."
+                            >?</span
+                          >
+                        </span>
+                        <select id="advanced-convert-size-mode">
+                          <option
+                            value="smallest"
+                            data-i18n="option.size_very_small"
+                          >
+                            Very coarse
+                          </option>
+                          <option value="small" data-i18n="option.size_small">
+                            Coarse
+                          </option>
+                          <option
+                            value="coarse"
+                            data-i18n="option.size_slightly_small"
+                          >
+                            Slightly coarse
+                          </option>
+                          <option
+                            value="balanced"
+                            data-i18n="option.size_standard"
+                          >
+                            Balanced
+                          </option>
+                          <option
+                            value="detailed"
+                            data-i18n="option.size_large"
+                          >
+                            Fine
+                          </option>
+                          <option
+                            value="custom-width"
+                            data-i18n="option.size_custom_width"
+                          >
+                            Specify width
+                          </option>
+                          <option
+                            value="custom-height"
+                            data-i18n="option.size_custom_height"
+                          >
+                            Specify height
+                          </option>
+                          <option
+                            value="custom-both"
+                            data-i18n="option.size_custom_both"
+                          >
+                            Specify width and height
+                          </option>
+                        </select>
+                      </label>
+                      <label
                         id="advanced-convert-width-setting"
                         class="setting-item"
                         hidden
@@ -891,7 +955,7 @@
                           >
                           <span
                             class="help"
-                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_size"
+                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_dimension"
                             data-tooltip="Sets the resampling width used by Convert. Trimming, outlines, and padding can change the final canvas size."
                             >?</span
                           >
@@ -916,7 +980,7 @@
                           >
                           <span
                             class="help"
-                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_size"
+                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_dimension"
                             data-tooltip="Sets the resampling height used by Convert. Trimming, outlines, and padding can change the final canvas size."
                             >?</span
                           >

--- a/index.html
+++ b/index.html
@@ -832,18 +832,24 @@
                       Processing
                     </h3>
                     <div class="grid-settings">
-                      <label class="setting-item">
+                      <label
+                        id="advanced-processing-mode-setting"
+                        class="setting-item"
+                      >
                         <span
                           class="label-text"
                           data-i18n="setting.processing_mode"
                           >Processing</span
                         >
-                        <select id="advanced-processing-mode">
+                        <select
+                          id="advanced-processing-mode"
+                          aria-describedby="advanced-processing-mode-notice"
+                        >
                           <option
                             value="auto"
                             data-i18n="option.processing_auto"
                           >
-                            Auto
+                            Automatic Selection
                           </option>
                           <option
                             value="refine"
@@ -865,30 +871,64 @@
                           </option>
                         </select>
                       </label>
-                      <label class="setting-item">
-                        <span class="label-text" data-i18n="setting.detail"
-                          >Detail</span
-                        >
-                        <select id="advanced-detail-level">
-                          <option
-                            value="coarse"
-                            data-i18n="option.detail_coarse"
+                      <p
+                        id="advanced-processing-mode-notice"
+                        class="processing-mode-notice"
+                        role="status"
+                        data-i18n="notice.processing_mode_forced_size"
+                        hidden
+                      >
+                        Pixel Only takes priority, so Processing is not used.
+                      </p>
+                      <label
+                        id="advanced-convert-width-setting"
+                        class="setting-item"
+                        hidden
+                      >
+                        <span class="label-text">
+                          <span data-i18n="setting.convert_output_width"
+                            >Output Width</span
                           >
-                            Coarse
-                          </option>
-                          <option
-                            value="balanced"
-                            data-i18n="option.detail_balanced"
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_size"
+                            data-tooltip="Sets the resampling width used by Convert. Trimming, outlines, and padding can change the final canvas size."
+                            >?</span
                           >
-                            Balanced
-                          </option>
-                          <option
-                            value="detailed"
-                            data-i18n="option.detail_detailed"
+                        </span>
+                        <div class="input-unit-wrapper">
+                          <input
+                            id="advanced-convert-width"
+                            type="number"
+                            required
+                          />
+                          <span class="unit-text">px</span>
+                        </div>
+                      </label>
+                      <label
+                        id="advanced-convert-height-setting"
+                        class="setting-item"
+                        hidden
+                      >
+                        <span class="label-text">
+                          <span data-i18n="setting.convert_output_height"
+                            >Output Height</span
                           >
-                            Detailed
-                          </option>
-                        </select>
+                          <span
+                            class="help"
+                            data-i18n-attr="data-tooltip:tooltip.help.convert_output_size"
+                            data-tooltip="Sets the resampling height used by Convert. Trimming, outlines, and padding can change the final canvas size."
+                            >?</span
+                          >
+                        </span>
+                        <div class="input-unit-wrapper">
+                          <input
+                            id="advanced-convert-height"
+                            type="number"
+                            required
+                          />
+                          <span class="unit-text">px</span>
+                        </div>
                       </label>
                     </div>
                   </div>

--- a/src/browser/advanced-processing-controls.test.ts
+++ b/src/browser/advanced-processing-controls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { RawImage } from "../shared/types";
 import {
+	hasCompleteConvertOutputSize,
 	hasCompleteForcedSize,
 	populateAdvancedConvertOutputSize,
 	updateAdvancedProcessingControls,
@@ -32,11 +33,13 @@ class MockControl extends MockElement {
 	disabled = false;
 }
 
-const createElements = (): Elements =>
-	({
+const createElements = (): Elements => {
+	const els = {
 		advancedProcessingModeSelect: new MockControl(),
 		advancedProcessingModeSetting: new MockElement(),
 		advancedProcessingModeNotice: new MockElement(),
+		advancedConvertSizeModeSetting: new MockElement(),
+		advancedConvertSizeModeSelect: new MockControl(),
 		advancedConvertWidthSetting: new MockElement(),
 		advancedConvertHeightSetting: new MockElement(),
 		advancedConvertWidthInput: new MockControl(),
@@ -44,7 +47,10 @@ const createElements = (): Elements =>
 		gridDetectionModeSelect: new MockControl(),
 		forcePixelsWInput: new MockControl(),
 		forcePixelsHInput: new MockControl(),
-	}) as unknown as Elements;
+	} as unknown as Elements;
+	els.advancedConvertSizeModeSelect.value = "balanced";
+	return els;
+};
 
 const image = (): RawImage => ({
 	width: 64,
@@ -58,20 +64,26 @@ describe("advanced processing controls", () => {
 		els.advancedProcessingModeSelect.value = "auto";
 
 		updateAdvancedProcessingControls(els, "refine");
+		expect(els.advancedConvertSizeModeSetting.hidden).toBe(true);
 		expect(els.advancedConvertWidthSetting.hidden).toBe(true);
 		expect(els.advancedConvertHeightSetting.hidden).toBe(true);
 
 		updateAdvancedProcessingControls(els, "convert");
-		expect(els.advancedConvertWidthSetting.hidden).toBe(false);
-		expect(els.advancedConvertHeightSetting.hidden).toBe(false);
+		expect(els.advancedConvertSizeModeSetting.hidden).toBe(false);
+		expect(els.advancedConvertWidthSetting.hidden).toBe(true);
+		expect(els.advancedConvertHeightSetting.hidden).toBe(true);
 
 		els.advancedProcessingModeSelect.value = "convert";
+		els.advancedConvertSizeModeSelect.value = "custom-width";
 		updateAdvancedProcessingControls(els);
+		expect(els.advancedConvertSizeModeSetting.hidden).toBe(false);
 		expect(els.advancedConvertWidthSetting.hidden).toBe(false);
+		expect(els.advancedConvertHeightSetting.hidden).toBe(true);
 	});
 
-	it("expands the balanced Convert candidate into concrete dimensions", () => {
+	it("fills both custom dimensions from the balanced Convert candidate", () => {
 		const els = createElements();
+		els.advancedConvertSizeModeSelect.value = "custom-both";
 
 		populateAdvancedConvertOutputSize(els, image());
 
@@ -79,14 +91,29 @@ describe("advanced processing controls", () => {
 		expect(Number(els.advancedConvertHeightInput.value)).toBeGreaterThan(0);
 	});
 
-	it("preserves one entered dimension and derives the other from the image ratio", () => {
+	it("fills only the dimension selected by the user", () => {
 		const els = createElements();
-		els.advancedConvertWidthInput.value = "20";
+		els.advancedConvertSizeModeSelect.value = "custom-width";
 
 		populateAdvancedConvertOutputSize(els, image());
 
-		expect(els.advancedConvertWidthInput.value).toBe("20");
-		expect(els.advancedConvertHeightInput.value).toBe("10");
+		expect(Number(els.advancedConvertWidthInput.value)).toBeGreaterThan(0);
+		expect(els.advancedConvertHeightInput.value).toBe("");
+	});
+
+	it("requires only the inputs selected by the output-size mode", () => {
+		const els = createElements();
+		expect(hasCompleteConvertOutputSize(els)).toBe(true);
+
+		els.advancedConvertSizeModeSelect.value = "custom-height";
+		expect(hasCompleteConvertOutputSize(els)).toBe(false);
+		els.advancedConvertHeightInput.value = "12";
+		expect(hasCompleteConvertOutputSize(els)).toBe(true);
+
+		els.advancedConvertSizeModeSelect.value = "custom-both";
+		expect(hasCompleteConvertOutputSize(els)).toBe(false);
+		els.advancedConvertWidthInput.value = "20";
+		expect(hasCompleteConvertOutputSize(els)).toBe(true);
 	});
 
 	it("disables Processing and explains why when a complete forced size wins", () => {
@@ -101,6 +128,7 @@ describe("advanced processing controls", () => {
 
 		expect(els.advancedProcessingModeSelect.disabled).toBe(true);
 		expect(els.advancedProcessingModeNotice.hidden).toBe(false);
+		expect(els.advancedConvertSizeModeSetting.hidden).toBe(true);
 		expect(els.advancedConvertWidthSetting.hidden).toBe(true);
 		expect(
 			els.advancedProcessingModeSetting.classList.contains(

--- a/src/browser/advanced-processing-controls.test.ts
+++ b/src/browser/advanced-processing-controls.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import type { RawImage } from "../shared/types";
+import {
+	hasCompleteForcedSize,
+	populateAdvancedConvertOutputSize,
+	updateAdvancedProcessingControls,
+} from "./advanced-processing-controls";
+import type { Elements } from "./app-elements";
+
+class MockClassList {
+	private values = new Set<string>();
+	toggle(name: string, force: boolean) {
+		if (force) this.values.add(name);
+		else this.values.delete(name);
+	}
+	contains(name: string) {
+		return this.values.has(name);
+	}
+}
+
+class MockElement {
+	hidden = false;
+	classList = new MockClassList();
+	attributes = new Map<string, string>();
+	setAttribute(name: string, value: string) {
+		this.attributes.set(name, value);
+	}
+}
+
+class MockControl extends MockElement {
+	value = "";
+	disabled = false;
+}
+
+const createElements = (): Elements =>
+	({
+		advancedProcessingModeSelect: new MockControl(),
+		advancedProcessingModeSetting: new MockElement(),
+		advancedProcessingModeNotice: new MockElement(),
+		advancedConvertWidthSetting: new MockElement(),
+		advancedConvertHeightSetting: new MockElement(),
+		advancedConvertWidthInput: new MockControl(),
+		advancedConvertHeightInput: new MockControl(),
+		gridDetectionModeSelect: new MockControl(),
+		forcePixelsWInput: new MockControl(),
+		forcePixelsHInput: new MockControl(),
+	}) as unknown as Elements;
+
+const image = (): RawImage => ({
+	width: 64,
+	height: 32,
+	data: new Uint8ClampedArray(64 * 32 * 4),
+});
+
+describe("advanced processing controls", () => {
+	it("shows Convert dimensions only for a Convert route", () => {
+		const els = createElements();
+		els.advancedProcessingModeSelect.value = "auto";
+
+		updateAdvancedProcessingControls(els, "refine");
+		expect(els.advancedConvertWidthSetting.hidden).toBe(true);
+		expect(els.advancedConvertHeightSetting.hidden).toBe(true);
+
+		updateAdvancedProcessingControls(els, "convert");
+		expect(els.advancedConvertWidthSetting.hidden).toBe(false);
+		expect(els.advancedConvertHeightSetting.hidden).toBe(false);
+
+		els.advancedProcessingModeSelect.value = "convert";
+		updateAdvancedProcessingControls(els);
+		expect(els.advancedConvertWidthSetting.hidden).toBe(false);
+	});
+
+	it("expands the balanced Convert candidate into concrete dimensions", () => {
+		const els = createElements();
+
+		populateAdvancedConvertOutputSize(els, image());
+
+		expect(Number(els.advancedConvertWidthInput.value)).toBeGreaterThan(0);
+		expect(Number(els.advancedConvertHeightInput.value)).toBeGreaterThan(0);
+	});
+
+	it("preserves one entered dimension and derives the other from the image ratio", () => {
+		const els = createElements();
+		els.advancedConvertWidthInput.value = "20";
+
+		populateAdvancedConvertOutputSize(els, image());
+
+		expect(els.advancedConvertWidthInput.value).toBe("20");
+		expect(els.advancedConvertHeightInput.value).toBe("10");
+	});
+
+	it("disables Processing and explains why when a complete forced size wins", () => {
+		const els = createElements();
+		els.advancedProcessingModeSelect.value = "convert";
+		els.gridDetectionModeSelect.value = "force";
+		els.forcePixelsWInput.value = "16";
+		els.forcePixelsHInput.value = "12";
+
+		expect(hasCompleteForcedSize(els)).toBe(true);
+		updateAdvancedProcessingControls(els);
+
+		expect(els.advancedProcessingModeSelect.disabled).toBe(true);
+		expect(els.advancedProcessingModeNotice.hidden).toBe(false);
+		expect(els.advancedConvertWidthSetting.hidden).toBe(true);
+		expect(
+			els.advancedProcessingModeSetting.classList.contains(
+				"is-disabled-visible",
+			),
+		).toBe(true);
+	});
+
+	it("keeps Processing available until both forced dimensions are present", () => {
+		const els = createElements();
+		els.gridDetectionModeSelect.value = "force";
+		els.forcePixelsWInput.value = "16";
+
+		updateAdvancedProcessingControls(els);
+
+		expect(els.advancedProcessingModeSelect.disabled).toBe(false);
+		expect(els.advancedProcessingModeNotice.hidden).toBe(true);
+	});
+});

--- a/src/browser/advanced-processing-controls.ts
+++ b/src/browser/advanced-processing-controls.ts
@@ -1,7 +1,24 @@
 import { createConvertCandidates } from "../core/converter";
 import { clampInt, PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
-import type { ProcessingRoute, RawImage } from "../shared/types";
+import type { DetailLevel, ProcessingRoute, RawImage } from "../shared/types";
 import type { Elements } from "./app-elements";
+
+export type AdvancedConvertSizeMode =
+	| DetailLevel
+	| "custom-width"
+	| "custom-height"
+	| "custom-both";
+
+const DETAIL_LEVELS: readonly DetailLevel[] = [
+	"smallest",
+	"small",
+	"coarse",
+	"balanced",
+	"detailed",
+];
+
+export const isConvertDetailLevel = (value: string): value is DetailLevel =>
+	DETAIL_LEVELS.includes(value as DetailLevel);
 
 const hasNumber = (input: HTMLInputElement): boolean => {
 	const value = input.value.trim();
@@ -9,8 +26,14 @@ const hasNumber = (input: HTMLInputElement): boolean => {
 };
 
 export const hasCompleteConvertOutputSize = (els: Elements): boolean =>
-	hasNumber(els.advancedConvertWidthInput) &&
-	hasNumber(els.advancedConvertHeightInput);
+	isConvertDetailLevel(els.advancedConvertSizeModeSelect.value) ||
+	(els.advancedConvertSizeModeSelect.value === "custom-width" &&
+		hasNumber(els.advancedConvertWidthInput)) ||
+	(els.advancedConvertSizeModeSelect.value === "custom-height" &&
+		hasNumber(els.advancedConvertHeightInput)) ||
+	(els.advancedConvertSizeModeSelect.value === "custom-both" &&
+		hasNumber(els.advancedConvertWidthInput) &&
+		hasNumber(els.advancedConvertHeightInput));
 
 export const hasCompleteForcedSize = (els: Elements): boolean =>
 	els.gridDetectionModeSelect.value === "force" &&
@@ -18,46 +41,34 @@ export const hasCompleteForcedSize = (els: Elements): boolean =>
 	hasNumber(els.forcePixelsHInput);
 
 /**
- * Convert の自動候補を、詳細設定で編集できる具体的な幅・高さへ展開する。
+ * Convert の自動候補を、選択したカスタム入力の初期値へ展開する。
  *
- * [Intended] 片方だけ入力済みなら利用者の値を保持し、欠けている軸だけを補う。
+ * [Intended] 幅だけ・高さだけの指定では、もう一方をコア側が実処理領域から算出する。
+ * UI は利用者が指定すると選んだ軸だけを補い、入力対象ではない値を暗黙に送らない。
  */
 export const populateAdvancedConvertOutputSize = (
 	els: Elements,
 	image: RawImage | undefined,
 ): void => {
 	if (!image) return;
-	if (
-		els.advancedConvertWidthInput.value.trim() !== "" &&
-		els.advancedConvertHeightInput.value.trim() !== ""
-	) {
-		return;
-	}
+	const mode = els.advancedConvertSizeModeSelect
+		.value as AdvancedConvertSizeMode;
+	if (isConvertDetailLevel(mode)) return;
 	const candidates = createConvertCandidates(image);
 	const suggested = candidates.find(
 		(candidate) => candidate.label === PROCESS_DEFAULTS.detailLevel,
 	);
 	if (!suggested) return;
-	const width = Number(els.advancedConvertWidthInput.value);
-	const height = Number(els.advancedConvertHeightInput.value);
-	if (els.advancedConvertWidthInput.value.trim() === "") {
+	const usesWidth = mode === "custom-width" || mode === "custom-both";
+	const usesHeight = mode === "custom-height" || mode === "custom-both";
+	if (usesWidth && els.advancedConvertWidthInput.value.trim() === "") {
 		els.advancedConvertWidthInput.value = String(
-			clampInt(
-				Number.isFinite(height) && height > 0
-					? Math.round((height * image.width) / image.height)
-					: suggested.outW,
-				PROCESS_RANGES.convertPixelsW,
-			),
+			clampInt(suggested.outW, PROCESS_RANGES.convertPixelsW),
 		);
 	}
-	if (els.advancedConvertHeightInput.value.trim() === "") {
+	if (usesHeight && els.advancedConvertHeightInput.value.trim() === "") {
 		els.advancedConvertHeightInput.value = String(
-			clampInt(
-				Number.isFinite(width) && width > 0
-					? Math.round((width * image.height) / image.width)
-					: suggested.outH,
-				PROCESS_RANGES.convertPixelsH,
-			),
+			clampInt(suggested.outH, PROCESS_RANGES.convertPixelsH),
 		);
 	}
 };
@@ -83,9 +94,18 @@ export const updateAdvancedProcessingControls = (
 	const showConvertSize =
 		!forced &&
 		(mode === "convert" || (mode === "auto" && activeRoute === "convert"));
+	const sizeMode = els.advancedConvertSizeModeSelect
+		.value as AdvancedConvertSizeMode;
+	const showWidth =
+		showConvertSize &&
+		(sizeMode === "custom-width" || sizeMode === "custom-both");
+	const showHeight =
+		showConvertSize &&
+		(sizeMode === "custom-height" || sizeMode === "custom-both");
 
-	els.advancedConvertWidthSetting.hidden = !showConvertSize;
-	els.advancedConvertHeightSetting.hidden = !showConvertSize;
+	els.advancedConvertSizeModeSetting.hidden = !showConvertSize;
+	els.advancedConvertWidthSetting.hidden = !showWidth;
+	els.advancedConvertHeightSetting.hidden = !showHeight;
 	els.advancedProcessingModeSelect.disabled = forced;
 	els.advancedProcessingModeSetting.classList.toggle(
 		"is-disabled-visible",

--- a/src/browser/advanced-processing-controls.ts
+++ b/src/browser/advanced-processing-controls.ts
@@ -1,0 +1,99 @@
+import { createConvertCandidates } from "../core/converter";
+import { clampInt, PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import type { ProcessingRoute, RawImage } from "../shared/types";
+import type { Elements } from "./app-elements";
+
+const hasNumber = (input: HTMLInputElement): boolean => {
+	const value = input.value.trim();
+	return value !== "" && Number.isFinite(Number(value));
+};
+
+export const hasCompleteConvertOutputSize = (els: Elements): boolean =>
+	hasNumber(els.advancedConvertWidthInput) &&
+	hasNumber(els.advancedConvertHeightInput);
+
+export const hasCompleteForcedSize = (els: Elements): boolean =>
+	els.gridDetectionModeSelect.value === "force" &&
+	hasNumber(els.forcePixelsWInput) &&
+	hasNumber(els.forcePixelsHInput);
+
+/**
+ * Convert の自動候補を、詳細設定で編集できる具体的な幅・高さへ展開する。
+ *
+ * [Intended] 片方だけ入力済みなら利用者の値を保持し、欠けている軸だけを補う。
+ */
+export const populateAdvancedConvertOutputSize = (
+	els: Elements,
+	image: RawImage | undefined,
+): void => {
+	if (!image) return;
+	if (
+		els.advancedConvertWidthInput.value.trim() !== "" &&
+		els.advancedConvertHeightInput.value.trim() !== ""
+	) {
+		return;
+	}
+	const candidates = createConvertCandidates(image);
+	const suggested = candidates.find(
+		(candidate) => candidate.label === PROCESS_DEFAULTS.detailLevel,
+	);
+	if (!suggested) return;
+	const width = Number(els.advancedConvertWidthInput.value);
+	const height = Number(els.advancedConvertHeightInput.value);
+	if (els.advancedConvertWidthInput.value.trim() === "") {
+		els.advancedConvertWidthInput.value = String(
+			clampInt(
+				Number.isFinite(height) && height > 0
+					? Math.round((height * image.width) / image.height)
+					: suggested.outW,
+				PROCESS_RANGES.convertPixelsW,
+			),
+		);
+	}
+	if (els.advancedConvertHeightInput.value.trim() === "") {
+		els.advancedConvertHeightInput.value = String(
+			clampInt(
+				Number.isFinite(width) && width > 0
+					? Math.round((width * image.height) / image.width)
+					: suggested.outH,
+				PROCESS_RANGES.convertPixelsH,
+			),
+		);
+	}
+};
+
+export const applyAdvancedConvertOutputRanges = (els: Elements): void => {
+	els.advancedConvertWidthInput.min = String(PROCESS_RANGES.convertPixelsW.min);
+	els.advancedConvertWidthInput.max = String(PROCESS_RANGES.convertPixelsW.max);
+	els.advancedConvertHeightInput.min = String(
+		PROCESS_RANGES.convertPixelsH.min,
+	);
+	els.advancedConvertHeightInput.max = String(
+		PROCESS_RANGES.convertPixelsH.max,
+	);
+};
+
+/** 詳細設定の処理経路に依存する表示と、強制サイズ優先時の無効状態を同期する。 */
+export const updateAdvancedProcessingControls = (
+	els: Elements,
+	activeRoute?: ProcessingRoute,
+): void => {
+	const mode = els.advancedProcessingModeSelect.value;
+	const forced = hasCompleteForcedSize(els);
+	const showConvertSize =
+		!forced &&
+		(mode === "convert" || (mode === "auto" && activeRoute === "convert"));
+
+	els.advancedConvertWidthSetting.hidden = !showConvertSize;
+	els.advancedConvertHeightSetting.hidden = !showConvertSize;
+	els.advancedProcessingModeSelect.disabled = forced;
+	els.advancedProcessingModeSetting.classList.toggle(
+		"is-disabled-visible",
+		forced,
+	);
+	els.advancedProcessingModeSetting.setAttribute(
+		"aria-disabled",
+		String(forced),
+	);
+	els.advancedProcessingModeNotice.hidden = !forced;
+};

--- a/src/browser/advanced-settings-fields.test.ts
+++ b/src/browser/advanced-settings-fields.test.ts
@@ -12,6 +12,9 @@ describe("migrateAdvancedSettings", () => {
 		expect(state["cell-sampling-mode"]).toBe(PROCESS_DEFAULTS.cellSamplingMode);
 		expect(state["small-aspect-grid-alignment"]).toBe("auto");
 		expect(state["watermark-sampling-compat"]).toBe("auto");
+		expect(state["advanced-convert-size-mode"]).toBe(
+			PROCESS_DEFAULTS.detailLevel,
+		);
 		expect(state["advanced-convert-width"]).toBe("");
 		expect(state["advanced-convert-height"]).toBe("");
 		expect(state["background-dehalo"]).toBe(true);
@@ -24,6 +27,22 @@ describe("migrateAdvancedSettings", () => {
 			PROCESS_RANGES.trimAlphaThreshold.default,
 		);
 		expect(state["auto-max-cells-w"]).toBe(PROCESS_RANGES.autoMaxCells.default);
+	});
+
+	it("migrates saved Convert dimensions to the matching custom mode", () => {
+		const widthOnly: Record<string, string | number | boolean> = {
+			"advanced-convert-width": 24,
+		};
+		const both: Record<string, string | number | boolean> = {
+			"advanced-convert-width": 24,
+			"advanced-convert-height": 18,
+		};
+
+		migrateAdvancedSettings(widthOnly);
+		migrateAdvancedSettings(both);
+
+		expect(widthOnly["advanced-convert-size-mode"]).toBe("custom-width");
+		expect(both["advanced-convert-size-mode"]).toBe("custom-both");
 	});
 
 	it("carries the old semi-transparent-edge toggle into the sampling mode", () => {

--- a/src/browser/advanced-settings-fields.test.ts
+++ b/src/browser/advanced-settings-fields.test.ts
@@ -12,6 +12,8 @@ describe("migrateAdvancedSettings", () => {
 		expect(state["cell-sampling-mode"]).toBe(PROCESS_DEFAULTS.cellSamplingMode);
 		expect(state["small-aspect-grid-alignment"]).toBe("auto");
 		expect(state["watermark-sampling-compat"]).toBe("auto");
+		expect(state["advanced-convert-width"]).toBe("");
+		expect(state["advanced-convert-height"]).toBe("");
 		expect(state["background-dehalo"]).toBe(true);
 		expect(state["background-edge-cleanup"]).toBe(true);
 		expect(state["background-confidence-gate"]).toBe(true);

--- a/src/browser/advanced-settings-fields.ts
+++ b/src/browser/advanced-settings-fields.ts
@@ -46,6 +46,7 @@ export const advancedModeControls = (
 	els: Elements,
 ): Array<HTMLInputElement | HTMLSelectElement> => [
 	els.advancedProcessingModeSelect,
+	els.advancedConvertSizeModeSelect,
 	els.advancedConvertWidthInput,
 	els.advancedConvertHeightInput,
 	els.quantStepInput,
@@ -201,6 +202,19 @@ export const migrateAdvancedSettings = (
 		PROCESS_DEFAULTS.smallAspectGridAlignment;
 	state["watermark-sampling-compat"] ??=
 		PROCESS_DEFAULTS.watermarkSamplingCompat;
+	const hasConvertWidth =
+		state["advanced-convert-width"] !== undefined &&
+		state["advanced-convert-width"] !== "";
+	const hasConvertHeight =
+		state["advanced-convert-height"] !== undefined &&
+		state["advanced-convert-height"] !== "";
+	state["advanced-convert-size-mode"] ??= hasConvertWidth
+		? hasConvertHeight
+			? "custom-both"
+			: "custom-width"
+		: hasConvertHeight
+			? "custom-height"
+			: PROCESS_DEFAULTS.detailLevel;
 	state["advanced-convert-width"] ??= "";
 	state["advanced-convert-height"] ??= "";
 

--- a/src/browser/advanced-settings-fields.ts
+++ b/src/browser/advanced-settings-fields.ts
@@ -46,7 +46,8 @@ export const advancedModeControls = (
 	els: Elements,
 ): Array<HTMLInputElement | HTMLSelectElement> => [
 	els.advancedProcessingModeSelect,
-	els.advancedDetailLevelSelect,
+	els.advancedConvertWidthInput,
+	els.advancedConvertHeightInput,
 	els.quantStepInput,
 	els.quantStepSlider,
 	els.forcePixelsWInput,
@@ -200,6 +201,8 @@ export const migrateAdvancedSettings = (
 		PROCESS_DEFAULTS.smallAspectGridAlignment;
 	state["watermark-sampling-compat"] ??=
 		PROCESS_DEFAULTS.watermarkSamplingCompat;
+	state["advanced-convert-width"] ??= "";
+	state["advanced-convert-height"] ??= "";
 
 	state["preserve-thin-features"] ??= PROCESS_DEFAULTS.preserveThinFeatures;
 	state["auto-grid-from-trimmed"] ??= PROCESS_DEFAULTS.autoGridFromTrimmed;

--- a/src/browser/app-elements.ts
+++ b/src/browser/app-elements.ts
@@ -93,7 +93,12 @@ export type Elements = {
 	quickEyedropperButton: HTMLButtonElement;
 	quickDitheringSelect: HTMLSelectElement;
 	advancedProcessingModeSelect: HTMLSelectElement;
-	advancedDetailLevelSelect: HTMLSelectElement;
+	advancedProcessingModeSetting: HTMLElement;
+	advancedProcessingModeNotice: HTMLElement;
+	advancedConvertWidthSetting: HTMLElement;
+	advancedConvertHeightSetting: HTMLElement;
+	advancedConvertWidthInput: HTMLInputElement;
+	advancedConvertHeightInput: HTMLInputElement;
 	advancedBgRemovalScopeSelect: HTMLSelectElement;
 
 	// パレット UI
@@ -284,7 +289,22 @@ export const getElements = (): Elements => {
 		advancedProcessingModeSelect: get<HTMLSelectElement>(
 			"advanced-processing-mode",
 		),
-		advancedDetailLevelSelect: get<HTMLSelectElement>("advanced-detail-level"),
+		advancedProcessingModeSetting: get<HTMLElement>(
+			"advanced-processing-mode-setting",
+		),
+		advancedProcessingModeNotice: get<HTMLElement>(
+			"advanced-processing-mode-notice",
+		),
+		advancedConvertWidthSetting: get<HTMLElement>(
+			"advanced-convert-width-setting",
+		),
+		advancedConvertHeightSetting: get<HTMLElement>(
+			"advanced-convert-height-setting",
+		),
+		advancedConvertWidthInput: get<HTMLInputElement>("advanced-convert-width"),
+		advancedConvertHeightInput: get<HTMLInputElement>(
+			"advanced-convert-height",
+		),
 		advancedBgRemovalScopeSelect: get<HTMLSelectElement>(
 			"advanced-bg-removal-scope",
 		),

--- a/src/browser/app-elements.ts
+++ b/src/browser/app-elements.ts
@@ -95,6 +95,8 @@ export type Elements = {
 	advancedProcessingModeSelect: HTMLSelectElement;
 	advancedProcessingModeSetting: HTMLElement;
 	advancedProcessingModeNotice: HTMLElement;
+	advancedConvertSizeModeSetting: HTMLElement;
+	advancedConvertSizeModeSelect: HTMLSelectElement;
 	advancedConvertWidthSetting: HTMLElement;
 	advancedConvertHeightSetting: HTMLElement;
 	advancedConvertWidthInput: HTMLInputElement;
@@ -294,6 +296,12 @@ export const getElements = (): Elements => {
 		),
 		advancedProcessingModeNotice: get<HTMLElement>(
 			"advanced-processing-mode-notice",
+		),
+		advancedConvertSizeModeSetting: get<HTMLElement>(
+			"advanced-convert-size-mode-setting",
+		),
+		advancedConvertSizeModeSelect: get<HTMLSelectElement>(
+			"advanced-convert-size-mode",
 		),
 		advancedConvertWidthSetting: get<HTMLElement>(
 			"advanced-convert-width-setting",

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -113,6 +113,9 @@ export const initApp = (): void => {
 				els,
 				item?.settingsMode === "quick" ? item.analysis?.route : undefined,
 			);
+			updateAdvancedProcessingDisabledStates(
+				item?.settingsMode === "advanced" ? item.analysis?.route : undefined,
+			);
 			if (item) {
 				// 結果があれば復元し、なければ元画像を使用
 				// const displayImage = item.result || item.original; // 未使用
@@ -251,6 +254,8 @@ export const initApp = (): void => {
 		updatePaletteDisplay: () => updatePaletteDisplay(),
 		updateGrid: () => updateGrid(),
 		updateBgColorFromMethod: () => updateBgColorFromMethod(),
+		updateAdvancedProcessingControls: (activeRoute) =>
+			updateAdvancedProcessingDisabledStates(activeRoute),
 		candidateChooser,
 	});
 	const processPendingImages = createProcessPendingImages({

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -85,6 +85,7 @@ const resources = {
 		"setting.processing_mode": "処理方法",
 		"setting.size": "サイズ",
 		"setting.detail": "細かさ",
+		"setting.convert_output_size": "出力サイズ",
 		"setting.convert_output_width": "出力幅",
 		"setting.convert_output_height": "出力高さ",
 		"setting.background": "背景透過",
@@ -110,6 +111,9 @@ const resources = {
 		"option.size_slightly_small": "やや粗い",
 		"option.size_standard": "標準",
 		"option.size_large": "細かい",
+		"option.size_custom_width": "幅を指定",
+		"option.size_custom_height": "高さを指定",
+		"option.size_custom_both": "幅と高さを指定",
 		"option.detail_coarse": "粗め",
 		"option.detail_balanced": "バランス",
 		"option.detail_detailed": "細かめ",
@@ -215,7 +219,9 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"目指す仕上がりを選びます。\n\nおまかせ: 画像に合う仕上がりを自動で選びます。\n輪郭をくっきり: ぼかしを除き、色と透明度をドット単位で揃えます。\n細部を残してドット化: 階調や細い線を残しながら低解像度化します。\nサイズを変えず補正: 縮小せず、背景や色だけを補正します。",
 		"tooltip.help.convert_output_size":
-			"Convertでリサンプリングする幅または高さを指定します。背景トリム、アウトライン、余白追加によって最終キャンバスの寸法は変わる場合があります。",
+			"5段階の細かさから選ぶか、Convertでリサンプリングする幅、高さ、または両方を指定します。片方だけ指定した場合、もう片方は画像の縦横比に合わせます。",
+		"tooltip.help.convert_output_dimension":
+			"Convertでリサンプリングする寸法を指定します。背景トリム、アウトライン、余白追加によって最終キャンバスの寸法は変わる場合があります。",
 		"tooltip.help.quick_detail":
 			"「細部を残してドット化」で使うドットの細かさを5段階から選びます。粗くするほど出力が小さくなり、1ドットが大きく見えます。「細かい」も元画像を超えて拡大しません。色数など、ほかの設定には影響しません。\n\n「おまかせ」では、細部を残す仕上がりが自動で選ばれた画像にだけ適用されます。",
 		"tooltip.help.quick_reduction_mode":
@@ -489,6 +495,7 @@ const resources = {
 		"setting.processing_mode": "处理方式",
 		"setting.size": "尺寸",
 		"setting.detail": "细节",
+		"setting.convert_output_size": "输出尺寸",
 		"setting.convert_output_width": "输出宽度",
 		"setting.convert_output_height": "输出高度",
 		"setting.background": "背景透明",
@@ -514,6 +521,9 @@ const resources = {
 		"option.size_slightly_small": "稍粗",
 		"option.size_standard": "标准",
 		"option.size_large": "精细",
+		"option.size_custom_width": "指定宽度",
+		"option.size_custom_height": "指定高度",
+		"option.size_custom_both": "指定宽度和高度",
 		"option.detail_coarse": "粗略",
 		"option.detail_balanced": "平衡",
 		"option.detail_detailed": "精细",
@@ -618,7 +628,9 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"选择目标效果。\n\n智能推荐：自动选择适合图像的效果。\n清晰轮廓：去除模糊，并按像素统一颜色和透明度。\n保留细节的像素画：在保留明暗层次和细线的同时降低分辨率。\n原尺寸优化：不缩小图像，只调整背景和色彩。",
 		"tooltip.help.convert_output_size":
-			"指定 Convert 重采样使用的宽度或高度。背景裁剪、描边和留白可能会改变最终画布尺寸。",
+			"选择五档细节级别，或指定 Convert 重采样使用的宽度、高度或两者。仅指定一个尺寸时，另一个尺寸将按图像纵横比计算。",
+		"tooltip.help.convert_output_dimension":
+			"指定 Convert 重采样使用的尺寸。背景裁剪、描边和留白可能会改变最终画布尺寸。",
 		"tooltip.help.quick_detail":
 			"为“保留细节的像素画”选择五档像素细节。设置越粗，输出尺寸越小，单个像素看起来越大。“精细”也不会放大到超过原图尺寸，不影响颜色数量等其他设置。\n\n在“智能推荐”中，仅当系统自动选择保留细节的效果时生效。",
 		"tooltip.help.quick_reduction_mode":
@@ -892,6 +904,7 @@ const resources = {
 		"setting.processing_mode": "Processing",
 		"setting.size": "Size",
 		"setting.detail": "Detail",
+		"setting.convert_output_size": "Output Size",
 		"setting.convert_output_width": "Output Width",
 		"setting.convert_output_height": "Output Height",
 		"setting.background": "Background Transparency",
@@ -917,6 +930,9 @@ const resources = {
 		"option.size_slightly_small": "Slightly coarse",
 		"option.size_standard": "Balanced",
 		"option.size_large": "Fine",
+		"option.size_custom_width": "Specify width",
+		"option.size_custom_height": "Specify height",
+		"option.size_custom_both": "Specify width and height",
 		"option.detail_coarse": "Coarse",
 		"option.detail_balanced": "Balanced",
 		"option.detail_detailed": "Detailed",
@@ -1022,7 +1038,9 @@ const resources = {
 		"tooltip.help.quick_processing_mode":
 			"Chooses the intended finish.\n\nBest Match: Selects a suitable finish for the image.\nCrisp Edges: Removes blur and aligns color and transparency to the pixel grid.\nDetailed Pixel Art: Reduces resolution while keeping gradients and thin lines.\nOriginal Size Cleanup: Adjusts the background and colors without downscaling.",
 		"tooltip.help.convert_output_size":
-			"Sets the width or height used for Convert resampling. Background trimming, outlines, and padding can change the final canvas dimensions.",
+			"Choose one of five detail levels, or specify the Convert resampling width, height, or both. When only one dimension is specified, the other follows the image aspect ratio.",
+		"tooltip.help.convert_output_dimension":
+			"Sets the resampling dimension used by Convert. Background trimming, outlines, and padding can change the final canvas size.",
 		"tooltip.help.quick_detail":
 			"Chooses from five pixel-detail levels for Detailed Pixel Art. Coarser settings produce a smaller output with larger-looking pixels. Fine never upscales beyond the original image and does not change the color count or other settings.\n\nIn Best Match, this applies only when a detailed finish is selected automatically.",
 		"tooltip.help.quick_reduction_mode":

--- a/src/browser/i18n.ts
+++ b/src/browser/i18n.ts
@@ -85,6 +85,8 @@ const resources = {
 		"setting.processing_mode": "処理方法",
 		"setting.size": "サイズ",
 		"setting.detail": "細かさ",
+		"setting.convert_output_width": "出力幅",
+		"setting.convert_output_height": "出力高さ",
 		"setting.background": "背景透過",
 		"setting.dithering": "ディザリング",
 		"preset.auto": "おまかせ",
@@ -97,7 +99,9 @@ const resources = {
 		"option.quick_processing_refine": "輪郭をくっきり",
 		"option.quick_processing_convert": "細部を残してドット化",
 		"option.quick_processing_preserve": "サイズを変えず補正",
-		"option.processing_auto": "Auto",
+		"option.processing_auto": "自動選択",
+		"notice.processing_mode_forced_size":
+			"完全ピクセル指定が優先されるため、処理方法は使用されません。",
 		"option.processing_refine": "ドットを整える",
 		"option.processing_convert": "ドット絵へ変換",
 		"option.processing_preserve": "原寸を維持",
@@ -210,6 +214,8 @@ const resources = {
 			"目指す仕上がりに合わせて、サイズ、色、背景などをまとめて設定します。",
 		"tooltip.help.quick_processing_mode":
 			"目指す仕上がりを選びます。\n\nおまかせ: 画像に合う仕上がりを自動で選びます。\n輪郭をくっきり: ぼかしを除き、色と透明度をドット単位で揃えます。\n細部を残してドット化: 階調や細い線を残しながら低解像度化します。\nサイズを変えず補正: 縮小せず、背景や色だけを補正します。",
+		"tooltip.help.convert_output_size":
+			"Convertでリサンプリングする幅または高さを指定します。背景トリム、アウトライン、余白追加によって最終キャンバスの寸法は変わる場合があります。",
 		"tooltip.help.quick_detail":
 			"「細部を残してドット化」で使うドットの細かさを5段階から選びます。粗くするほど出力が小さくなり、1ドットが大きく見えます。「細かい」も元画像を超えて拡大しません。色数など、ほかの設定には影響しません。\n\n「おまかせ」では、細部を残す仕上がりが自動で選ばれた画像にだけ適用されます。",
 		"tooltip.help.quick_reduction_mode":
@@ -483,6 +489,8 @@ const resources = {
 		"setting.processing_mode": "处理方式",
 		"setting.size": "尺寸",
 		"setting.detail": "细节",
+		"setting.convert_output_width": "输出宽度",
+		"setting.convert_output_height": "输出高度",
 		"setting.background": "背景透明",
 		"setting.dithering": "抖动",
 		"preset.auto": "智能推荐",
@@ -495,7 +503,9 @@ const resources = {
 		"option.quick_processing_refine": "清晰轮廓",
 		"option.quick_processing_convert": "保留细节的像素画",
 		"option.quick_processing_preserve": "原尺寸优化",
-		"option.processing_auto": "Auto",
+		"option.processing_auto": "自动选择",
+		"notice.processing_mode_forced_size":
+			"完全像素指定优先，因此不会使用处理方式。",
 		"option.processing_refine": "优化像素",
 		"option.processing_convert": "转换为像素画",
 		"option.processing_preserve": "保持原尺寸",
@@ -607,6 +617,8 @@ const resources = {
 			"根据目标效果，一次设置尺寸、色彩和背景等项目。",
 		"tooltip.help.quick_processing_mode":
 			"选择目标效果。\n\n智能推荐：自动选择适合图像的效果。\n清晰轮廓：去除模糊，并按像素统一颜色和透明度。\n保留细节的像素画：在保留明暗层次和细线的同时降低分辨率。\n原尺寸优化：不缩小图像，只调整背景和色彩。",
+		"tooltip.help.convert_output_size":
+			"指定 Convert 重采样使用的宽度或高度。背景裁剪、描边和留白可能会改变最终画布尺寸。",
 		"tooltip.help.quick_detail":
 			"为“保留细节的像素画”选择五档像素细节。设置越粗，输出尺寸越小，单个像素看起来越大。“精细”也不会放大到超过原图尺寸，不影响颜色数量等其他设置。\n\n在“智能推荐”中，仅当系统自动选择保留细节的效果时生效。",
 		"tooltip.help.quick_reduction_mode":
@@ -880,6 +892,8 @@ const resources = {
 		"setting.processing_mode": "Processing",
 		"setting.size": "Size",
 		"setting.detail": "Detail",
+		"setting.convert_output_width": "Output Width",
+		"setting.convert_output_height": "Output Height",
 		"setting.background": "Background Transparency",
 		"setting.dithering": "Dithering",
 		"preset.auto": "Best Match",
@@ -892,7 +906,9 @@ const resources = {
 		"option.quick_processing_refine": "Crisp Edges",
 		"option.quick_processing_convert": "Detailed Pixel Art",
 		"option.quick_processing_preserve": "Original Size Cleanup",
-		"option.processing_auto": "Auto",
+		"option.processing_auto": "Automatic Selection",
+		"notice.processing_mode_forced_size":
+			"Pixel Only takes priority, so Processing is not used.",
 		"option.processing_refine": "Refine Pixels",
 		"option.processing_convert": "Convert to Pixel Art",
 		"option.processing_preserve": "Preserve Original Size",
@@ -1005,6 +1021,8 @@ const resources = {
 			"Sets the size, colors, background, and related options together for the finish you want.",
 		"tooltip.help.quick_processing_mode":
 			"Chooses the intended finish.\n\nBest Match: Selects a suitable finish for the image.\nCrisp Edges: Removes blur and aligns color and transparency to the pixel grid.\nDetailed Pixel Art: Reduces resolution while keeping gradients and thin lines.\nOriginal Size Cleanup: Adjusts the background and colors without downscaling.",
+		"tooltip.help.convert_output_size":
+			"Sets the width or height used for Convert resampling. Background trimming, outlines, and padding can change the final canvas dimensions.",
 		"tooltip.help.quick_detail":
 			"Chooses from five pixel-detail levels for Detailed Pixel Art. Coarser settings produce a smaller output with larger-looking pixels. Fine never upscales beyond the original image and does not change the color count or other settings.\n\nIn Best Match, this applies only when a detailed finish is selected automatically.",
 		"tooltip.help.quick_reduction_mode":

--- a/src/browser/preset-controls.ts
+++ b/src/browser/preset-controls.ts
@@ -70,7 +70,13 @@ export const setupPresetControls = ({
 				if (input.type === "checkbox") {
 					state[input.id] = input.checked;
 				} else if (input.type === "number" || input.type === "range") {
-					state[input.id] = Number(input.value);
+					const optionalConvertDimension =
+						input.id === "advanced-convert-width" ||
+						input.id === "advanced-convert-height";
+					state[input.id] =
+						optionalConvertDimension && input.value === ""
+							? ""
+							: Number(input.value);
 				} else {
 					state[input.id] = input.value;
 				}

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -162,14 +162,24 @@ export const createRunProcessing = ({
 				els,
 				processingState.settingsMode === "quick" ? analysis.route : undefined,
 			);
-			// [Intended] Convert 候補を選んだ場合は、画像単位の上書きを非表示にせず
-			// 詳細設定の具体的な出力寸法として表示する。
+			// [Intended] Convert 候補の選択を、詳細設定でも同じサイズ指定として表示する。
 			if (
 				processingState.settingsMode === "advanced" &&
 				effectiveSelection?.processingMode === "convert"
 			) {
-				els.advancedConvertWidthInput.value = String(effectiveSelection.outW);
-				els.advancedConvertHeightInput.value = String(effectiveSelection.outH);
+				if (effectiveSelection.detailLevel) {
+					els.advancedConvertSizeModeSelect.value =
+						effectiveSelection.detailLevel;
+				} else if (
+					effectiveSelection.outW !== undefined &&
+					effectiveSelection.outH !== undefined
+				) {
+					els.advancedConvertSizeModeSelect.value = "custom-both";
+					els.advancedConvertWidthInput.value = String(effectiveSelection.outW);
+					els.advancedConvertHeightInput.value = String(
+						effectiveSelection.outH,
+					);
+				}
 			}
 			updateAdvancedProcessingControls(
 				processingState.settingsMode === "advanced"

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -1,7 +1,7 @@
 import { wrap } from "comlink";
 import { evaluateCandidateModalDecision } from "../core/candidate-modal-decision";
 import type { ProcessorWorker } from "../core/worker";
-import type { CandidateSelection } from "../shared/types";
+import type { CandidateSelection, ProcessingRoute } from "../shared/types";
 import { sortPalette } from "../utils/palette";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
@@ -33,6 +33,7 @@ type ProcessingControllerOptions = {
 	updatePaletteDisplay: () => void;
 	updateGrid: () => void;
 	updateBgColorFromMethod: () => void;
+	updateAdvancedProcessingControls: (activeRoute?: ProcessingRoute) => void;
 	candidateChooser: CandidateChooser;
 };
 
@@ -60,6 +61,7 @@ export const createRunProcessing = ({
 	updatePaletteDisplay,
 	updateGrid,
 	updateBgColorFromMethod,
+	updateAdvancedProcessingControls,
 	candidateChooser,
 }: ProcessingControllerOptions): ((
 	options?: RunProcessingOptions,
@@ -159,6 +161,20 @@ export const createRunProcessing = ({
 			updateQuickSettingsDisabledStates(
 				els,
 				processingState.settingsMode === "quick" ? analysis.route : undefined,
+			);
+			// [Intended] Convert 候補を選んだ場合は、画像単位の上書きを非表示にせず
+			// 詳細設定の具体的な出力寸法として表示する。
+			if (
+				processingState.settingsMode === "advanced" &&
+				effectiveSelection?.processingMode === "convert"
+			) {
+				els.advancedConvertWidthInput.value = String(effectiveSelection.outW);
+				els.advancedConvertHeightInput.value = String(effectiveSelection.outH);
+			}
+			updateAdvancedProcessingControls(
+				processingState.settingsMode === "advanced"
+					? analysis.route
+					: undefined,
 			);
 
 			mainResultViewer.updateImage(resultImage);

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -295,6 +295,7 @@ export const setupSettingsControls = ({
 
 		els.bgExtractionMethod.value = defaults.bgExtractionMethod;
 		els.advancedProcessingModeSelect.value = defaults.processingMode;
+		els.advancedConvertSizeModeSelect.value = defaults.detailLevel;
 		els.advancedConvertWidthInput.value = "";
 		els.advancedConvertHeightInput.value = "";
 		els.quickProcessingModeSelect.value =
@@ -358,6 +359,7 @@ export const setupSettingsControls = ({
 		els.forcePixelsWInput,
 		els.forcePixelsHInput,
 		els.advancedProcessingModeSelect,
+		els.advancedConvertSizeModeSelect,
 		els.advancedConvertWidthInput,
 		els.advancedConvertHeightInput,
 		...gridDetectionAdvancedControls(els),
@@ -420,32 +422,48 @@ export const setupSettingsControls = ({
 			setDisabledClass(el, !isAutoOrHint);
 		});
 	};
-	const updateAdvancedProcessingDisabledStates = (
-		activeRoute?: ProcessingRoute,
-	) => {
+	let activeAdvancedRoute: ProcessingRoute | undefined;
+	const refreshAdvancedProcessingControls = () => {
 		const mode = els.advancedProcessingModeSelect.value;
-		if (mode === "convert" || (mode === "auto" && activeRoute === "convert")) {
+		if (
+			mode === "convert" ||
+			(mode === "auto" && activeAdvancedRoute === "convert")
+		) {
 			populateAdvancedConvertOutputSize(
 				els,
 				imageSession.getActiveImage()?.original,
 			);
 		}
-		updateAdvancedProcessingControls(els, activeRoute);
+		updateAdvancedProcessingControls(els, activeAdvancedRoute);
+	};
+	const updateAdvancedProcessingDisabledStates = (
+		activeRoute?: ProcessingRoute,
+	) => {
+		activeAdvancedRoute = activeRoute;
+		refreshAdvancedProcessingControls();
 	};
 
 	els.gridDetectionModeSelect.addEventListener("change", () => {
 		updateDisabledStates();
-		updateAdvancedProcessingDisabledStates();
+		refreshAdvancedProcessingControls();
 	});
 	els.advancedProcessingModeSelect.addEventListener("change", () => {
-		updateAdvancedProcessingDisabledStates();
+		refreshAdvancedProcessingControls();
+	});
+	els.advancedConvertSizeModeSelect.addEventListener("change", () => {
+		populateAdvancedConvertOutputSize(
+			els,
+			imageSession.getActiveImage()?.original,
+		);
+		refreshAdvancedProcessingControls();
+		if (hasCompleteConvertOutputSize(els)) triggerAutoProcess();
 	});
 	[els.forcePixelsWInput, els.forcePixelsHInput].forEach((input) => {
 		input.addEventListener("input", () => {
-			updateAdvancedProcessingDisabledStates();
+			refreshAdvancedProcessingControls();
 		});
 		input.addEventListener("change", () => {
-			updateAdvancedProcessingDisabledStates();
+			refreshAdvancedProcessingControls();
 		});
 	});
 	[els.advancedConvertWidthInput, els.advancedConvertHeightInput].forEach(

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -1,6 +1,13 @@
 import { rgbToHex } from "../core/colorUtils";
 import { createDefaultProcessOptions } from "../core/processor-options";
 import { PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
+import type { ProcessingRoute } from "../shared/types";
+import {
+	applyAdvancedConvertOutputRanges,
+	hasCompleteConvertOutputSize,
+	populateAdvancedConvertOutputSize,
+	updateAdvancedProcessingControls,
+} from "./advanced-processing-controls";
 import {
 	advancedSettingControls,
 	applyAdvancedSettingDefaults,
@@ -35,7 +42,9 @@ export type SettingsControls = {
 	updateProcessButtonVisibility: () => void;
 	triggerAutoProcess: () => void;
 	updateDisabledStates: () => void;
-	updateAdvancedProcessingDisabledStates: () => void;
+	updateAdvancedProcessingDisabledStates: (
+		activeRoute?: ProcessingRoute,
+	) => void;
 	updatePaletteButtonVisibility: () => void;
 	updateReduceColorsDisabledStates: () => void;
 	updateBgDisabledStates: () => void;
@@ -266,6 +275,7 @@ export const setupSettingsControls = ({
 		els.forcePixelsWInput.max = String(PROCESS_RANGES.forcePixelsW.max);
 		els.forcePixelsHInput.min = String(PROCESS_RANGES.forcePixelsH.min);
 		els.forcePixelsHInput.max = String(PROCESS_RANGES.forcePixelsH.max);
+		applyAdvancedConvertOutputRanges(els);
 
 		els.preRemoveCheck.checked = defaults.preRemoveBackground;
 		els.postRemoveCheck.checked = defaults.postRemoveBackground;
@@ -285,7 +295,8 @@ export const setupSettingsControls = ({
 
 		els.bgExtractionMethod.value = defaults.bgExtractionMethod;
 		els.advancedProcessingModeSelect.value = defaults.processingMode;
-		els.advancedDetailLevelSelect.value = defaults.detailLevel;
+		els.advancedConvertWidthInput.value = "";
+		els.advancedConvertHeightInput.value = "";
 		els.quickProcessingModeSelect.value =
 			QUICK_SETTINGS_DEFAULTS.processingMode;
 		els.quickDetailLevelSelect.value = QUICK_SETTINGS_DEFAULTS.detailLevel;
@@ -347,7 +358,8 @@ export const setupSettingsControls = ({
 		els.forcePixelsWInput,
 		els.forcePixelsHInput,
 		els.advancedProcessingModeSelect,
-		els.advancedDetailLevelSelect,
+		els.advancedConvertWidthInput,
+		els.advancedConvertHeightInput,
 		...gridDetectionAdvancedControls(els),
 	].forEach((el) => {
 		el.addEventListener("change", clearCandidateSelections);
@@ -408,19 +420,47 @@ export const setupSettingsControls = ({
 			setDisabledClass(el, !isAutoOrHint);
 		});
 	};
-	const updateAdvancedProcessingDisabledStates = () => {
+	const updateAdvancedProcessingDisabledStates = (
+		activeRoute?: ProcessingRoute,
+	) => {
 		const mode = els.advancedProcessingModeSelect.value;
-		const disabled = mode !== "auto" && mode !== "convert";
-		els.advancedDetailLevelSelect.disabled = disabled;
-		els.advancedDetailLevelSelect
-			.closest(".setting-item")
-			?.classList.toggle("disabled", disabled);
+		if (mode === "convert" || (mode === "auto" && activeRoute === "convert")) {
+			populateAdvancedConvertOutputSize(
+				els,
+				imageSession.getActiveImage()?.original,
+			);
+		}
+		updateAdvancedProcessingControls(els, activeRoute);
 	};
 
-	els.gridDetectionModeSelect.addEventListener("change", updateDisabledStates);
-	els.advancedProcessingModeSelect.addEventListener(
-		"change",
-		updateAdvancedProcessingDisabledStates,
+	els.gridDetectionModeSelect.addEventListener("change", () => {
+		updateDisabledStates();
+		updateAdvancedProcessingDisabledStates();
+	});
+	els.advancedProcessingModeSelect.addEventListener("change", () => {
+		updateAdvancedProcessingDisabledStates();
+	});
+	[els.forcePixelsWInput, els.forcePixelsHInput].forEach((input) => {
+		input.addEventListener("input", () => {
+			updateAdvancedProcessingDisabledStates();
+		});
+		input.addEventListener("change", () => {
+			updateAdvancedProcessingDisabledStates();
+		});
+	});
+	[els.advancedConvertWidthInput, els.advancedConvertHeightInput].forEach(
+		(input) => {
+			input.addEventListener("input", () => {
+				if (hasCompleteConvertOutputSize(els)) triggerAutoProcess();
+			});
+			input.addEventListener("change", () => {
+				populateAdvancedConvertOutputSize(
+					els,
+					imageSession.getActiveImage()?.original,
+				);
+				if (hasCompleteConvertOutputSize(els)) triggerAutoProcess();
+			});
+		},
 	);
 
 	// 減色設定の UI 制御
@@ -613,7 +653,6 @@ export const setupSettingsControls = ({
 		els.reduceColorModeSelect,
 		els.ditherModeSelect,
 		els.advancedProcessingModeSelect,
-		els.advancedDetailLevelSelect,
 		els.advancedBgRemovalScopeSelect,
 
 		els.bgExtractionMethod,

--- a/src/browser/settings-options.test.ts
+++ b/src/browser/settings-options.test.ts
@@ -31,7 +31,8 @@ const advancedElements = (
 		preRemoveCheck: input("", preRemove),
 		postRemoveCheck: input("", postRemove),
 		advancedProcessingModeSelect: select("auto"),
-		advancedDetailLevelSelect: select("balanced"),
+		advancedConvertWidthInput: input("24"),
+		advancedConvertHeightInput: input("18"),
 		advancedBgRemovalScopeSelect: select("auto"),
 		bgConnectivitySelect: select("4"),
 		cellSamplingModeSelect: select("hard-alpha-medoid"),
@@ -103,4 +104,21 @@ describe("settings mode options", () => {
 			expect(options.trimToContent).toBe(trimToContent);
 		},
 	);
+
+	it("passes Advanced Convert output dimensions independently of forced grid dimensions", () => {
+		const state = createProcessingState();
+		const els = advancedElements("auto", true, true);
+		els.advancedProcessingModeSelect.value = "convert";
+		els.gridDetectionModeSelect.value = "auto";
+
+		const options = createAdvancedProcessOptions(els, state);
+
+		expect(options).toMatchObject({
+			processingMode: "convert",
+			convertPixelsW: 24,
+			convertPixelsH: 18,
+		});
+		expect(options.forcePixelsW).toBeUndefined();
+		expect(options.forcePixelsH).toBeUndefined();
+	});
 });

--- a/src/browser/settings-options.test.ts
+++ b/src/browser/settings-options.test.ts
@@ -31,6 +31,7 @@ const advancedElements = (
 		preRemoveCheck: input("", preRemove),
 		postRemoveCheck: input("", postRemove),
 		advancedProcessingModeSelect: select("auto"),
+		advancedConvertSizeModeSelect: select("custom-both"),
 		advancedConvertWidthInput: input("24"),
 		advancedConvertHeightInput: input("18"),
 		advancedBgRemovalScopeSelect: select("auto"),
@@ -120,5 +121,39 @@ describe("settings mode options", () => {
 		});
 		expect(options.forcePixelsW).toBeUndefined();
 		expect(options.forcePixelsH).toBeUndefined();
+	});
+
+	it("passes only the selected Convert dimension", () => {
+		const state = createProcessingState();
+		const els = advancedElements("auto", true, true);
+		els.advancedConvertSizeModeSelect.value = "custom-width";
+
+		const options = createAdvancedProcessOptions(els, state);
+
+		expect(options.convertPixelsW).toBe(24);
+		expect(options.convertPixelsH).toBeUndefined();
+	});
+
+	it("uses a five-level Convert size without explicit dimensions", () => {
+		const state = createProcessingState();
+		const els = advancedElements("auto", true, true);
+		els.advancedConvertSizeModeSelect.value = "small";
+
+		const options = createAdvancedProcessOptions(els, state);
+
+		expect(options.detailLevel).toBe("small");
+		expect(options.convertPixelsW).toBeUndefined();
+		expect(options.convertPixelsH).toBeUndefined();
+	});
+
+	it("does not apply a partially entered two-dimension size", () => {
+		const state = createProcessingState();
+		const els = advancedElements("auto", true, true);
+		els.advancedConvertHeightInput.value = "";
+
+		const options = createAdvancedProcessOptions(els, state);
+
+		expect(options.convertPixelsW).toBeUndefined();
+		expect(options.convertPixelsH).toBeUndefined();
 	});
 });

--- a/src/browser/settings-options.ts
+++ b/src/browser/settings-options.ts
@@ -35,6 +35,16 @@ export const createAdvancedProcessOptions = (
 		PROCESS_RANGES.forcePixelsH,
 	);
 	const usePixels = pixelsW !== undefined && pixelsH !== undefined;
+	const convertPixelsW = parseOptionalInt(
+		els.advancedConvertWidthInput,
+		PROCESS_RANGES.convertPixelsW,
+	);
+	const convertPixelsH = parseOptionalInt(
+		els.advancedConvertHeightInput,
+		PROCESS_RANGES.convertPixelsH,
+	);
+	const useConvertPixels =
+		convertPixelsW !== undefined && convertPixelsH !== undefined;
 	type GridDetectionMode = "auto" | "hint" | "force" | "off";
 	const gridMode = els.gridDetectionModeSelect.value as GridDetectionMode;
 	const method = els.bgExtractionMethod
@@ -50,8 +60,8 @@ export const createAdvancedProcessOptions = (
 		debug: BROWSER_RUNTIME_CONFIG.debug,
 		processingMode: els.advancedProcessingModeSelect
 			.value as ProcessOptions["processingMode"],
-		detailLevel: els.advancedDetailLevelSelect
-			.value as ProcessOptions["detailLevel"],
+		convertPixelsW: useConvertPixels ? convertPixelsW : undefined,
+		convertPixelsH: useConvertPixels ? convertPixelsH : undefined,
 		detectionQuantStep: clampInt(
 			Number(els.quantStepInput.value),
 			PROCESS_RANGES.detectionQuantStep,

--- a/src/browser/settings-options.ts
+++ b/src/browser/settings-options.ts
@@ -1,7 +1,8 @@
 import type { ProcessOptions } from "../core/processor";
 import { createDefaultProcessOptions } from "../core/processor-options";
-import { clampInt, PROCESS_RANGES } from "../shared/config";
+import { clampInt, PROCESS_DEFAULTS, PROCESS_RANGES } from "../shared/config";
 import type { DitherMode, OutlineStyle } from "../shared/types";
+import { isConvertDetailLevel } from "./advanced-processing-controls";
 import type { Elements } from "./app-elements";
 import type { ProcessingState } from "./app-state";
 import {
@@ -43,8 +44,15 @@ export const createAdvancedProcessOptions = (
 		els.advancedConvertHeightInput,
 		PROCESS_RANGES.convertPixelsH,
 	);
-	const useConvertPixels =
+	const convertSizeMode = els.advancedConvertSizeModeSelect.value;
+	const hasBothConvertDimensions =
 		convertPixelsW !== undefined && convertPixelsH !== undefined;
+	const useConvertWidth =
+		(convertSizeMode === "custom-width" && convertPixelsW !== undefined) ||
+		(convertSizeMode === "custom-both" && hasBothConvertDimensions);
+	const useConvertHeight =
+		(convertSizeMode === "custom-height" && convertPixelsH !== undefined) ||
+		(convertSizeMode === "custom-both" && hasBothConvertDimensions);
 	type GridDetectionMode = "auto" | "hint" | "force" | "off";
 	const gridMode = els.gridDetectionModeSelect.value as GridDetectionMode;
 	const method = els.bgExtractionMethod
@@ -60,8 +68,11 @@ export const createAdvancedProcessOptions = (
 		debug: BROWSER_RUNTIME_CONFIG.debug,
 		processingMode: els.advancedProcessingModeSelect
 			.value as ProcessOptions["processingMode"],
-		convertPixelsW: useConvertPixels ? convertPixelsW : undefined,
-		convertPixelsH: useConvertPixels ? convertPixelsH : undefined,
+		detailLevel: isConvertDetailLevel(convertSizeMode)
+			? convertSizeMode
+			: PROCESS_DEFAULTS.detailLevel,
+		convertPixelsW: useConvertWidth ? convertPixelsW : undefined,
+		convertPixelsH: useConvertHeight ? convertPixelsH : undefined,
 		detectionQuantStep: clampInt(
 			Number(els.quantStepInput.value),
 			PROCESS_RANGES.detectionQuantStep,

--- a/src/browser/style.css
+++ b/src/browser/style.css
@@ -390,12 +390,35 @@ main {
   gap: 8px;
 }
 
+.setting-item[hidden] {
+  display: none;
+}
+
 .setting-item.disabled {
   display: none;
 }
 
 .setting-item.full-width {
   grid-column: 1 / -1;
+}
+
+.setting-item.is-disabled-visible {
+  opacity: 0.62;
+}
+
+.processing-mode-notice {
+  align-self: end;
+  margin: 0;
+  padding: 10px 12px;
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-panel));
+  color: var(--text-muted);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.processing-mode-notice[hidden] {
+  display: none;
 }
 
 .input-with-slider,

--- a/src/core/candidate-previews.test.ts
+++ b/src/core/candidate-previews.test.ts
@@ -9,8 +9,8 @@ import { resizeRawImageNearest } from "./image-operations";
 import { processImage } from "./processor";
 import {
 	expectSameImageExcept,
-	readPngAsRawImage,
 	RESIZE_WITH_TRIMMING_AUTO_EDGE_PIXELS,
+	readPngAsRawImage,
 } from "./processor-test-helpers";
 
 const analysis = (
@@ -246,11 +246,21 @@ describe("candidate previews", () => {
 		const selection = selectCandidatePlans(value)[0];
 		expect(selection.processingMode).toBe("auto");
 		expect(
-			candidateProcessOptions({ hintPixelsW: 10, hintPixelsH: 12 }, selection),
+			candidateProcessOptions(
+				{
+					hintPixelsW: 10,
+					hintPixelsH: 12,
+					convertPixelsW: 24,
+					convertPixelsH: 20,
+				},
+				selection,
+			),
 		).toMatchObject({
 			processingMode: "auto",
 			hintPixelsW: 10,
 			hintPixelsH: 12,
+			convertPixelsW: 24,
+			convertPixelsH: 20,
 			forcePixelsW: undefined,
 			forcePixelsH: undefined,
 		});

--- a/src/core/candidate-previews.ts
+++ b/src/core/candidate-previews.ts
@@ -150,6 +150,8 @@ export const candidateProcessOptions = (
 		forcePixelsH: undefined,
 		hintPixelsW: undefined,
 		hintPixelsH: undefined,
+		convertPixelsW: undefined,
+		convertPixelsH: undefined,
 	};
 	// [Intended] Auto 実結果の再現は初回と同じ入力で Auto を再実行することが前提なので、
 	// グリッド検出の検索開始点となるヒントは消さない。消すと検出結果が変わり、
@@ -157,6 +159,8 @@ export const candidateProcessOptions = (
 	if (selection.processingMode === "auto") {
 		options.hintPixelsW = base.hintPixelsW;
 		options.hintPixelsH = base.hintPixelsH;
+		options.convertPixelsW = base.convertPixelsW;
+		options.convertPixelsH = base.convertPixelsH;
 		return options;
 	}
 	if (selection.processingMode === "refine") {
@@ -165,6 +169,8 @@ export const candidateProcessOptions = (
 	}
 	if (selection.processingMode === "convert") {
 		options.detailLevel = selection.detailLevel;
+		options.convertPixelsW = selection.outW;
+		options.convertPixelsH = selection.outH;
 	}
 	return options;
 };

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -145,15 +145,48 @@ export const processConvertRoute = (
 	}
 
 	const candidates = createConvertCandidates(source);
-	const selected = selectConvertCandidate(candidates, o.detailLevel);
-	const selectedCandidateIndex = candidates.indexOf(selected);
-	const reports = candidateReports(
+	const hasExplicitSize =
+		o.convertPixelsW !== undefined && o.convertPixelsH !== undefined;
+	const selected = hasExplicitSize
+		? {
+				label: o.detailLevel,
+				outW: o.convertPixelsW as number,
+				outH: o.convertPixelsH as number,
+			}
+		: selectConvertCandidate(candidates, o.detailLevel);
+	let selectedCandidateIndex = candidates.indexOf(selected);
+	let reports = candidateReports(
 		source,
 		candidates,
 		o.detailLevel,
 		sourceX,
 		sourceY,
 	);
+	if (hasExplicitSize) {
+		const explicitGrid = gridForCandidate(
+			source,
+			selected,
+			o.detailLevel,
+			sourceX,
+			sourceY,
+		);
+		reports = [
+			{
+				grid: explicitGrid,
+				outW: selected.outW,
+				outH: selected.outH,
+				cropX: sourceX,
+				cropY: sourceY,
+				cropW: source.width,
+				cropH: source.height,
+				method: "convert-explicit-size",
+				totalScore: 1,
+				confidence: 1,
+			},
+			...reports,
+		];
+		selectedCandidateIndex = 0;
+	}
 	let grid = gridForCandidate(
 		source,
 		selected,
@@ -361,7 +394,7 @@ export const processConvertRoute = (
 		compareBeforeSanitized,
 		grid,
 		"convert",
-		`convert-${selected.label}`,
+		hasExplicitSize ? "convert-explicit-size" : `convert-${selected.label}`,
 		trimAlphaThreshold,
 		reports,
 		backgroundDiagnostic,

--- a/src/core/processor-convert-route.ts
+++ b/src/core/processor-convert-route.ts
@@ -1,3 +1,4 @@
+import { clampInt, PROCESS_RANGES } from "../shared/config";
 import type {
 	ConvertCandidate,
 	DetailLevel,
@@ -82,6 +83,29 @@ const candidateReports = (
 		};
 	});
 
+/** Convert の片軸指定は、実際にリサンプリングする領域の縦横比で補完する。 */
+const explicitConvertCandidate = (
+	image: RawImage,
+	detailLevel: DetailLevel,
+	width: number | undefined,
+	height: number | undefined,
+): ConvertCandidate | undefined => {
+	if (width === undefined && height === undefined) return undefined;
+	const outW =
+		width ??
+		clampInt(
+			Math.round(((height as number) * image.width) / image.height),
+			PROCESS_RANGES.convertPixelsW,
+		);
+	const outH =
+		height ??
+		clampInt(
+			Math.round((outW * image.height) / image.width),
+			PROCESS_RANGES.convertPixelsH,
+		);
+	return { label: detailLevel, outW, outH };
+};
+
 export const processConvertRoute = (
 	context: SimpleRouteContext,
 ): ProcessResult => {
@@ -145,14 +169,15 @@ export const processConvertRoute = (
 	}
 
 	const candidates = createConvertCandidates(source);
-	const hasExplicitSize =
-		o.convertPixelsW !== undefined && o.convertPixelsH !== undefined;
-	const selected = hasExplicitSize
-		? {
-				label: o.detailLevel,
-				outW: o.convertPixelsW as number,
-				outH: o.convertPixelsH as number,
-			}
+	const explicitCandidate = explicitConvertCandidate(
+		source,
+		o.detailLevel,
+		o.convertPixelsW,
+		o.convertPixelsH,
+	);
+	const hasExplicitSize = explicitCandidate !== undefined;
+	const selected = explicitCandidate
+		? explicitCandidate
 		: selectConvertCandidate(candidates, o.detailLevel);
 	let selectedCandidateIndex = candidates.indexOf(selected);
 	let reports = candidateReports(

--- a/src/core/processor-options.test.ts
+++ b/src/core/processor-options.test.ts
@@ -79,6 +79,18 @@ describe("default process options", () => {
 			debug: PROCESS_DEFAULTS.debug,
 		});
 	});
+
+	it("normalizes explicit Convert dimensions independently of forced dimensions", () => {
+		const options = normalizeProcessOptions({
+			convertPixelsW: 2048,
+			convertPixelsH: 0,
+		});
+
+		expect(options.convertPixelsW).toBe(PROCESS_RANGES.convertPixelsW.max);
+		expect(options.convertPixelsH).toBe(PROCESS_RANGES.convertPixelsH.min);
+		expect(options.forcePixelsW).toBeUndefined();
+		expect(options.forcePixelsH).toBeUndefined();
+	});
 });
 
 describe("small-component options", () => {

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -30,9 +30,9 @@ export type ProcessOptions = DetectOptions & {
 	processingMode?: ProcessingMode;
 	/** Convert 経路で採用する論理解像度。 */
 	detailLevel?: DetailLevel;
-	/** Convert 経路で使う明示的な出力幅。detailLevel より優先する。 */
+	/** Convert 経路で使う明示的な出力幅。片軸だけなら比率から高さを補完する。 */
 	convertPixelsW?: number;
-	/** Convert 経路で使う明示的な出力高さ。detailLevel より優先する。 */
+	/** Convert 経路で使う明示的な出力高さ。片軸だけなら比率から幅を補完する。 */
 	convertPixelsH?: number;
 	/** グリッド候補の各信号を個別に有効／無効にする。 */
 	gridSignals?: Partial<GridSignalOptions>;

--- a/src/core/processor-options.ts
+++ b/src/core/processor-options.ts
@@ -30,6 +30,10 @@ export type ProcessOptions = DetectOptions & {
 	processingMode?: ProcessingMode;
 	/** Convert 経路で採用する論理解像度。 */
 	detailLevel?: DetailLevel;
+	/** Convert 経路で使う明示的な出力幅。detailLevel より優先する。 */
+	convertPixelsW?: number;
+	/** Convert 経路で使う明示的な出力高さ。detailLevel より優先する。 */
+	convertPixelsH?: number;
 	/** グリッド候補の各信号を個別に有効／無効にする。 */
 	gridSignals?: Partial<GridSignalOptions>;
 	/** 縁のにじみ（ハロー）を背景色から遠ざける補正を行う。 */
@@ -265,6 +269,8 @@ export const normalizeProcessOptions = (
 	detect: DetectOptions;
 	processingMode: ProcessingMode;
 	detailLevel: DetailLevel;
+	convertPixelsW?: number;
+	convertPixelsH?: number;
 	convertReduceColors: boolean;
 	convertReduceColorMode: string;
 	convertDitherMode: DitherMode;
@@ -350,6 +356,14 @@ export const normalizeProcessOptions = (
 		raw.preRemoveBackground ?? PROCESS_DEFAULTS.preRemoveBackground;
 	const processingMode = raw.processingMode ?? PROCESS_DEFAULTS.processingMode;
 	const detailLevel = raw.detailLevel ?? PROCESS_DEFAULTS.detailLevel;
+	const convertPixelsW = clampOptionalInt(
+		raw.convertPixelsW,
+		PROCESS_RANGES.convertPixelsW,
+	);
+	const convertPixelsH = clampOptionalInt(
+		raw.convertPixelsH,
+		PROCESS_RANGES.convertPixelsH,
+	);
 	const postRemoveBackground =
 		raw.postRemoveBackground ?? PROCESS_DEFAULTS.postRemoveBackground;
 	const forcePixelsW = clampOptionalInt(
@@ -466,6 +480,8 @@ export const normalizeProcessOptions = (
 		detect,
 		processingMode,
 		detailLevel,
+		convertPixelsW,
+		convertPixelsH,
 		convertReduceColors: raw.reduceColors ?? CONVERT_DEFAULTS.reduceColors,
 		convertReduceColorMode:
 			raw.reduceColorMode ?? CONVERT_DEFAULTS.reduceColorMode,

--- a/src/core/processor-routing.test.ts
+++ b/src/core/processor-routing.test.ts
@@ -211,6 +211,38 @@ describe("processing router", () => {
 		}
 	});
 
+	it("uses explicit Convert dimensions without entering the forced-grid route", () => {
+		const processed = processImage(createContinuousImage(), {
+			...safeOptions,
+			processingMode: "convert",
+			convertPixelsW: 19,
+			convertPixelsH: 11,
+		});
+
+		expect(processed.result.width).toBe(19);
+		expect(processed.result.height).toBe(11);
+		expect(processed.analysis.route).toBe("convert");
+		expect(processed.analysis.gridCandidates[0]).toMatchObject({
+			outW: 19,
+			outH: 11,
+			method: "convert-explicit-size",
+		});
+	});
+
+	it("keeps the forced-grid dimensions ahead of Processing and Convert dimensions", () => {
+		const processed = processImage(createContinuousImage(), {
+			...safeOptions,
+			processingMode: "convert",
+			convertPixelsW: 19,
+			convertPixelsH: 11,
+			forcePixelsW: 8,
+			forcePixelsH: 6,
+		});
+
+		expect(processed.result.width).toBe(8);
+		expect(processed.result.height).toBe(6);
+	});
+
 	it.each([
 		["transparent", 0],
 		["single-color", 255],

--- a/src/core/processor-routing.test.ts
+++ b/src/core/processor-routing.test.ts
@@ -21,9 +21,7 @@ const createNativePixelArt = (width = 8, height = 8): RawImage => {
 	return { width, height, data };
 };
 
-const createContinuousImage = (): RawImage => {
-	const width = 32;
-	const height = 32;
+const createContinuousImage = (width = 32, height = 32): RawImage => {
 	const data = new Uint8ClampedArray(width * height * 4);
 	for (let y = 0; y < height; y += 1) {
 		for (let x = 0; x < width; x += 1) {
@@ -228,6 +226,23 @@ describe("processing router", () => {
 			method: "convert-explicit-size",
 		});
 	});
+
+	it.each([
+		["width", { convertPixelsW: 20 }, 20, 10],
+		["height", { convertPixelsH: 12 }, 24, 12],
+	] as const)(
+		"derives the Convert %s counterpart from the processed aspect ratio",
+		(_, dimensions, expectedWidth, expectedHeight) => {
+			const processed = processImage(createContinuousImage(40, 20), {
+				...safeOptions,
+				processingMode: "convert",
+				...dimensions,
+			});
+
+			expect(processed.result.width).toBe(expectedWidth);
+			expect(processed.result.height).toBe(expectedHeight);
+		},
+	);
 
 	it("keeps the forced-grid dimensions ahead of Processing and Convert dimensions", () => {
 		const processed = processImage(createContinuousImage(), {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -6,6 +6,8 @@ export type IntRange = {
 	default: number;
 };
 
+const OUTPUT_DIMENSION_RANGE = { min: 1, max: 1024, default: 0 } as const;
+
 export const PROCESS_RANGES = {
 	// 検出器: ポスタライズの段階数
 	detectionQuantStep: { min: 1, max: 128, default: 64 } as const,
@@ -24,8 +26,11 @@ export const PROCESS_RANGES = {
 	// 小さな孤立領域（連結成分）を背景として除去する
 	floatingMaxPixels: { min: 0, max: 1000000, default: 0 } as const,
 	// 出力ピクセルサイズを強制する（境界ボックスのトリミング後）
-	forcePixelsW: { min: 1, max: 1024, default: 0 } as const,
-	forcePixelsH: { min: 1, max: 1024, default: 0 } as const,
+	forcePixelsW: OUTPUT_DIMENSION_RANGE,
+	forcePixelsH: OUTPUT_DIMENSION_RANGE,
+	// Convert 経路のエッジ考慮リサンプリングで使う明示的な出力寸法
+	convertPixelsW: OUTPUT_DIMENSION_RANGE,
+	convertPixelsH: OUTPUT_DIMENSION_RANGE,
 	// 減色
 	colorCount: { min: 2, max: 256, default: 32 } as const,
 	// ディザリング


### PR DESCRIPTION
## 概要

詳細設定で Convert の出力サイズと完全ピクセル指定との優先関係を分かりやすく設定できるようにします。

## 変更内容

### UI/UX

- 詳細設定の処理方法「Auto」を「自動選択」へ改め、自動判定を行う選択肢であることを明確にします。
- Convert の出力サイズを5段階または幅・高さ・両方の数値で指定でき、Convert が選択された場合だけ表示します。
- 完全ピクセル指定中は処理方法を無効化し、完全ピクセル指定が優先されることを隣接メッセージで案内します。

### ロジック

- Convert の数値指定を完全ピクセル指定とは別に処理し、片方の寸法だけなら実処理領域の縦横比でもう一方を決定します。

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
