### PR TITLE
fix: 1 枚だけの変換で「一括処理中」と表示されないようにする

### DIFF
--- a/src/browser/batch-controller.ts
+++ b/src/browser/batch-controller.ts
@@ -88,7 +88,9 @@ export const setupBatchController = ({
 
 		els.downloadAllButton.disabled = true;
 		els.downloadAllDropdownButton.disabled = true;
-		loadingOverlay.showProgress(0, images.length);
+		// [Intended] 枚数は添えない。processBatch は途中経過を通知しないため、
+		// 添えても開始時と完了時の 2 値しか動かず、進捗として意味をなさない。
+		loadingOverlay.show();
 
 		try {
 			const processingTokens = new Map<string, number>();
@@ -143,7 +145,8 @@ export const setupBatchController = ({
 			processingCompleted = true;
 			const activeId = imageSession.getActiveImage()?.id;
 			if (activeId) imageSession.setActiveImage(activeId);
-			loadingOverlay.showProgress(images.length, images.length);
+			// [Intended] 表示の更新が同じオーバーレイを閉じるため、ZIP を作る間は開き直す。
+			loadingOverlay.show();
 
 			// [Intended] 処理開始後に追加・個別処理された画像を混ぜず、
 			// 開始時の入力と今回の Worker 結果だけで ZIP を構成する。

--- a/src/browser/i18n/messages/ui.ts
+++ b/src/browser/i18n/messages/ui.ts
@@ -222,10 +222,10 @@ export const uiMessages = defineMessages({
 		en: "Processing...",
 		"zh-CN": "处理中...",
 	},
-	"status.processing_batch": {
-		ja: "一括処理中... ({current}/{total})",
-		en: "Batch Processing... ({current}/{total})",
-		"zh-CN": "正在批量处理... ({current}/{total})",
+	"status.processing_progress": {
+		ja: "処理中... ({current}/{total})",
+		en: "Processing... ({current}/{total})",
+		"zh-CN": "处理中... ({current}/{total})",
 	},
 	// modal.*
 	"modal.eyedropper.title": {

--- a/src/browser/loading-overlay.ts
+++ b/src/browser/loading-overlay.ts
@@ -2,6 +2,8 @@ import type { Elements } from "./app-elements";
 import { i18n } from "./i18n";
 
 export type LoadingOverlay = {
+	/** 何枚目かを添えずに表示する */
+	show: () => void;
 	/** 何枚目を処理しているかを添えて表示する */
 	showProgress: (current: number, total: number) => void;
 	/** 非表示にし、進捗テキストを既定の文言へ戻す */
@@ -18,10 +20,22 @@ export const createLoadingOverlay = (els: Elements): LoadingOverlay => {
 		if (loadingText) loadingText.textContent = text;
 	};
 
+	const show = () => {
+		els.loadingOverlay.style.display = "flex";
+		setText(i18n.t("status.processing"));
+	};
+
 	return {
+		show,
 		showProgress: (current: number, total: number) => {
+			// [Intended] 1 枚しかないときは枚数を添えない。(1/1) は進捗を伝えないうえ、
+			// 複数枚の処理が走っているかのように見える。
+			if (total <= 1) {
+				show();
+				return;
+			}
 			els.loadingOverlay.style.display = "flex";
-			setText(i18n.t("status.processing_batch", { current, total }));
+			setText(i18n.t("status.processing_progress", { current, total }));
 		},
 		hide: () => {
 			els.loadingOverlay.style.display = "none";


### PR DESCRIPTION
## 概要

変換中に出る処理中表示を実際の処理内容に合わせ、1 枚だけの変換で「一括処理中... (1/1)」と出ないようにする。

## 変更内容

### UI/UX

- 画像を 1 枚だけ変換したときの処理中表示が「処理中...」になる（未変換の画像は 1 枚でもまとめ変換のキューを通るため、これまでは常に「一括処理中... (1/1)」と出ていた）。
- 複数枚をまとめて変換したときの処理中表示が「処理中... (2/5)」になり、1 枚ずつ順に変換する実態と合わない「一括」という語をやめる。
- 一括ダウンロードの処理中表示に枚数を添えなくなり、開始時の「(0/5)」のような 0 枚目に見える表示がなくなる（変換の途中経過を受け取れず、実際には開始時と完了時の 2 値しか動かないため）。

### ロジック

- なし

### 開発体験

- なし

### その他

- なし

## 動作確認

- なし
