### PR TITLE
test: 表示コントロールの重複マークアップの整合をテストで担保

### DIFF
--- a/index.html
+++ b/index.html
@@ -2419,6 +2419,8 @@
                     - 結果モーダル（#result-modal）
                     ResultViewer はこれらのクラスフック（例: .js-bg-selector/.js-zoom-output/.js-grid-output）に依存している。
                     ボタンや構造を編集する場合は、動作と i18n の整合性を保つため両方を更新する。
+                    ResultViewer が参照するフックが両方に揃っていることは
+                    src/browser/result-viewer.test.ts が検証する。
                   -->
                   <div class="bg-selector js-bg-selector" id="bg-selector">
                     <button
@@ -2784,6 +2786,8 @@
           <!-- 注:
             この表示コントロールのマークアップは、ResultViewer 用に出力パネル（#output-panel）から意図的に複製している。
             ボタンや構造を編集する場合は、両方を更新する。
+            ResultViewer が参照するフックが両方に揃っていることは
+            src/browser/result-viewer.test.ts が検証する。
           -->
           <div class="status-bar">
             <div class="status-text">

--- a/index.html
+++ b/index.html
@@ -2782,7 +2782,7 @@
             &times;
           </button>
         </div>
-        <div class="modal-body result-modal-body">
+        <div id="result-modal-body" class="modal-body result-modal-body">
           <!-- 注:
             この表示コントロールのマークアップは、ResultViewer 用に出力パネル（#output-panel）から意図的に複製している。
             ボタンや構造を編集する場合は、両方を更新する。

--- a/src/browser/result-viewer.test.ts
+++ b/src/browser/result-viewer.test.ts
@@ -1,5 +1,63 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { ResultViewer } from "./result-viewer";
+
+const HERE = resolve(fileURLToPath(import.meta.url), "..");
+const REPO_ROOT = resolve(HERE, "../..");
+
+/**
+ * ResultViewer が参照するクラスフックをソースから集める。
+ * [Intended] 一覧をテストへ書き写さず `".js-*"` の形のリテラルを拾うので、
+ * 実装側でフックが増えても追随する。コメント内の同じ書き方も対象に含める。
+ * フック名を名指しする記述は、それ自体が HTML への依存を表すため。
+ */
+const collectSourceHooks = (source: string): string[] => {
+	const hooks = new Set<string>();
+	for (const [, hook] of source.matchAll(/"\.(js-[a-zA-Z0-9-]+)"/g)) {
+		hooks.add(hook);
+	}
+	return [...hooks].sort();
+};
+
+/** class 属性に現れるクラスフックを集める */
+const collectMarkupHooks = (markup: string): Set<string> => {
+	const hooks = new Set<string>();
+	for (const [, value] of markup.matchAll(/class="([^"]*)"/g)) {
+		for (const name of value.split(/\s+/)) {
+			if (name.startsWith("js-")) hooks.add(name);
+		}
+	}
+	return hooks;
+};
+
+/**
+ * id を起点に要素のマークアップを切り出す。
+ * [Intended] 行番号で範囲を決めない。index.html は編集頻度が高く、
+ * 行番号を固定するとマークアップより先にテストが壊れる。
+ */
+const extractElementById = (html: string, id: string): string => {
+	const attributeIndex = html.indexOf(`id="${id}"`);
+	if (attributeIndex < 0) throw new Error(`id="${id}" が index.html にない`);
+	const start = html.lastIndexOf("<", attributeIndex);
+	const tagName = /^<([a-zA-Z][a-zA-Z0-9-]*)/.exec(html.slice(start))?.[1];
+	if (!tagName) throw new Error(`id="${id}" の開始タグを特定できない`);
+	// 同名タグの開閉を数えて、対応する閉じタグまでを取り出す
+	const tags = new RegExp(`<${tagName}\\b|</${tagName}>`, "g");
+	tags.lastIndex = start;
+	let depth = 0;
+	for (let match = tags.exec(html); match; match = tags.exec(html)) {
+		depth += match[0].startsWith("</") ? -1 : 1;
+		if (depth === 0) return html.slice(start, match.index + match[0].length);
+	}
+	throw new Error(`id="${id}" の閉じタグが見つからない`);
+};
+
+// [Intended] コメントを外してから走査する。フックを例示するコメントが
+// 出力パネル側にあり、要素が消えても残るので実在の証拠にならない。
+const stripComments = (html: string): string =>
+	html.replace(/<!--[\s\S]*?-->/g, "");
 
 const createViewer = () => {
 	const attributes = new Map<string, string>();
@@ -46,4 +104,32 @@ describe("ResultViewer.updateWarnings", () => {
 		expect(indicator.dataset.tooltip).toBeUndefined();
 		expect(attributes.has("aria-label")).toBe(false);
 	});
+});
+
+describe("ResultViewer のクラスフック", () => {
+	/**
+	 * [Policy] 表示コントロールのマークアップは出力パネルと結果モーダルに
+	 * 意図的に複製されており、整合は index.html のコメントの指示だけが担保していた。
+	 * 片方だけにフックを足しても型検査もテストも落ちないため、ここで機械的に縛る。
+	 */
+	const source = readFileSync(join(HERE, "result-viewer.ts"), "utf8");
+	const html = stripComments(
+		readFileSync(join(REPO_ROOT, "index.html"), "utf8"),
+	);
+	const hooks = collectSourceHooks(source);
+
+	it("ソースからフックを抽出できている", () => {
+		// 抽出が空振りすると以降の検査が素通りするので、取れていること自体を確かめる
+		expect(hooks.length).toBeGreaterThan(0);
+	});
+
+	for (const id of ["output-panel", "result-modal"]) {
+		it(`#${id} に ResultViewer が参照するフックがすべてある`, () => {
+			// [Intended] 検査は「ResultViewer が参照するフック ⊆ ブロック」の一方向。
+			// 候補一覧やモーダルの閉じるボタンなど片側にしか無いフックが正なので、
+			// 2 ブロックの集合一致は求めない。
+			const present = collectMarkupHooks(extractElementById(html, id));
+			expect(hooks.filter((hook) => !present.has(hook))).toEqual([]);
+		});
+	}
 });

