### PR TITLE
fix: 最新の自動変換要求で処理を置き換える

### DIFF
--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -241,7 +241,7 @@ export const initApp = (): void => {
 		}
 	};
 
-	const runProcessing = createRunProcessing({
+	const processingController = createRunProcessing({
 		els,
 		processingState,
 		imageSession,
@@ -253,6 +253,7 @@ export const initApp = (): void => {
 		updateBgColorFromMethod: () => updateBgColorFromMethod(),
 		candidateChooser,
 	});
+	const { runProcessing } = processingController;
 	const processPendingImages = createProcessPendingImages({
 		els,
 		processingState,
@@ -274,6 +275,7 @@ export const initApp = (): void => {
 		processingState,
 		imageSession,
 		runProcessing,
+		onAutoProcessScheduledChange: processingController.setAutoProcessScheduled,
 		saveSettings,
 		onLanguageChange: () =>
 			updateProcessingAnalysis(imageSession.getActiveImage()),

--- a/src/browser/app.ts
+++ b/src/browser/app.ts
@@ -24,7 +24,7 @@ import { showError } from "./notifications";
 import { createProcessPendingImages } from "./pending-processing";
 import { setupPresetControls } from "./preset-controls";
 import { formatProcessingAnalysis } from "./processing-analysis-display";
-import { createRunProcessing } from "./processing-controller";
+import { createProcessingController } from "./processing-controller";
 import { translateProcessingWarnings } from "./processing-warnings";
 import { updateQuickSettingsDisabledStates } from "./quick-settings-controls";
 import { setupResultActions } from "./result-actions";
@@ -241,7 +241,7 @@ export const initApp = (): void => {
 		}
 	};
 
-	const processingController = createRunProcessing({
+	const processingController = createProcessingController({
 		els,
 		processingState,
 		imageSession,

--- a/src/browser/batch-controller.ts
+++ b/src/browser/batch-controller.ts
@@ -16,7 +16,7 @@ import { i18n } from "./i18n";
 import { drawRawImageToCanvas } from "./io";
 import { createLoadingOverlay } from "./loading-overlay";
 import { showError, showWarning } from "./notifications";
-import { processor } from "./processing-controller";
+import { processor } from "./processor-worker";
 import type { ImageSession } from "./session";
 import { createProcessOptions } from "./settings-options";
 

--- a/src/browser/batch-controller.ts
+++ b/src/browser/batch-controller.ts
@@ -91,8 +91,10 @@ export const setupBatchController = ({
 		loadingOverlay.showProgress(0, images.length);
 
 		try {
+			const processingTokens = new Map<string, number>();
 			for (let index = 0; index < images.length; index += 1) {
-				imageSession.setImageStatus(images[index].id, "processing");
+				const id = images[index].id;
+				processingTokens.set(id, imageSession.beginProcessing(id));
 			}
 			const colorCount = clampInt(
 				Number(els.batchColorCountInput.value),
@@ -120,6 +122,14 @@ export const setupBatchController = ({
 
 			for (let index = 0; index < batchResult.items.length; index += 1) {
 				const item = batchResult.items[index];
+				// [Intended] 一括変換の待機中に同じ画像を個別処理していたら、古い結果で上書きしない。
+				const token = processingTokens.get(item.id);
+				if (
+					token === undefined ||
+					!imageSession.isProcessingCurrent(item.id, token)
+				) {
+					continue;
+				}
 				if (item.status === "done") {
 					imageSession.updateImageResult(
 						item.id,

--- a/src/browser/latest-processing-state.test.ts
+++ b/src/browser/latest-processing-state.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { createLatestProcessingState } from "./latest-processing-state";
+
+describe("latest processing state", () => {
+	it("only lets the latest processing run hide the loading display", () => {
+		const state = createLatestProcessingState();
+		const first = state.begin();
+		const second = state.begin();
+
+		expect(state.finish(first, false)).toBe("stale");
+		expect(state.finish(second, false)).toBe("hide-loading");
+	});
+
+	it("keeps loading while an auto-process request is scheduled", () => {
+		const state = createLatestProcessingState();
+		const generation = state.begin();
+		state.setAutoProcessScheduled(true);
+
+		expect(state.finish(generation, false)).toBe("keep-loading");
+		expect(state.setAutoProcessScheduled(false)).toBe(true);
+	});
+
+	it("leaves an externally managed loading display open", () => {
+		const state = createLatestProcessingState();
+		const generation = state.begin();
+
+		expect(state.finish(generation, true)).toBe("keep-loading");
+		expect(state.setAutoProcessScheduled(false)).toBe(false);
+	});
+});

--- a/src/browser/latest-processing-state.test.ts
+++ b/src/browser/latest-processing-state.test.ts
@@ -11,6 +11,29 @@ describe("latest processing state", () => {
 		expect(state.finish(second, false)).toBe("hide-loading");
 	});
 
+	it("treats only the newest generation as the latest one", () => {
+		const state = createLatestProcessingState();
+		const first = state.begin();
+
+		expect(state.isLatest(first)).toBe(true);
+
+		const second = state.begin();
+
+		expect(state.isLatest(first)).toBe(false);
+		expect(state.isLatest(second)).toBe(true);
+	});
+
+	it("leaves the running generation untouched when a stale run finishes", () => {
+		const state = createLatestProcessingState();
+		const first = state.begin();
+		const second = state.begin();
+
+		expect(state.finish(first, true)).toBe("stale");
+		// 古い処理の完了は、実行中の判定にも外部管理の保持にも影響しない。
+		expect(state.setAutoProcessScheduled(false)).toBe(false);
+		expect(state.finish(second, false)).toBe("hide-loading");
+	});
+
 	it("keeps loading while an auto-process request is scheduled", () => {
 		const state = createLatestProcessingState();
 		const generation = state.begin();

--- a/src/browser/latest-processing-state.ts
+++ b/src/browser/latest-processing-state.ts
@@ -1,0 +1,42 @@
+export type ProcessingFinishDecision =
+	| "stale"
+	| "keep-loading"
+	| "hide-loading";
+
+/**
+ * 最新の変換と、自動変換のデバウンス待機をまとめて管理する。
+ * DOM や Worker には依存せず、表示を閉じてよいタイミングだけを判定する。
+ */
+export const createLatestProcessingState = () => {
+	let latestGeneration = 0;
+	let activeGeneration: number | undefined;
+	let autoProcessScheduled = false;
+	let loadingHeldExternally = false;
+
+	return {
+		begin: (): number => {
+			latestGeneration += 1;
+			activeGeneration = latestGeneration;
+			loadingHeldExternally = false;
+			return latestGeneration;
+		},
+		isLatest: (generation: number): boolean => generation === latestGeneration,
+		finish: (
+			generation: number,
+			keepLoadingOverlay: boolean,
+		): ProcessingFinishDecision => {
+			if (generation !== latestGeneration) return "stale";
+			activeGeneration = undefined;
+			loadingHeldExternally = keepLoadingOverlay;
+			return keepLoadingOverlay || autoProcessScheduled
+				? "keep-loading"
+				: "hide-loading";
+		},
+		setAutoProcessScheduled: (scheduled: boolean): boolean => {
+			autoProcessScheduled = scheduled;
+			return (
+				!scheduled && activeGeneration === undefined && !loadingHeldExternally
+			);
+		},
+	};
+};

--- a/src/browser/pending-processing.ts
+++ b/src/browser/pending-processing.ts
@@ -6,7 +6,7 @@ import { createLoadingOverlay } from "./loading-overlay";
 import { showWarning } from "./notifications";
 import { createPendingImageQueue } from "./pending-queue";
 import type { RunProcessingOptions } from "./processing-controller";
-import { processor } from "./processing-controller";
+import { processor } from "./processor-worker";
 import type { ImageSession } from "./session";
 import { createProcessOptions } from "./settings-options";
 

--- a/src/browser/pending-processing.ts
+++ b/src/browser/pending-processing.ts
@@ -47,7 +47,7 @@ export const createProcessPendingImages = ({
 	const processInactiveImage = async (id: string) => {
 		const item = imageSession.getImages().find((image) => image.id === id);
 		if (!item) return;
-		imageSession.setImageStatus(id, "processing");
+		const processingToken = imageSession.beginProcessing(id);
 		showProgress();
 		try {
 			// [Intended] 候補プレビューで確定済みの方針は、一括変換でも画像ごとに引き継ぐ。
@@ -56,6 +56,8 @@ export const createProcessPendingImages = ({
 				item.candidateSelection,
 			);
 			const processResult = await processor.process(item.original, options);
+			// [Intended] 待機中にこの画像が個別処理などで変換し直されていたら、古い結果で上書きしない。
+			if (!imageSession.isProcessingCurrent(id, processingToken)) return;
 			imageSession.updateImageResult(
 				id,
 				processResult,
@@ -68,6 +70,7 @@ export const createProcessPendingImages = ({
 		} catch (error) {
 			// [Intended] 失敗した画像は一覧でエラーとして示し、残りの画像の変換は続ける。
 			// 通知は一巡の完了時にまとめる（トーストは重ねて表示できない）。
+			if (!imageSession.isProcessingCurrent(id, processingToken)) return;
 			const message = `${i18n.t("error.process_failed")}: ${(error as Error).message}`;
 			imageSession.setImageStatus(id, "error", message);
 		}

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -121,7 +121,7 @@ export const createRunProcessing = ({
 		if (selection) {
 			imageSession.setCandidateSelection(currentItem.id, selection);
 		}
-		imageSession.setImageStatus(currentItem.id, "processing");
+		const processingToken = imageSession.beginProcessing(currentItem.id);
 
 		// [Intended] 結果を書き込んだ後に中断された場合は、done の画像を pending へ戻さない。
 		// 戻すと一覧が未変換のまま表示され、保留キューが同じ設定で変換をやり直す。
@@ -145,8 +145,13 @@ export const createRunProcessing = ({
 					)
 				: await processor.process(currentImage, processOptions);
 			// [Intended] キャンセル直前に完了通知が届いた旧処理も、結果や画像状態を上書きさせない。
-			if (!latestProcessing.isLatest(generation)) {
-				if (currentItem.id !== latestImageId) {
+			// 一括処理など別経路がこの画像を処理し直していた場合は、状態もその経路に委ねる。
+			const superseded = !imageSession.isProcessingCurrent(
+				currentItem.id,
+				processingToken,
+			);
+			if (superseded || !latestProcessing.isLatest(generation)) {
+				if (!superseded && currentItem.id !== latestImageId) {
 					imageSession.setImageStatus(currentItem.id, "pending");
 				}
 				return;
@@ -298,7 +303,11 @@ export const createRunProcessing = ({
 				isProcessingCancelledError(err) ||
 				!latestProcessing.isLatest(generation)
 			) {
-				if (!resultApplied && currentItem.id !== latestImageId) {
+				if (
+					!resultApplied &&
+					currentItem.id !== latestImageId &&
+					imageSession.isProcessingCurrent(currentItem.id, processingToken)
+				) {
 					imageSession.setImageStatus(currentItem.id, "pending");
 				}
 				return;
@@ -307,7 +316,9 @@ export const createRunProcessing = ({
 			// [Intended] トーストは重ねて表示できないため、呼び出し側がまとめて通知する場合は出さない。
 			// 原因は画像一覧の状態として残るので、ここで失われるわけではない。
 			if (!options.suppressErrorNotification) showError(msg);
-			imageSession.setImageStatus(currentItem.id, "error", msg);
+			if (imageSession.isProcessingCurrent(currentItem.id, processingToken)) {
+				imageSession.setImageStatus(currentItem.id, "error", msg);
+			}
 		} finally {
 			const finishDecision = latestProcessing.finish(
 				generation,

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -1,6 +1,4 @@
-import { wrap } from "comlink";
 import { evaluateCandidateModalDecision } from "../core/candidate-modal-decision";
-import type { ProcessorWorker } from "../core/worker";
 import type { CandidateSelection } from "../shared/types";
 import { sortPalette } from "../utils/palette";
 import type { Elements } from "./app-elements";
@@ -9,19 +7,18 @@ import type { CandidateChooser } from "./candidate-chooser";
 import type { ImageComparer } from "./compare";
 import { i18n } from "./i18n";
 import { drawRawImageToCanvas } from "./io";
+import { createLatestProcessingState } from "./latest-processing-state";
 import { showError } from "./notifications";
 import { formatProcessingAnalysis } from "./processing-analysis-display";
 import { translateProcessingWarnings } from "./processing-warnings";
+import {
+	createCancellableProcessor,
+	isProcessingCancelledError,
+} from "./processor-worker";
 import { updateQuickSettingsDisabledStates } from "./quick-settings-controls";
 import type { ResultViewer } from "./result-viewer";
 import type { ImageSession } from "./session";
 import { createProcessOptions } from "./settings-options";
-
-const workerInstance = new Worker(
-	new URL("../core/worker.ts", import.meta.url),
-	{ type: "module" },
-);
-export const processor = wrap<ProcessorWorker>(workerInstance);
 
 type ProcessingControllerOptions = {
 	els: Elements;
@@ -50,6 +47,11 @@ export type RunProcessingOptions = {
 	suppressErrorNotification?: boolean;
 };
 
+export type ProcessingController = {
+	runProcessing: (options?: RunProcessingOptions) => Promise<void>;
+	setAutoProcessScheduled: (scheduled: boolean) => void;
+};
+
 export const createRunProcessing = ({
 	els,
 	processingState,
@@ -61,15 +63,21 @@ export const createRunProcessing = ({
 	updateGrid,
 	updateBgColorFromMethod,
 	candidateChooser,
-}: ProcessingControllerOptions): ((
-	options?: RunProcessingOptions,
-) => Promise<void>) => {
+}: ProcessingControllerOptions): ProcessingController => {
 	const compareBeforeCanvas = document.createElement("canvas");
 	const compareAfterCanvas = document.createElement("canvas");
 	const compareBeforeSanitizedCanvas = document.createElement("canvas");
-	// [Intended] 候補プレビューの生成は await を挟むため、完了時に自分が最新の処理か判定する。
-	// これがないと、遅れて返った旧画像・旧設定の候補が現在の状態のものとして表示される。
-	let latestGeneration = 0;
+	const processor = createCancellableProcessor();
+	const latestProcessing = createLatestProcessingState();
+	let latestImageId: string | undefined;
+
+	const hideLoading = () => {
+		mainResultViewer.setLoading(false);
+		els.loadingOverlay.style.display = "none";
+		els.outputPanel.classList.remove("is-processing");
+		els.outputPanel.removeAttribute("aria-busy");
+		els.processButton.disabled = false;
+	};
 
 	const runProcessing = async (
 		selection?: CandidateSelection,
@@ -78,7 +86,9 @@ export const createRunProcessing = ({
 		const showCandidates = options.showCandidates !== false;
 		const images = imageSession.getImages();
 		if (images.length === 0) return;
-		const generation = ++latestGeneration;
+		const generation = latestProcessing.begin();
+		// [Intended] 最新設定の結果を優先し、実行中の同期 Worker 処理と待機中の要求を破棄する。
+		processor.cancelActive();
 		if (!selection) candidateChooser.dismiss();
 
 		// [Intended] 設定変更前の警告を処理中の設定へ引き継がない。
@@ -97,13 +107,13 @@ export const createRunProcessing = ({
 		// （一括処理には別実装が必要だが、現在は切替時に自動処理する）
 		const currentItem = imageSession.getActiveImage();
 		if (!currentItem) {
-			// クリーンアップして完了
-			els.loadingOverlay.style.display = "none";
-			els.outputPanel.classList.remove("is-processing");
-			els.outputPanel.removeAttribute("aria-busy");
-			els.processButton.disabled = false;
+			latestImageId = undefined;
+			if (latestProcessing.finish(generation, false) === "hide-loading") {
+				hideLoading();
+			}
 			return;
 		}
+		latestImageId = currentItem.id;
 
 		const currentImage = currentItem.original;
 		// 明示的な選択がなければ、この画像に対して以前選ばれた候補を引き継ぐ。
@@ -130,6 +140,13 @@ export const createRunProcessing = ({
 						effectiveSelection,
 					)
 				: await processor.process(currentImage, processOptions);
+			// [Intended] キャンセル直前に完了通知が届いた旧処理も、結果や画像状態を上書きさせない。
+			if (!latestProcessing.isLatest(generation)) {
+				if (currentItem.id !== latestImageId) {
+					imageSession.setImageStatus(currentItem.id, "pending");
+				}
+				return;
+			}
 
 			// 転送したデータは呼び出し元スレッドで利用できなくなる可能性がある（Comlink の挙動に依存し、
 			// RawImage を再利用しない設計のため、ここで再代入する）
@@ -250,7 +267,7 @@ export const createRunProcessing = ({
 					);
 					// 待機中に別の処理が始まった、または表示対象が切り替わった場合は表示しない。
 					const stillCurrent =
-						generation === latestGeneration &&
+						latestProcessing.isLatest(generation) &&
 						imageSession.getActiveImage()?.id === currentItem.id;
 					const candidateModalAfterPreview = evaluateCandidateModalDecision({
 						...candidateModalInput,
@@ -262,6 +279,7 @@ export const createRunProcessing = ({
 						candidateChooser.show(previews, analysis.warnings, currentItem.id);
 					}
 				} catch (error) {
+					if (isProcessingCancelledError(error)) throw error;
 					// [Intended] 候補UIの失敗は、すでに得られた安全な処理結果を無効にしない。
 					console.error("Failed to create candidate previews:", error);
 				}
@@ -271,23 +289,31 @@ export const createRunProcessing = ({
 			// 背景除去方法がコーナーベースの場合は、抽出した色を UI に反映
 			updateBgColorFromMethod();
 		} catch (err) {
+			if (
+				isProcessingCancelledError(err) ||
+				!latestProcessing.isLatest(generation)
+			) {
+				if (currentItem.id !== latestImageId) {
+					imageSession.setImageStatus(currentItem.id, "pending");
+				}
+				return;
+			}
 			const msg = `${i18n.t("error.process_failed")}: ${(err as Error).message}`;
 			// [Intended] トーストは重ねて表示できないため、呼び出し側がまとめて通知する場合は出さない。
 			// 原因は画像一覧の状態として残るので、ここで失われるわけではない。
 			if (!options.suppressErrorNotification) showError(msg);
 			imageSession.setImageStatus(currentItem.id, "error", msg);
 		} finally {
-			// [Intended] 続けて別の画像を変換する呼び出し側は、オーバーレイの開閉を自分で行う。
-			// mainResultViewer の読み込み表示は els.loadingOverlay と同じ要素なので、
-			// ここで閉じると呼び出し側が開いたままにできない。
-			if (!options.keepLoadingOverlay) {
-				// [Intended] 途中で表示対象が切り替わった場合や失敗した場合も読み込み表示を残さない。
-				mainResultViewer.setLoading(false);
-				els.loadingOverlay.style.display = "none";
+			const finishDecision = latestProcessing.finish(
+				generation,
+				options.keepLoadingOverlay === true,
+			);
+			if (finishDecision === "hide-loading") hideLoading();
+			if (finishDecision === "keep-loading" && options.keepLoadingOverlay) {
+				els.outputPanel.classList.remove("is-processing");
+				els.outputPanel.removeAttribute("aria-busy");
+				els.processButton.disabled = false;
 			}
-			els.outputPanel.classList.remove("is-processing");
-			els.outputPanel.removeAttribute("aria-busy");
-			els.processButton.disabled = false;
 		}
 	};
 
@@ -298,5 +324,11 @@ export const createRunProcessing = ({
 			await runProcessing(selection);
 		},
 	});
-	return (options?: RunProcessingOptions) => runProcessing(undefined, options);
+	return {
+		runProcessing: (options?: RunProcessingOptions) =>
+			runProcessing(undefined, options),
+		setAutoProcessScheduled: (scheduled: boolean) => {
+			if (latestProcessing.setAutoProcessScheduled(scheduled)) hideLoading();
+		},
+	};
 };

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -123,6 +123,10 @@ export const createRunProcessing = ({
 		}
 		imageSession.setImageStatus(currentItem.id, "processing");
 
+		// [Intended] 結果を書き込んだ後に中断された場合は、done の画像を pending へ戻さない。
+		// 戻すと一覧が未変換のまま表示され、保留キューが同じ設定で変換をやり直す。
+		let resultApplied = false;
+
 		try {
 			const processOptions = createProcessOptions(els, processingState);
 
@@ -167,6 +171,7 @@ export const createRunProcessing = ({
 				},
 				processingState.settingsMode,
 			);
+			resultApplied = true;
 
 			// [Intended] 待機中に表示対象が切り替わっていたら、結果の保存だけで表示は更新しない。
 			// 複数画像をまとめて変換する際に、古い画像の結果が現在の表示を上書きしないようにする。
@@ -293,7 +298,7 @@ export const createRunProcessing = ({
 				isProcessingCancelledError(err) ||
 				!latestProcessing.isLatest(generation)
 			) {
-				if (currentItem.id !== latestImageId) {
+				if (!resultApplied && currentItem.id !== latestImageId) {
 					imageSession.setImageStatus(currentItem.id, "pending");
 				}
 				return;

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -325,10 +325,16 @@ export const createProcessingController = ({
 				options.keepLoadingOverlay === true,
 			);
 			if (finishDecision === "hide-loading") hideLoading();
-			if (finishDecision === "keep-loading" && options.keepLoadingOverlay) {
-				els.outputPanel.classList.remove("is-processing");
-				els.outputPanel.removeAttribute("aria-busy");
-				els.processButton.disabled = false;
+			if (finishDecision === "keep-loading") {
+				// [Intended] 結果の表示更新が同じオーバーレイを閉じるため、維持する場合は開き直す。
+				// 開き直さないと、次の変換が始まるまで処理中表示が一度消えて点滅する。
+				mainResultViewer.setLoading(true);
+				els.loadingOverlay.style.display = "flex";
+				if (options.keepLoadingOverlay) {
+					els.outputPanel.classList.remove("is-processing");
+					els.outputPanel.removeAttribute("aria-busy");
+					els.processButton.disabled = false;
+				}
 			}
 		}
 	};

--- a/src/browser/processing-controller.ts
+++ b/src/browser/processing-controller.ts
@@ -52,7 +52,7 @@ export type ProcessingController = {
 	setAutoProcessScheduled: (scheduled: boolean) => void;
 };
 
-export const createRunProcessing = ({
+export const createProcessingController = ({
 	els,
 	processingState,
 	imageSession,

--- a/src/browser/processor-worker.test.ts
+++ b/src/browser/processor-worker.test.ts
@@ -82,4 +82,19 @@ describe("cancellable processor", () => {
 
 		expect(createEndpoint).not.toHaveBeenCalled();
 	});
+
+	it("clears the cancellation entry when the worker call throws synchronously", async () => {
+		const failingEndpoint = endpoint(() => {
+			throw new Error("boom");
+		});
+		const createEndpoint = vi.fn(() => failingEndpoint);
+		const processor = createCancellableProcessor(createEndpoint);
+
+		await expect(processor.process(image as RawImage, options)).rejects.toThrow(
+			"boom",
+		);
+		processor.cancelActive();
+
+		expect(failingEndpoint.terminate).not.toHaveBeenCalled();
+	});
 });

--- a/src/browser/processor-worker.test.ts
+++ b/src/browser/processor-worker.test.ts
@@ -62,6 +62,25 @@ describe("cancellable processor", () => {
 		expect(createEndpoint).toHaveBeenCalledTimes(2);
 	});
 
+	it("ignores a late resolution from the terminated worker", async () => {
+		const firstResult = deferred<never>();
+		const firstEndpoint = endpoint(() => firstResult.promise);
+		const createEndpoint = vi.fn(() => firstEndpoint);
+		const processor = createCancellableProcessor(createEndpoint);
+
+		const first = processor.process(image as RawImage, options);
+		const cancelled = expect(first).rejects.toBeInstanceOf(
+			ProcessingCancelledError,
+		);
+		processor.cancelActive();
+		await cancelled;
+
+		// 終了させた Worker から遅れて応答が届いても、呼び出し側の結果は中断のままにする。
+		firstResult.resolve(undefined as never);
+
+		await expect(first).rejects.toBeInstanceOf(ProcessingCancelledError);
+	});
+
 	it("keeps an idle worker instead of recreating it", async () => {
 		const firstEndpoint = endpoint(vi.fn(async () => undefined as never));
 		const createEndpoint = vi.fn(() => firstEndpoint);

--- a/src/browser/processor-worker.test.ts
+++ b/src/browser/processor-worker.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProcessOptions } from "../core/processor";
+import type { RawImage } from "../shared/types";
+import {
+	createCancellableProcessor,
+	ProcessingCancelledError,
+	type ProcessorClient,
+	type ProcessorEndpoint,
+} from "./processor-worker";
+
+const image = { width: 1, height: 1, data: new Uint8ClampedArray(4) };
+const options = {} as ProcessOptions;
+
+const deferred = <Value>() => {
+	let resolve!: (value: Value) => void;
+	const promise = new Promise<Value>((complete) => {
+		resolve = complete;
+	});
+	return { promise, resolve };
+};
+
+const endpoint = (
+	process: ProcessorClient["process"],
+): ProcessorEndpoint & { terminate: ReturnType<typeof vi.fn> } => {
+	const terminate = vi.fn();
+	return {
+		terminate,
+		worker: { terminate },
+		processor: {
+			process,
+			processBatch: vi.fn(),
+			previewCandidates: vi.fn(),
+			processCandidate: vi.fn(),
+		},
+	};
+};
+
+describe("cancellable processor", () => {
+	it("terminates the running worker and uses a new worker for the latest request", async () => {
+		const firstResult = deferred<never>();
+		const secondResult = deferred<never>();
+		const firstEndpoint = endpoint(() => firstResult.promise);
+		const secondEndpoint = endpoint(() => secondResult.promise);
+		const createEndpoint = vi
+			.fn<() => ProcessorEndpoint>()
+			.mockReturnValueOnce(firstEndpoint)
+			.mockReturnValueOnce(secondEndpoint);
+		const processor = createCancellableProcessor(createEndpoint);
+
+		const first = processor.process(image as RawImage, options);
+		const cancelled = expect(first).rejects.toBeInstanceOf(
+			ProcessingCancelledError,
+		);
+		processor.cancelActive();
+
+		await cancelled;
+		expect(firstEndpoint.terminate).toHaveBeenCalledOnce();
+		expect(createEndpoint).toHaveBeenCalledTimes(2);
+
+		const second = processor.process(image as RawImage, options);
+		secondResult.resolve(undefined as never);
+		await expect(second).resolves.toBeUndefined();
+	});
+
+	it("keeps an idle worker instead of recreating it", () => {
+		const firstEndpoint = endpoint(vi.fn());
+		const createEndpoint = vi.fn(() => firstEndpoint);
+		const processor = createCancellableProcessor(createEndpoint);
+
+		processor.cancelActive();
+
+		expect(firstEndpoint.terminate).not.toHaveBeenCalled();
+		expect(createEndpoint).toHaveBeenCalledOnce();
+	});
+});

--- a/src/browser/processor-worker.test.ts
+++ b/src/browser/processor-worker.test.ts
@@ -55,21 +55,31 @@ describe("cancellable processor", () => {
 
 		await cancelled;
 		expect(firstEndpoint.terminate).toHaveBeenCalledOnce();
-		expect(createEndpoint).toHaveBeenCalledTimes(2);
 
 		const second = processor.process(image as RawImage, options);
 		secondResult.resolve(undefined as never);
 		await expect(second).resolves.toBeUndefined();
+		expect(createEndpoint).toHaveBeenCalledTimes(2);
 	});
 
-	it("keeps an idle worker instead of recreating it", () => {
-		const firstEndpoint = endpoint(vi.fn());
+	it("keeps an idle worker instead of recreating it", async () => {
+		const firstEndpoint = endpoint(vi.fn(async () => undefined as never));
 		const createEndpoint = vi.fn(() => firstEndpoint);
 		const processor = createCancellableProcessor(createEndpoint);
 
+		await processor.process(image as RawImage, options);
 		processor.cancelActive();
+		await processor.process(image as RawImage, options);
 
 		expect(firstEndpoint.terminate).not.toHaveBeenCalled();
 		expect(createEndpoint).toHaveBeenCalledOnce();
+	});
+
+	it("does not create a worker before the first request", () => {
+		const createEndpoint = vi.fn(() => endpoint(vi.fn()));
+
+		createCancellableProcessor(createEndpoint);
+
+		expect(createEndpoint).not.toHaveBeenCalled();
 	});
 });

--- a/src/browser/processor-worker.ts
+++ b/src/browser/processor-worker.ts
@@ -46,12 +46,15 @@ export const createProcessorEndpoint = (): ProcessorEndpoint => {
 export const createCancellableProcessor = (
 	createEndpoint: () => ProcessorEndpoint = createProcessorEndpoint,
 ): ProcessorClient & { cancelActive: () => void } => {
-	let endpoint = createEndpoint();
+	// [Intended] Worker は最初の要求まで作らない。中断のたびに作り直すと、
+	// 次の要求が来ない場合に使われない Worker を起こすことになる。
+	let endpoint: ProcessorEndpoint | undefined;
 	const pendingCancellations = new Set<(error: Error) => void>();
 
 	const invoke = <Result>(
 		operation: (processor: ProcessorClient) => Promise<Result>,
 	): Promise<Result> => {
+		endpoint ??= createEndpoint();
 		const activeProcessor = endpoint.processor;
 		return new Promise<Result>((resolve, reject) => {
 			let settled = false;
@@ -95,8 +98,8 @@ export const createCancellableProcessor = (
 			if (pendingCancellations.size === 0) return;
 			const cancellations = [...pendingCancellations];
 			// [Intended] 同期的な画像処理は Worker 内から中断できないため、Worker 自体を終了して CPU 処理を止める。
-			endpoint.worker.terminate();
-			endpoint = createEndpoint();
+			endpoint?.worker.terminate();
+			endpoint = undefined;
 			const error = new ProcessingCancelledError();
 			for (let index = 0; index < cancellations.length; index += 1) {
 				cancellations[index](error);

--- a/src/browser/processor-worker.ts
+++ b/src/browser/processor-worker.ts
@@ -58,31 +58,30 @@ export const createCancellableProcessor = (
 		const activeProcessor = endpoint.processor;
 		return new Promise<Result>((resolve, reject) => {
 			let settled = false;
-			const settle = (
-				callback: (value: Result | PromiseLike<Result>) => void,
-				value: Result | PromiseLike<Result>,
-			) => {
-				if (settled) return;
+			// 決着済みなら false を返す。中断の登録を必ず 1 箇所で取り消すためにまとめる。
+			const finalize = (): boolean => {
+				if (settled) return false;
 				settled = true;
 				pendingCancellations.delete(cancel);
-				callback(value);
+				return true;
 			};
 			const cancel = (error: Error) => {
-				if (settled) return;
-				settled = true;
-				pendingCancellations.delete(cancel);
-				reject(error);
+				if (finalize()) reject(error);
 			};
 			pendingCancellations.add(cancel);
-			void operation(activeProcessor).then(
-				(result) => settle(resolve, result),
-				(error: unknown) => {
-					if (settled) return;
-					settled = true;
-					pendingCancellations.delete(cancel);
-					reject(error);
-				},
-			);
+			// [Intended] operation が同期的に投げた例外も reject 経路へ流す。
+			// executor の例外として抜けると中断の登録が集合に残り、
+			// 実行中の処理がなくても cancelActive が Worker を終了し続けてしまう。
+			void Promise.resolve()
+				.then(() => operation(activeProcessor))
+				.then(
+					(result) => {
+						if (finalize()) resolve(result);
+					},
+					(error: unknown) => {
+						if (finalize()) reject(error);
+					},
+				);
 		});
 	};
 

--- a/src/browser/processor-worker.ts
+++ b/src/browser/processor-worker.ts
@@ -1,0 +1,122 @@
+import { wrap } from "comlink";
+import type { ProcessorWorker } from "../core/worker";
+
+export type ProcessorClient = {
+	process: (
+		...args: Parameters<ProcessorWorker["process"]>
+	) => Promise<ReturnType<ProcessorWorker["process"]>>;
+	processBatch: (
+		...args: Parameters<ProcessorWorker["processBatch"]>
+	) => Promise<ReturnType<ProcessorWorker["processBatch"]>>;
+	previewCandidates: (
+		...args: Parameters<ProcessorWorker["previewCandidates"]>
+	) => Promise<ReturnType<ProcessorWorker["previewCandidates"]>>;
+	processCandidate: (
+		...args: Parameters<ProcessorWorker["processCandidate"]>
+	) => Promise<ReturnType<ProcessorWorker["processCandidate"]>>;
+};
+
+export type ProcessorEndpoint = {
+	worker: Pick<Worker, "terminate">;
+	processor: ProcessorClient;
+};
+
+export class ProcessingCancelledError extends Error {
+	constructor() {
+		super("Processing was cancelled.");
+		this.name = "ProcessingCancelledError";
+	}
+}
+
+export const isProcessingCancelledError = (
+	error: unknown,
+): error is ProcessingCancelledError =>
+	error instanceof ProcessingCancelledError;
+
+export const createProcessorEndpoint = (): ProcessorEndpoint => {
+	const worker = new Worker(new URL("../core/worker.ts", import.meta.url), {
+		type: "module",
+	});
+	return {
+		worker,
+		processor: wrap<ProcessorWorker>(worker),
+	};
+};
+
+export const createCancellableProcessor = (
+	createEndpoint: () => ProcessorEndpoint = createProcessorEndpoint,
+): ProcessorClient & { cancelActive: () => void } => {
+	let endpoint = createEndpoint();
+	const pendingCancellations = new Set<(error: Error) => void>();
+
+	const invoke = <Result>(
+		operation: (processor: ProcessorClient) => Promise<Result>,
+	): Promise<Result> => {
+		const activeProcessor = endpoint.processor;
+		return new Promise<Result>((resolve, reject) => {
+			let settled = false;
+			const settle = (
+				callback: (value: Result | PromiseLike<Result>) => void,
+				value: Result | PromiseLike<Result>,
+			) => {
+				if (settled) return;
+				settled = true;
+				pendingCancellations.delete(cancel);
+				callback(value);
+			};
+			const cancel = (error: Error) => {
+				if (settled) return;
+				settled = true;
+				pendingCancellations.delete(cancel);
+				reject(error);
+			};
+			pendingCancellations.add(cancel);
+			void operation(activeProcessor).then(
+				(result) => settle(resolve, result),
+				(error: unknown) => {
+					if (settled) return;
+					settled = true;
+					pendingCancellations.delete(cancel);
+					reject(error);
+				},
+			);
+		});
+	};
+
+	return {
+		process: (...args) => invoke((processor) => processor.process(...args)),
+		processBatch: (...args) =>
+			invoke((processor) => processor.processBatch(...args)),
+		previewCandidates: (...args) =>
+			invoke((processor) => processor.previewCandidates(...args)),
+		processCandidate: (...args) =>
+			invoke((processor) => processor.processCandidate(...args)),
+		cancelActive: () => {
+			if (pendingCancellations.size === 0) return;
+			const cancellations = [...pendingCancellations];
+			// [Intended] 同期的な画像処理は Worker 内から中断できないため、Worker 自体を終了して CPU 処理を止める。
+			endpoint.worker.terminate();
+			endpoint = createEndpoint();
+			const error = new ProcessingCancelledError();
+			for (let index = 0; index < cancellations.length; index += 1) {
+				cancellations[index](error);
+			}
+		},
+	};
+};
+
+let sharedProcessor: ProcessorClient | undefined;
+
+const getSharedProcessor = (): ProcessorClient => {
+	sharedProcessor ??= createProcessorEndpoint().processor;
+	return sharedProcessor;
+};
+
+// 一括処理など、キャンセル対象ではない処理は従来どおり 1 つの Worker を共有する。
+export const processor: ProcessorClient = {
+	process: (...args) => getSharedProcessor().process(...args),
+	processBatch: (...args) => getSharedProcessor().processBatch(...args),
+	previewCandidates: (...args) =>
+		getSharedProcessor().previewCandidates(...args),
+	processCandidate: (...args) => getSharedProcessor().processCandidate(...args),
+};

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -36,6 +36,12 @@ export class ImageSession {
 	private activeImageId: string | null = null;
 	private onUpdate: () => void;
 	private onActiveChange: (image: ImageItem | null) => void;
+	/**
+	 * 画像ごとの変換開始の通し番号。
+	 * 個別処理と一括処理は別々の Worker で並行しうるため、開始が古い処理の結果で
+	 * 新しい結果を上書きしないよう、書き込み側がこの番号で自分の順番を確かめる。
+	 */
+	private processingTokens = new Map<string, number>();
 
 	constructor(callbacks: {
 		onUpdate: () => void;
@@ -71,6 +77,7 @@ export class ImageSession {
 
 		const wasActive = this.activeImageId === id;
 		this.images.splice(idx, 1);
+		this.processingTokens.delete(id);
 
 		if (wasActive) {
 			// 次に利用可能な画像を選択し、空なら null にする
@@ -88,7 +95,24 @@ export class ImageSession {
 
 	public clearAll(): void {
 		this.images = [];
+		this.processingTokens.clear();
 		this.setActiveImage(null);
+	}
+
+	/**
+	 * この画像の変換開始を記録し、結果を書き込んでよいかを判定するトークンを返す。
+	 * 状態を processing にする役割も兼ねる。
+	 */
+	public beginProcessing(id: string): number {
+		const token = (this.processingTokens.get(id) ?? 0) + 1;
+		this.processingTokens.set(id, token);
+		this.setImageStatus(id, "processing");
+		return token;
+	}
+
+	/** beginProcessing で得たトークンが、この画像の最新の変換のものかを返す。 */
+	public isProcessingCurrent(id: string, token: number): boolean {
+		return this.processingTokens.get(id) === token;
 	}
 
 	public setActiveImage(id: string | null): void {

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -336,8 +336,13 @@ export const setupSettingsControls = ({
 			autoProcessTimeout = undefined;
 			// [Intended] 設定調整のたびに候補モーダルが開くと、入力からフォーカスが奪われ調整を続けられない。
 			// 候補の提示は明示的な処理実行に限る。
-			runProcessing({ showCandidates: false });
-			onAutoProcessScheduledChange(false);
+			void runProcessing({ showCandidates: false }).finally(() => {
+				// [Intended] 予約の解除は変換の完了時に行う。呼び出し直後に解除すると、
+				// runProcessing が最初の await までに変換の開始を記録することへ暗黙に依存する。
+				// 待機中に次の予約が入っていた場合は、その予約の完了時の解除に任せる。
+				if (autoProcessTimeout === undefined)
+					onAutoProcessScheduledChange(false);
+			});
 		}, 300);
 	};
 

--- a/src/browser/settings-controls.ts
+++ b/src/browser/settings-controls.ts
@@ -26,6 +26,7 @@ type SettingsControlsOptions = {
 	processingState: ProcessingState;
 	imageSession: ImageSession;
 	runProcessing: (options?: RunProcessingOptions) => Promise<void>;
+	onAutoProcessScheduledChange: (scheduled: boolean) => void;
 	saveSettings: () => void;
 	onLanguageChange: () => void;
 };
@@ -47,6 +48,7 @@ export const setupSettingsControls = ({
 	processingState,
 	imageSession,
 	runProcessing,
+	onAutoProcessScheduledChange,
 	saveSettings,
 	onLanguageChange,
 }: SettingsControlsOptions): SettingsControls => {
@@ -328,11 +330,14 @@ export const setupSettingsControls = ({
 		if (autoProcessTimeout) {
 			window.clearTimeout(autoProcessTimeout);
 		}
+		onAutoProcessScheduledChange(true);
 
 		autoProcessTimeout = window.setTimeout(() => {
+			autoProcessTimeout = undefined;
 			// [Intended] 設定調整のたびに候補モーダルが開くと、入力からフォーカスが奪われ調整を続けられない。
 			// 候補の提示は明示的な処理実行に限る。
 			runProcessing({ showCandidates: false });
+			onAutoProcessScheduledChange(false);
 		}, 300);
 	};
 
@@ -594,6 +599,11 @@ export const setupSettingsControls = ({
 	// 自動処理トグルの変更時に処理ボタンの表示を切り替え
 	els.autoProcessToggle.addEventListener("change", () => {
 		updateProcessButtonVisibility();
+		if (!els.autoProcessToggle.checked && autoProcessTimeout) {
+			window.clearTimeout(autoProcessTimeout);
+			autoProcessTimeout = undefined;
+			onAutoProcessScheduledChange(false);
+		}
 	});
 
 	// 設定変更時に自動処理を開始するイベントリスナーを追加


### PR DESCRIPTION
## 概要

自動変換中の古い処理を打ち切り、最新設定の結果を優先して表示する。

## 変更内容

### UI/UX

- 自動変換の処理中表示を、デバウンス待機を含む最後の変換が完了するまで維持する。
- 結果の表示更新で処理中表示が閉じられる場合も、表示を維持するときは開き直して点滅させない。

### ロジック

- 自動変換中に新しい要求が確定した場合は実行中の変換を中止し、最新設定の変換へ置き換える。
- 自動変換をオフにした時点で、待機中の自動変換の要求を取り消す。
- 個別変換・保留変換・一括変換が同じ画像を並行して処理した場合に、開始が古い側の結果で新しい結果を上書きしない。
- 結果を書き込んだ後に中断された画像を、未変換の状態へ戻さない。
- 変換を中止した後の Worker は、次の要求が来るまで作り直さない。

### 開発体験

- 中断後の遅延応答と変換の世代判定について単体テストを追加する。
- 変換の実行と予約通知をまとめて返すファクトリを `createProcessingController` へ改名する。

### その他

- なし

## 動作確認

- なし
