### PR TITLE
feat: Vercel Speed Insightsを有効化

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "comlink": "^4.4.2",
     "jszip": "^3.10.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0
       comlink:
         specifier: ^4.4.2
         version: 4.4.2
@@ -454,6 +457,32 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -1693,6 +1722,8 @@ snapshots:
     optional: true
 
   '@vercel/analytics@2.0.1': {}
+
+  '@vercel/speed-insights@2.0.0': {}
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/src/browser/guide.ts
+++ b/src/browser/guide.ts
@@ -1,4 +1,5 @@
 import { inject } from "@vercel/analytics";
+import { injectSpeedInsights } from "@vercel/speed-insights";
 import { setupLanguageButtons, setupPromptCopyButtons } from "./guide-controls";
 import { i18n } from "./i18n";
 import { guideMessages } from "./i18n/messages/guide";
@@ -14,6 +15,7 @@ i18n.registerMessages(guideMessages);
 
 initTheme();
 inject();
+injectSpeedInsights();
 
 window.addEventListener("DOMContentLoaded", () => {
 	setupLanguageButtons();

--- a/src/browser/main.ts
+++ b/src/browser/main.ts
@@ -1,4 +1,5 @@
 import { inject } from "@vercel/analytics";
+import { injectSpeedInsights } from "@vercel/speed-insights";
 import { initApp } from "./app";
 import { initQualityReportLink } from "./quality-report-link";
 import { initTheme } from "./theme";
@@ -7,6 +8,7 @@ import "./style.css";
 
 initTheme();
 inject();
+injectSpeedInsights();
 
 window.addEventListener("DOMContentLoaded", () => {
 	initApp();


### PR DESCRIPTION
## 概要

Vercel 上のアプリ本体とガイドページで Web Vitals を収集し、性能を継続的に把握できるようにします。

## 変更内容

### UI/UX

- なし

### ロジック

- アプリ本体とガイドページの閲覧時に Vercel Speed Insights の計測を開始します。

### 開発体験

- なし

### その他

- なし

## 動作確認

- [x] Vercel の本番デプロイ後に両ページを開き、Speed Insights に計測データが表示されることを確認します。
