### PR TITLE
docs: 翻訳キーの登録手順を各ディレクトリの AGENTS.md へ移設

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@
 
 ## Localization
 
-Translation keys are registered per directory: app UI keys in [src/browser/i18n/AGENTS.md](src/browser/i18n/AGENTS.md), quality report keys in [test/quality/report/AGENTS.md](test/quality/report/AGENTS.md).
+Before adding, renaming, or removing a translation key, read the `AGENTS.md` of the directory that owns it: app UI keys in [src/browser/i18n/AGENTS.md](src/browser/i18n/AGENTS.md), quality report keys in [test/quality/report/AGENTS.md](test/quality/report/AGENTS.md).
 
 ## Guide Page
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,11 @@
 
 ## Localization
 
-Keys for `data-i18n` and `data-i18n-attr` in the app UI (`index.html` and `src/browser`) live in `src/browser/i18n/messages/`, one module per group of related key prefixes (a module owns several prefixes, e.g. `ui.ts` holds `app.` / `section.` / `ui.` and more), with the three languages written together in a single entry per key. `src/browser/i18n/messages.test.ts` checks the prefix-to-module mapping, keys referenced from HTML but never defined, and keys that nothing references anymore. When you introduce a new key prefix, add it to `MODULE_OF_PREFIX` in that test as well, naming the module that owns it.
-
-`guide.*` belongs to `messages/guide.ts` and is deliberately left out of `appMessages`, so the recipe copy stays out of the app bundle; `src/browser/guide.ts` registers it with `i18n.registerMessages()`.
-
-The quality report generated under `test/quality/report` is a standalone artifact with its own self-contained resource, so register the keys of its `data-i18n`, `data-i18n-alt`, and `data-i18n-placeholder` attributes in `test/quality/report/translations.ts` instead, writing the three languages together in a single entry per key as the app messages do. Do not add report-only keys to `src/browser/i18n/`. `test/quality/report/translations.test.ts` checks the same things for the report, but the report builds its markup in TypeScript, so keys it assembles at run time cannot be found by reading the source: when you add one, register where its value comes from in `GROUP_VALUES` (for `<group>.<value>` keys) or `DYNAMIC_FLAT_KEYS` (for flat keys) in that test, preferring a type or a constant the report already exports over a hand-written list.
+Translation keys are registered per directory: app UI keys in [src/browser/i18n/AGENTS.md](src/browser/i18n/AGENTS.md), quality report keys in [test/quality/report/AGENTS.md](test/quality/report/AGENTS.md).
 
 ## Guide Page
 
