### PR TITLE
test: guide.html のレシピと品質ケースの対応を CI で検証

### DIFF
--- a/src/browser/i18n/html-keys.ts
+++ b/src/browser/i18n/html-keys.ts
@@ -1,0 +1,20 @@
+/**
+ * [Policy] HTML が data-i18n / data-i18n-attr で参照している i18n キーを取り出す。
+ * 翻訳キーの過不足検査（src/browser/i18n/messages.test.ts）と、ガイドのレシピと
+ * 品質ケースの対応検査（test/quality/guide-cases.test.ts）が同じ抽出を使う。
+ * 属性の書き方を増やしたときに片方だけ古い抽出のまま残ると、その検査が対象を
+ * 取りこぼしても失敗として現れないため、実装を 1 か所にまとめている。
+ */
+export const collectHtmlKeys = (html: string): string[] => {
+	const keys: string[] = [];
+	for (const [, key] of html.matchAll(/data-i18n="([^"]+)"/g)) {
+		keys.push(key);
+	}
+	for (const [, config] of html.matchAll(/data-i18n-attr="([^"]+)"/g)) {
+		for (const pair of config.split(",")) {
+			const key = pair.split(":")[1];
+			if (key) keys.push(key.trim());
+		}
+	}
+	return keys;
+};

--- a/src/browser/i18n/messages.test.ts
+++ b/src/browser/i18n/messages.test.ts
@@ -9,6 +9,7 @@ import type {
 	ProcessingRoute,
 } from "../../shared/types";
 import type { ImageItem } from "../session";
+import { collectHtmlKeys } from "./html-keys";
 import { LANGUAGES } from "./language";
 import { appMessageCatalogs, appMessages } from "./messages";
 import { guideMessages } from "./messages/guide";
@@ -20,21 +21,6 @@ const MESSAGES_DIR = join(HERE, "messages");
 
 const catalogs = { ...appMessageCatalogs, guide: guideMessages };
 const allMessages = { ...appMessages, ...guideMessages };
-
-// data-i18n / data-i18n-attr で参照しているキーを HTML から取り出す
-const collectHtmlKeys = (html: string): string[] => {
-	const keys: string[] = [];
-	for (const [, key] of html.matchAll(/data-i18n="([^"]+)"/g)) {
-		keys.push(key);
-	}
-	for (const [, config] of html.matchAll(/data-i18n-attr="([^"]+)"/g)) {
-		for (const pair of config.split(",")) {
-			const key = pair.split(":")[1];
-			if (key) keys.push(key.trim());
-		}
-	}
-	return keys;
-};
 
 const readHtml = (name: string) => readFileSync(join(REPO_ROOT, name), "utf8");
 

--- a/test/quality/README.md
+++ b/test/quality/README.md
@@ -117,6 +117,13 @@ or changing a Quick Settings item. Every published example has one case here, so
 the report keeps answering whether that published result is still reproducible
 by following the published steps.
 
+The case for recipe N is named `guide-recipeN-<name>`, and
+[`guide-cases.test.ts`](./guide-cases.test.ts) holds the page and `cases.json` to
+that convention: it collects the `guide.recipeN.*` keys referenced by
+`guide.html` and fails when a recipe has no case, when a case has no recipe, and
+when a `guide-` case ID departs from the naming. It only reads sources, so it
+runs in `make ci` rather than with the image cases.
+
 Those cases set `presetId`, or `quickSettings` when the page names Quick
 Settings instead of a preset, and no `options`. The benchmark resolves the
 options from `BUILT_IN_PRESETS` or from `createQuickProcessOptions` when the

--- a/test/quality/README.md
+++ b/test/quality/README.md
@@ -119,8 +119,10 @@ by following the published steps.
 
 The case for recipe N is named `guide-recipeN-<name>`, and
 [`guide-cases.test.ts`](./guide-cases.test.ts) holds the page and `cases.json` to
