### PR TITLE
docs: 作業ファイルの置き場所を tmp/<YYYYMMDD>/ に統一する規約を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 
 ## Work Files
 
-- 調査メモやログなど自分で作る作業ファイルは、作業日の `tmp/<YYYYMMDD>/` に置く。出力先が決まっているツールの成果物はその場所のままにする。
+- 調査メモやログなど自分で作る作業ファイルは、メインリポジトリのルート直下にある作業日の `tmp/<YYYYMMDD>/` に置く（worktree で作業しているときも worktree 側には置かない）。出力先が決まっているツールの成果物はその場所のままにする。
 - 過去の日付のディレクトリはその時点の記録なので、現状の根拠には使わず、コードや設定を読み直して確かめる。
 
 ## Verification

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 - `[Intended]` は意図的な挙動、`[Policy]` は運用上の制約、`[Workaround]` は一時的な外部要因への回避策を記録する。
 - タグ付きコードは、コメントの根拠を確認して無効になった場合を除き保持する。特殊な形のために誤ったリファクタリングを招きうる新規コードにはタグを付ける。
 
+## Work Files
+
+- 調査メモやログなど自分で作る作業ファイルは、作業日の `tmp/<YYYYMMDD>/` に置く。出力先が決まっているツールの成果物はその場所のままにする。
+- 過去の日付のディレクトリはその時点の記録なので、現状の根拠には使わず、コードや設定を読み直して確かめる。
+
 ## Verification
 
 - Run `make ci` after changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ When `guide.html` publishes a converted example, add one quality case for it so 
 ## Work Files
 
 - 調査メモやログなど自分で作る作業ファイルは、メインリポジトリのルート直下にある作業日の `tmp/<YYYYMMDD>/` に置く（worktree で作業しているときも worktree 側には置かない）。出力先が決まっているツールの成果物はその場所のままにする。
-- 過去の日付のディレクトリはその時点の記録なので、現状の根拠には使わず、コードや設定を読み直して確かめる。
+- 既にある作業ファイルはその時点の記録なので、現状の根拠には使わず、コードや設定を読み直して確かめる。
 
 ## Verification
 


### PR DESCRIPTION
## 概要

作業ファイルの置き場所を日付ごとのディレクトリに統一し、過去の作業結果を現状と取り違えないようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- AGENTS.md に作業ファイルの置き場所の規約を追加し、調査メモやログを作業日の `tmp/<YYYYMMDD>/` へ集約するようにした。
- 既にある作業ファイルを現状の根拠に使わず、コードや設定を読み直して確かめる方針を明記した。

### その他

- 既存の `tmp/` 直下に残っている作業結果の整理は、リポジトリの管理外のためこの PR には含まない。

## 動作確認

- なし

