### PR TITLE
fix: Vercelデプロイをmainに限定

### DIFF
--- a/.github/workflows/quality-report-main.yml
+++ b/.github/workflows/quality-report-main.yml
@@ -135,6 +135,9 @@ jobs:
       name: quality-reports
       url: ${{ steps.deploy-pages.outputs.page_url }}
     steps:
+      - name: Check out the Vercel deployment policy
+        uses: actions/checkout@v7
+
       - name: Download comparison report
         uses: actions/download-artifact@v8
         with:
@@ -155,6 +158,8 @@ jobs:
             git checkout --orphan gh-pages
           fi
           touch .nojekyll
+          # [Policy] gh-pages の push では Vercel Deployment を作らない。
+          cp "$GITHUB_WORKSPACE/vercel.json" vercel.json
           # [Policy] README と UI のフッターから参照する固定の公開先。パスを変える場合は
           # 参照側（README と src/browser/quality-report-link.ts）も同時に直す。
           report_path="quality/latest"

--- a/.github/workflows/quality-report.yml
+++ b/.github/workflows/quality-report.yml
@@ -151,6 +151,9 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      - name: Check out the Vercel deployment policy
+        uses: actions/checkout@v7
+
       - name: Download comparison report
         uses: actions/download-artifact@v8
         with:
@@ -171,6 +174,8 @@ jobs:
             git checkout --orphan gh-pages
           fi
           touch .nojekyll
+          # [Policy] gh-pages の push では Vercel Deployment を作らない。
+          cp "$GITHUB_WORKSPACE/vercel.json" vercel.json
           report_path="quality/pr-${PR_NUMBER}"
           rm -rf "$report_path"
           mkdir -p "$report_path"
@@ -235,6 +240,9 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      - name: Check out the Vercel deployment policy
+        uses: actions/checkout@v7
+
       - name: Remove the closed PR report
         env:
           GH_TOKEN: ${{ github.token }}
@@ -249,6 +257,8 @@ jobs:
             git checkout --orphan gh-pages
           fi
           touch .nojekyll
+          # [Policy] gh-pages の push では Vercel Deployment を作らない。
+          cp "$GITHUB_WORKSPACE/vercel.json" vercel.json
           report_path="quality/pr-${PR_NUMBER}"
           rm -rf "$report_path"
           git config user.name github-actions[bot]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://openapi.vercel.sh/vercel.json",
+	"git": {
+		"deploymentEnabled": {
+			"main": true,
+			"*": false
+		}
+	}
+}


### PR DESCRIPTION
## 概要

Vercelの自動デプロイをmainに限定し、Previewと品質レポート公開による1日100件の上限到達を防ぎます。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- Vercelはmainへのpushだけをデプロイし、開発ブランチのpushではDeploymentを作成しないようになります。
- 品質レポート公開時のgh-pagesにも同じポリシーを含め、レポート更新がVercelの枠を消費しないようにします。

### その他

- なし

## 動作確認

- なし
