### PR TITLE
chore: Vercelデプロイ検証用コメントを削除

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { resolve } from "node:path";
 import { defineConfig } from "vite";
 import { htmlIncludes } from "./scripts/html-includes";
 
-// [Workaround] Vercel プロジェクト再作成後の自動デプロイ経路を確認するための一時的な変更。
 export default defineConfig({
 	// [Intended] index.html を partials/ のパーシャルへ分割して読めるようにする。
 	plugins: [htmlIncludes()],


### PR DESCRIPTION
## 概要

自動デプロイ検証のために追加した一時コメントを削除し、通常の構成へ戻します。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- Vercelの自動デプロイ検証用コメントを取り除き、検証前と同じ設定ファイルへ戻します。

### その他

- なし

## 動作確認

- なし
