### PR TITLE
refactor: 比較の「サニタイズ」を「縮小のみ」に言い換える

### DIFF
--- a/index.html
+++ b/index.html
@@ -2966,7 +2966,7 @@
               data-i18n="ui.compare_before_sanitized"
               type="button"
             >
-              Sanitized
+              Downscaled only
             </button>
           </div>
           <button

--- a/src/browser/i18n/messages/ui.ts
+++ b/src/browser/i18n/messages/ui.ts
@@ -127,9 +127,9 @@ export const uiMessages = defineMessages({
 		"zh-CN": "原图",
 	},
 	"ui.compare_before_sanitized": {
-		ja: "サニタイズ",
-		en: "Sanitized",
-		"zh-CN": "预处理",
+		ja: "縮小のみ",
+		en: "Downscaled only",
+		"zh-CN": "仅缩小",
 	},
 	"ui.compare_preparing": {
 		ja: "比較画像を準備中...",


### PR DESCRIPTION
## 概要

比較モーダルで処理前として表示している画像が何なのかを、文言から読み取れるようにする。

## 変更内容

### UI/UX

- 比較モーダルで処理前側を切り替えるボタンの文言を「サニタイズ」から「縮小のみ」に変え、出力の格子に合わせて縮小しただけの入力が出ることを日本語・英語・中国語で示すようにする。

### ロジック

- なし

### 開発体験

- なし

### その他

- 表示文言だけの変更で、切り替えで出る画像そのものは変えていない。
- コード側の `compareBeforeSanitized` や i18n キー `ui.compare_before_sanitized` は、比較用画像を組み立てる処理と対応が付くようそのままにした。

## 動作確認

- [x] 表示言語を英語にして比較モーダルを開き、スマートフォン程度の幅でもボタンの文言が折り返さないことを確認する。