-that convention: it collects the `guide.recipeN.*` keys referenced by
-`guide.html` and fails when a recipe has no case, when a case has no recipe, and
+that convention: it collects the `guide.recipeN.*` keys that `guide.html`
+references outside comments, expects each recipe to carry exactly one
+`guide.recipeN.heading`, and fails when a recipe has no case, when a case has no
+recipe, when a case reads or expects a file outside `public/guide/recipeN-`, and
 when a `guide-` case ID departs from the naming. It only reads sources, so it
 runs in `make ci` rather than with the image cases.
 

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { loadCases } from "./manifest";
+import type { QualityImageCase } from "./types";
 
 /**
  * [Policy] guide.html が公開する変換例と、その再現を証明する品質ケースの対応を縛る。
@@ -53,17 +54,24 @@ for (const key of htmlKeys) {
 	headingCountByRecipe.set(number, (headingCountByRecipe.get(number) ?? 0) + 1);
 }
 
-const guideCaseIds = loadCases()
-	.map((qualityCase) => qualityCase.id)
-	.filter((id) => id.startsWith("guide-"))
-	.sort();
+const guideCases = loadCases()
+	.filter((qualityCase) => qualityCase.id.startsWith("guide-"))
+	.sort((a, b) => a.id.localeCompare(b.id));
 
-const caseIdsByRecipe = new Map<string, string[]>();
-for (const id of guideCaseIds) {
-	const number = RECIPE_CASE_ID.exec(id)?.[1];
+const guideCaseIds = guideCases.map((qualityCase) => qualityCase.id);
+
+const casesByRecipe = new Map<string, QualityImageCase[]>();
+for (const qualityCase of guideCases) {
+	const number = RECIPE_CASE_ID.exec(qualityCase.id)?.[1];
 	if (number === undefined) continue;
-	caseIdsByRecipe.set(number, [...(caseIdsByRecipe.get(number) ?? []), id]);
+	casesByRecipe.set(number, [
+		...(casesByRecipe.get(number) ?? []),
+		qualityCase,
+	]);
 }
+
+const idsOfRecipe = (number: string): string[] =>
+	(casesByRecipe.get(number) ?? []).map((qualityCase) => qualityCase.id);
 
 describe("guide recipes and quality cases", () => {
 	it("guide.html のレシピ番号を取り違えていない", () => {
@@ -93,7 +101,7 @@ describe("guide recipes and quality cases", () => {
 
 	it("guide.html の各レシピに品質ケースが 1 つある", () => {
 		const problems = recipeNumbers.flatMap((number) => {
-			const ids = caseIdsByRecipe.get(number) ?? [];
+			const ids = idsOfRecipe(number);
 			if (ids.length === 1) return [];
 			if (ids.length === 0) {
 				return [
@@ -110,14 +118,41 @@ describe("guide recipes and quality cases", () => {
 	it("品質ケースに対応するレシピが guide.html に残っている", () => {
 		// [Intended] レシピを消してケースだけ残ると、公開していない変換例を
 		// 再現し続けることになる。逆向きも落とす。
-		const orphaned = [...caseIdsByRecipe.entries()]
-			.filter(([number]) => !recipeNumbers.includes(number))
-			.flatMap(([number, ids]) =>
-				ids.map(
+		const orphaned = [...casesByRecipe.keys()]
+			.filter((number) => !recipeNumbers.includes(number))
+			.flatMap((number) =>
+				idsOfRecipe(number).map(
 					(id) => `${id}: guide.html に guide.recipe${number}.* の参照が無い`,
 				),
 			);
 		expect(orphaned).toEqual([]);
+	});
+
+	it("guide ケースの入出力がそのレシピの掲載画像を指している", () => {
+		// [Intended] レシピとケースの対応づけは ID の番号だけが根拠なので、
+		// 既存ケースを複製して ID だけ書き換えると、別レシピの画像を検証した
+		// まま「そのレシピは再現できている」と表示し続ける。
+		const problems = [...casesByRecipe.entries()].flatMap(([number, cases]) =>
+			cases.flatMap((qualityCase) => {
+				const prefix = `public/guide/recipe${number}-`;
+				if (qualityCase.expected === undefined) {
+					return [`${qualityCase.id}: 掲載結果を示す expected が無い`];
+				}
+				return (
+					[
+						["input", qualityCase.input],
+						["expected", qualityCase.expected],
+					] as const
+				).flatMap(([field, file]) =>
+					file.startsWith(prefix)
+						? []
+						: [
+								`${qualityCase.id}: ${field} が ${prefix}* を指していない（${file}）`,
+							],
+				);
+			}),
+		);
+		expect(problems).toEqual([]);
 	});
 
 	it("guide ケースの ID が guide-recipeN-<name> の規約に従っている", () => {

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { collectHtmlKeys } from "../../src/browser/i18n/html-keys";
 import { loadCases } from "./manifest";
 import type { QualityImageCase } from "./types";
 
@@ -20,22 +21,6 @@ const RECIPE_HEADING_KEY = /^guide\.recipe(\d+)\.heading$/;
 const RECIPE_CASE_ID = /^guide-recipe(\d+)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const GUIDE_HTML = path.resolve("guide.html");
-
-// data-i18n / data-i18n-attr で参照しているキーを HTML から取り出す
-// （src/browser/i18n/messages.test.ts の collectHtmlKeys と同じ抽出）
-const collectHtmlKeys = (html: string): string[] => {
-	const keys: string[] = [];
-	for (const [, key] of html.matchAll(/data-i18n="([^"]+)"/g)) {
-		keys.push(key);
-	}
-	for (const [, config] of html.matchAll(/data-i18n-attr="([^"]+)"/g)) {
-		for (const pair of config.split(",")) {
-			const key = pair.split(":")[1];
-			if (key) keys.push(key.trim());
-		}
-	}
-	return keys;
-};
 
 const byNumber = (a: string, b: string) => Number(a) - Number(b);
 

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -8,12 +8,14 @@ import { loadCases } from "./manifest";
  * 対応づけは次の命名規約に依存する。
  *
  * - guide.html のレシピ N の文言は `guide.recipeN.*` というキーで参照する
+ * - レシピ N の記事は見出しを `guide.recipeN.heading` で 1 つだけ持つ
  * - そのレシピを再現する品質ケースの ID は `guide-recipeN-<name>` にする（レシピ 1 つにつき 1 ケース）
  *
- * 規約を変える場合は、この 2 つの正規表現と test/quality/README.md の
+ * 規約を変える場合は、この 3 つの正規表現と test/quality/README.md の
  * 「Guide page examples」も合わせて直すこと。
  */
 const RECIPE_KEY = /^guide\.recipe(\d+)\./;