--- a/src/browser/result-viewer.test.ts
+++ b/src/browser/result-viewer.test.ts
@@ -119,8 +119,12 @@ describe("ResultViewer のクラスフック", () => {
 	const hooks = collectSourceHooks(source);
 
 	it("ソースからフックを抽出できている", () => {
-		// 抽出が空振りすると以降の検査が素通りするので、取れていること自体を確かめる
-		expect(hooks.length).toBeGreaterThan(0);
+		// [Intended] 抽出が痩せると以降の検査が黙って素通りするので、下限を
+		// get() の呼び出し回数に取る。セレクタが定数へ括り出されて
+		// `".js-*"` の形で拾えなくなった時点で落ちる。
+		const getCallCount = source.match(/this\.get</g)?.length ?? 0;
+		expect(getCallCount).toBeGreaterThan(0);
+		expect(hooks.length).toBeGreaterThanOrEqual(getCallCount);
 	});
 
 	// [Intended] 検査単位は ResultViewer に渡すコンテナそのものに合わせる。

--- a/src/browser/result-viewer.test.ts
+++ b/src/browser/result-viewer.test.ts
@@ -123,7 +123,10 @@ describe("ResultViewer のクラスフック", () => {
 		expect(hooks.length).toBeGreaterThan(0);
 	});
 
-	for (const id of ["output-panel", "result-modal"]) {
+	// [Intended] 検査単位は ResultViewer に渡すコンテナそのものに合わせる。
+	// モーダルは #result-modal ではなく .result-modal-body を渡しており、
+	// ヘッダーまで含めて数えるとコンテナの外にあるフックを「ある」と誤判定する。
+	for (const id of ["output-panel", "result-modal-body"]) {
 		it(`#${id} に ResultViewer が参照するフックがすべてある`, () => {
 			// [Intended] 検査は「ResultViewer が参照するフック ⊆ ブロック」の一方向。
 			// 候補一覧やモーダルの閉じるボタンなど片側にしか無いフックが正なので、

--- a/src/browser/result-viewer.ts
+++ b/src/browser/result-viewer.ts
@@ -158,13 +158,9 @@ export class ResultViewer {
 			this.callbacks.onCompare?.();
 		});
 
-		// キャンバスコンテナのクリックで onImageClick を発火する
-		// レイアウトによってはキャンバスがコンテナより小さいためコンテナを使用するが、
-		// 通常は画像のクリックを受け取りたい。
-		// ただし、要望された機能は「画像をクリック」である。
-		// ズームモードではキャンバスがコンテナを満たすか、スクロールする。
-		// コンテナに設定しつつ、必要に応じて有効領域のクリックか確認する？
-		// コンテナ ".js-result-canvas-container" に設定するだけなら簡単で領域もカバーできる。
+		// [Intended] クリック領域はキャンバスではなく親の ".js-result-canvas-container" に張る。
+		// レイアウトによってはキャンバスがコンテナより小さく、余白のクリックを取りこぼすため。
+		// セレクタでは引かず parentElement を使うが、マークアップ側のこのクラスに依存している。
 		const canvasContainer = this.canvas.parentElement;
 		if (canvasContainer) {
 			canvasContainer.addEventListener("click", () => {


### PR DESCRIPTION
## 概要

出力パネルと結果モーダルに複製された表示コントロールの整合を、HTML コメントの指示ではなくテストで担保する。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- 表示コントロールのクラスフックを片方のブロックだけに足すと `make ci` が落ちるようになり、
  結果モーダルだけ操作できないといった不整合をレビュー前に検出できる。
- 検証するフックの一覧は `src/browser/result-viewer.ts` から自動で集めるため、
  フックが増減してもテストの書き換えは要らない。
- 複製箇所の HTML コメントから検証しているテストを辿れるようにした。

### その他

- 検証の向きは「ResultViewer が参照するフックが両ブロックに存在する」の一方向で、
  候補一覧や閉じるボタンのように片側にしか無いフックは対象外とする。
- ブロックの切り出しは `id` を起点にするため、index.html の行が動いてもテストは壊れない。

## 動作確認

- なし