-When `guide.html` publishes a converted example, add one quality case for it so the report keeps proving that the published result is reproducible: publish the generated source image at its original size under `public/guide/` and use that same file as the case `input`, and add a case to `test/quality/cases.json` whose `presetId` is the preset the page tells the reader to select — or whose `quickSettings` holds the Quick Settings changes when the page names those instead — and whose `expected` is the published output image. The page must offer that original for download, because the displayed copy is downscaled and does not reproduce the published result. See [Guide page examples](test/quality/README.md#guide-page-examples).
+When `guide.html` publishes a converted example, add one quality case for it by following [Guide page examples](test/quality/README.md#guide-page-examples), so the report keeps proving that the published result is reproducible.
 
 ## Intent Comments
 

--- a/src/browser/i18n/AGENTS.md
+++ b/src/browser/i18n/AGENTS.md
@@ -1,0 +1,7 @@
+# App UI Localization
+
+Keys for `data-i18n` and `data-i18n-attr` in the app UI (`index.html` and `src/browser`) live in `src/browser/i18n/messages/`, one module per group of related key prefixes (a module owns several prefixes, e.g. `ui.ts` holds `app.` / `section.` / `ui.` and more), with the three languages written together in a single entry per key. `src/browser/i18n/messages.test.ts` checks the prefix-to-module mapping, keys referenced from HTML but never defined, and keys that nothing references anymore. When you introduce a new key prefix, add it to `MODULE_OF_PREFIX` in that test as well, naming the module that owns it.
+
+`guide.*` belongs to `messages/guide.ts` and is deliberately left out of `appMessages`, so the recipe copy stays out of the app bundle; `src/browser/guide.ts` registers it with `i18n.registerMessages()`.
+
+Keys that only the quality report emits are registered elsewhere: see [test/quality/report/AGENTS.md](../../../test/quality/report/AGENTS.md).

--- a/src/browser/i18n/CLAUDE.md
+++ b/src/browser/i18n/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/test/quality/report/AGENTS.md
+++ b/test/quality/report/AGENTS.md
@@ -1,0 +1,5 @@
+# Quality Report Localization
+
+The quality report generated under `test/quality/report` is a standalone artifact with its own self-contained resource, so register the keys of its `data-i18n`, `data-i18n-alt`, and `data-i18n-placeholder` attributes in `test/quality/report/translations.ts`, writing the three languages together in a single entry per key as the app messages do. Do not add report-only keys to `src/browser/i18n/`.
+
+`test/quality/report/translations.test.ts` matches the registered keys against the ones the report references in both directions and requires all three languages to be filled in. Because the report builds its markup in TypeScript, keys it assembles at run time cannot be found by reading the source: when you add one, register where its value comes from in `GROUP_VALUES` (for `<group>.<value>` keys) or `DYNAMIC_FLAT_KEYS` (for flat keys) in that test, preferring a type or a constant the report already exports over a hand-written list.

--- a/test/quality/report/AGENTS.md
+++ b/test/quality/report/AGENTS.md
@@ -3,3 +3,5 @@
 The quality report generated under `test/quality/report` is a standalone artifact with its own self-contained resource, so register the keys of its `data-i18n`, `data-i18n-alt`, and `data-i18n-placeholder` attributes in `test/quality/report/translations.ts`, writing the three languages together in a single entry per key as the app messages do. Do not add report-only keys to `src/browser/i18n/`.
 
 `test/quality/report/translations.test.ts` matches the registered keys against the ones the report references in both directions and requires all three languages to be filled in. Because the report builds its markup in TypeScript, keys it assembles at run time cannot be found by reading the source: when you add one, register where its value comes from in `GROUP_VALUES` (for `<group>.<value>` keys) or `DYNAMIC_FLAT_KEYS` (for flat keys) in that test, preferring a type or a constant the report already exports over a hand-written list.
+
+Keys the app UI emits are registered elsewhere: see [src/browser/i18n/AGENTS.md](../../../src/browser/i18n/AGENTS.md).

--- a/test/quality/report/CLAUDE.md
+++ b/test/quality/report/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## 概要

翻訳キーの登録手順を編集対象のディレクトリ側に置き、AI エージェントが作業に無関係なルールまで読まずに済むようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- アプリ UI の翻訳キーを追加するとき、`src/browser/i18n/` を開けばその場に登録手順があり、リポジトリのトップまで戻らずに済む。
- 品質レポートの翻訳キーを追加するとき、`test/quality/report/` の指示に登録先と `GROUP_VALUES` / `DYNAMIC_FLAT_KEYS` への登録義務がまとまっている。
- ガイドページの変換例を追加するとき、トップの指示から `test/quality/README.md` の該当節へ 1 行でたどれる。
- トップの `AGENTS.md` は Localization と Guide Page が参照だけになり、i18n を触らない作業で読む量が減る。

### その他

- 各ディレクトリには `@AGENTS.md` の 1 行だけを書いた `CLAUDE.md` を併置し、リポジトリのトップと同じ構成にしている。
- `test/quality/README.md` は変更していない。
  トップの Guide Page 節が述べていた内容は「Guide page examples」節がすべて含んでいることを確認したため。
- 移設のついでに `test/quality/report/translations.test.ts` の説明を実際の検査内容に合わせた。
  従来の「同じことを検査する」という表現は、レポート側に存在しないモジュール対応の検査まで含む言い方だった。

## 動作確認

- なし