+const RECIPE_HEADING_KEY = /^guide\.recipe(\d+)\.heading$/;
 const RECIPE_CASE_ID = /^guide-recipe(\d+)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 const GUIDE_HTML = path.resolve("guide.html");
@@ -36,14 +38,20 @@ const collectHtmlKeys = (html: string): string[] => {
 
 const byNumber = (a: string, b: string) => Number(a) - Number(b);
 
+const htmlKeys = collectHtmlKeys(readFileSync(GUIDE_HTML, "utf8"));
+
 // guide.html が参照しているレシピ番号
 const recipeNumbers = [
-	...new Set(
-		collectHtmlKeys(readFileSync(GUIDE_HTML, "utf8")).flatMap(
-			(key) => RECIPE_KEY.exec(key)?.[1] ?? [],
-		),
-	),
+	...new Set(htmlKeys.flatMap((key) => RECIPE_KEY.exec(key)?.[1] ?? [])),
 ].sort(byNumber);
+
+// レシピ番号ごとの見出しキーの本数 = そのレシピを名乗る記事の数
+const headingCountByRecipe = new Map<string, number>();
+for (const key of htmlKeys) {
+	const number = RECIPE_HEADING_KEY.exec(key)?.[1];
+	if (number === undefined) continue;
+	headingCountByRecipe.set(number, (headingCountByRecipe.get(number) ?? 0) + 1);
+}
 
 const guideCaseIds = loadCases()
 	.map((qualityCase) => qualityCase.id)
@@ -62,6 +70,25 @@ describe("guide recipes and quality cases", () => {
 		// [Intended] 抽出が空のまま以降の検査を通すと、レシピが 1 つも無い状態と
 		// 区別できずに「対応が取れている」と誤判定する。
 		expect(recipeNumbers.length).toBeGreaterThan(0);
+	});
+
+	it("guide.html のレシピ記事が番号ごとに 1 つある", () => {
+		// [Intended] レシピ番号は Set で重複を落とすため、記事を複製して番号を
+		// 直し忘れても 1 レシピとしか見えず、既存のケース 1 件で全検査が通る。
+		// 見出しキーの本数で記事の数を数え直し、番号の重複を落とす。
+		const problems = recipeNumbers.flatMap((number) => {
+			const count = headingCountByRecipe.get(number) ?? 0;
+			if (count === 1) return [];
+			if (count === 0) {
+				return [
+					`guide.recipe${number}: guide.recipe${number}.heading の参照が guide.html に無い`,
+				];
+			}
+			return [
+				`guide.recipe${number}: 見出しが ${count} 件ある。レシピ記事 1 つにつき見出し 1 つ`,
+			];
+		});
+		expect(problems).toEqual([]);
 	});
 
 	it("guide.html の各レシピに品質ケースが 1 つある", () => {

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -74,9 +74,10 @@ const idsOfRecipe = (number: string): string[] =>
 	(casesByRecipe.get(number) ?? []).map((qualityCase) => qualityCase.id);
 
 describe("guide recipes and quality cases", () => {
-	it("guide.html のレシピ番号を取り違えていない", () => {
-		// [Intended] 抽出が空のまま以降の検査を通すと、レシピが 1 つも無い状態と
-		// 区別できずに「対応が取れている」と誤判定する。
+	it("guide.html からレシピ番号を抽出できている", () => {
+		// [Intended] 抽出が壊れても、品質ケースが残っていれば下の孤立ケース検出が
+		// 落ちる。ただしケースも 0 件なら空同士で全検査が成立して緑になるため、
+		// その同時縮退より手前で抽出の破損を止める。
 		expect(recipeNumbers.length).toBeGreaterThan(0);
 	});
 
@@ -156,8 +157,8 @@ describe("guide recipes and quality cases", () => {
 	});
 
 	it("guide ケースの ID が guide-recipeN-<name> の規約に従っている", () => {
-		// [Intended] 規約から外れた ID は上の 2 つの検査のどちらにも引っかからず、
-		// 「ケースがある」と「レシピがある」の両方をすり抜ける。
+		// [Intended] 規約から外れた ID は番号を取り出せないため対応表に載らず、
+		// 「ケースがある」と「レシピがある」の両方の検査をすり抜ける。
 		const invalid = guideCaseIds.filter((id) => !RECIPE_CASE_ID.test(id));
 		expect(invalid).toEqual([]);
 	});

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadCases } from "./manifest";
+
+/**
+ * [Policy] guide.html が公開する変換例と、その再現を証明する品質ケースの対応を縛る。
+ * 対応づけは次の命名規約に依存する。
+ *
+ * - guide.html のレシピ N の文言は `guide.recipeN.*` というキーで参照する
+ * - そのレシピを再現する品質ケースの ID は `guide-recipeN-<name>` にする（レシピ 1 つにつき 1 ケース）
+ *
+ * 規約を変える場合は、この 2 つの正規表現と test/quality/README.md の
+ * 「Guide page examples」も合わせて直すこと。
+ */
+const RECIPE_KEY = /^guide\.recipe(\d+)\./;
+const RECIPE_CASE_ID = /^guide-recipe(\d+)-[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const GUIDE_HTML = path.resolve("guide.html");
+
+// data-i18n / data-i18n-attr で参照しているキーを HTML から取り出す
+// （src/browser/i18n/messages.test.ts の collectHtmlKeys と同じ抽出）
+const collectHtmlKeys = (html: string): string[] => {
+	const keys: string[] = [];
+	for (const [, key] of html.matchAll(/data-i18n="([^"]+)"/g)) {
+		keys.push(key);
+	}
+	for (const [, config] of html.matchAll(/data-i18n-attr="([^"]+)"/g)) {
+		for (const pair of config.split(",")) {
+			const key = pair.split(":")[1];
+			if (key) keys.push(key.trim());
+		}
+	}
+	return keys;
+};
+
+const byNumber = (a: string, b: string) => Number(a) - Number(b);
+
+// guide.html が参照しているレシピ番号
+const recipeNumbers = [
+	...new Set(
+		collectHtmlKeys(readFileSync(GUIDE_HTML, "utf8")).flatMap(
+			(key) => RECIPE_KEY.exec(key)?.[1] ?? [],
+		),
+	),
+].sort(byNumber);
+
+const guideCaseIds = loadCases()
+	.map((qualityCase) => qualityCase.id)
+	.filter((id) => id.startsWith("guide-"))
+	.sort();
+
+const caseIdsByRecipe = new Map<string, string[]>();
+for (const id of guideCaseIds) {
+	const number = RECIPE_CASE_ID.exec(id)?.[1];
+	if (number === undefined) continue;
+	caseIdsByRecipe.set(number, [...(caseIdsByRecipe.get(number) ?? []), id]);
+}
+
+describe("guide recipes and quality cases", () => {
+	it("guide.html のレシピ番号を取り違えていない", () => {
+		// [Intended] 抽出が空のまま以降の検査を通すと、レシピが 1 つも無い状態と
+		// 区別できずに「対応が取れている」と誤判定する。
+		expect(recipeNumbers.length).toBeGreaterThan(0);
+	});
+
+	it("guide.html の各レシピに品質ケースが 1 つある", () => {
+		const problems = recipeNumbers.flatMap((number) => {
+			const ids = caseIdsByRecipe.get(number) ?? [];
+			if (ids.length === 1) return [];
+			if (ids.length === 0) {
+				return [
+					`guide.recipe${number}: guide-recipe${number}-* の品質ケースが cases.json に無い`,
+				];
+			}
+			return [
+				`guide.recipe${number}: 品質ケースが ${ids.length} 件ある（${ids.join(", ")}）。レシピ 1 つにつき 1 ケース`,
+			];
+		});
+		expect(problems).toEqual([]);
+	});
+
+	it("品質ケースに対応するレシピが guide.html に残っている", () => {
+		// [Intended] レシピを消してケースだけ残ると、公開していない変換例を
+		// 再現し続けることになる。逆向きも落とす。
+		const orphaned = [...caseIdsByRecipe.entries()]
+			.filter(([number]) => !recipeNumbers.includes(number))
+			.flatMap(([number, ids]) =>
+				ids.map(
+					(id) => `${id}: guide.html に guide.recipe${number}.* の参照が無い`,
+				),
+			);
+		expect(orphaned).toEqual([]);
+	});
+
+	it("guide ケースの ID が guide-recipeN-<name> の規約に従っている", () => {
+		// [Intended] 規約から外れた ID は上の 2 つの検査のどちらにも引っかからず、
+		// 「ケースがある」と「レシピがある」の両方をすり抜ける。
+		const invalid = guideCaseIds.filter((id) => !RECIPE_CASE_ID.test(id));
+		expect(invalid).toEqual([]);
+	});
+});

--- a/test/quality/guide-cases.test.ts
+++ b/test/quality/guide-cases.test.ts
@@ -24,7 +24,15 @@ const GUIDE_HTML = path.resolve("guide.html");
 
 const byNumber = (a: string, b: string) => Number(a) - Number(b);
 
-const htmlKeys = collectHtmlKeys(readFileSync(GUIDE_HTML, "utf8"));
+// [Intended] 属性は HTML を構文解析せず生の文字列から拾うため、コメントアウト
+// した記事のキーも一緒に取れてしまう。ページに出ていない記事を公開中のレシピと
+// 数えると、レシピを隠してもケースが孤立扱いにならず検査が素通りする。
+const stripHtmlComments = (html: string): string =>
+	html.replace(/<!--[\s\S]*?-->/g, "");
+
+const htmlKeys = collectHtmlKeys(
+	stripHtmlComments(readFileSync(GUIDE_HTML, "utf8")),
+);
 
 // guide.html が参照しているレシピ番号
 const recipeNumbers = [


### PR DESCRIPTION
## 概要

レシピ集のガイドページに載せた変換例が、その再現を証明する品質ケースと必ず対になっていることを CI で保証する。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- `make ci` で、`guide.html` のレシピと `test/quality/cases.json` の `guide-recipeN-*` ケースの対応を検査するようになり、レシピを追加したのにケースを足し忘れた変更が CI で止まる。
- 検査は双方向で、レシピを消してケースだけが残った場合や、`guide-` で始まるケース ID が命名規約から外れた場合も検出する。記事を複製してレシピ番号を直し忘れた場合、ケースの `input` / `expected` が別レシピの掲載画像を指している場合、レシピをコメントアウトしてページから下げた場合も落ちる。
- 検査はソースを読むだけなので、画像を処理する品質ケースを回さなくても `make ci` の実行時間の範囲で終わる。

### その他

- レポート側でレシピごとの説明文を持つ `describeCase` は今回の対象外で、レシピ追加時に手で更新する箇所として残る。

## 動作確認

- なし

