### PR TITLE
docs: 品質テストを回すべき変更の条件をAGENTS.mdに追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,5 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 ## Verification
 
 - Run `make ci` after changes.
-- `make ci` leaves out the image quality cases, so also run `make quality` after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, the presets or the Quick Settings mapping in `src/browser/quick-settings.ts`, or `test/quality/cases.json`. See [Commands](test/quality/README.md#commands) for the other quality commands.
+- `make ci` leaves out the image quality cases, so also run `make quality` after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, the presets or the Quick Settings mapping in `src/browser/quick-settings.ts`, `test/quality/cases.json`, or the case images under `test/fixtures/` and `public/guide/`. See [Commands](test/quality/README.md#commands) for the other quality commands.
 - コミットを求められた場合は、Conventional Commits 形式を使い、説明を日本語で記述する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,5 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 ## Verification
 
 - Run `make ci` after changes.
-- `make ci` leaves out the image quality cases, so also run `make quality` (about 30 seconds) after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, or `test/quality/cases.json`. See [Commands](test/quality/README.md#commands) for the other quality commands.
+- `make ci` leaves out the image quality cases, so also run `make quality` after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, the presets or the Quick Settings mapping in `src/browser/quick-settings.ts`, or `test/quality/cases.json`. See [Commands](test/quality/README.md#commands) for the other quality commands.
 - コミットを求められた場合は、Conventional Commits 形式を使い、説明を日本語で記述する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,4 +34,5 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 ## Verification
 
 - Run `make ci` after changes.
+- `make ci` leaves out the image quality cases, so also run `make quality` (about 30 seconds) after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, or `test/quality/cases.json`. See [Commands](test/quality/README.md#commands) for the other quality commands.
 - コミットを求められた場合は、Conventional Commits 形式を使い、説明を日本語で記述する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,5 +34,5 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 ## Verification
 
 - Run `make ci` after changes.
-- `make ci` leaves out the image quality cases, so also run `make quality` after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, the presets or the Quick Settings mapping in `src/browser/quick-settings.ts`, `test/quality/cases.json`, or the case images under `test/fixtures/` and `public/guide/`. See [Commands](test/quality/README.md#commands) for the other quality commands.
+- `make ci` leaves out the image quality cases, so also run `make quality` after changing processing in `src/core`, defaults or ranges in `src/shared/config.ts`, the presets or the Quick Settings mapping in `src/browser/quick-settings.ts`, the cases or the harness under `test/quality/`, or the case images under `test/fixtures/` and `public/guide/`. See [Commands](test/quality/README.md#commands) for the other quality commands.
 - コミットを求められた場合は、Conventional Commits 形式を使い、説明を日本語で記述する。

--- a/test/quality/README.md
+++ b/test/quality/README.md
@@ -10,6 +10,7 @@ APIs.
 ```sh
 pnpm test:quality          # lightweight smoke profile for local checks
 pnpm test:quality:full     # all cases used by the pull-request quality gate
+make quality               # same as pnpm test:quality:full
 make report                # only generate tmp/quality-report/latest
 pnpm test:quality:update   # intentionally replace the stored baseline
 ```


### PR DESCRIPTION
## 概要

画像処理に関わる変更をしたときに `make quality` まで回すべきだと、AGENTS.md だけで判断できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- AGENTS.md の Verification 節に、`src/core` の処理・`src/shared/config.ts` の既定値や範囲・`src/browser/quick-settings.ts` のプリセットやかんたん設定のマッピング・`test/quality/` 配下のケースやハーネス・`test/fixtures/` と `public/guide/` のケース画像を変更したときは `make quality` も実行すると明記し、`make ci` だけで完了と判断して画像品質の劣化を見逃す状況をなくす。
- 品質テストのその他のコマンドは `test/quality/README.md` の Commands 節を見るよう導線を張り、その一覧に `make quality` を併記して、AGENTS.md が指示するコマンド名をリンク先で見つけられるようにする。

### その他

- なし

## 動作確認

- なし

