### PR TITLE
chore: main以外のVercel自動デプロイを無効化

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
 	"git": {
 		"deploymentEnabled": {
 			"main": true,
-			"*": false
+			"**": false
 		}
 	}
 }


### PR DESCRIPTION
## 概要

VercelのGit連携による自動Deploymentを`main`ブランチのみに制限します。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- Vercelプロジェクト`pixel-refiner`（scope: `happyonigiris-projects`、Root Directory: `.`）で、スラッシュを含む`main`以外のブランチも自動Deploymentの対象外にします。

### その他

- `gh-pages`生成処理は既にルートの`vercel.json`を生成ブランチへ含めるため、追加変更はありません。

## 動作確認

- なし

## 検証結果

- `vercel.json`をJSONとして解析し、`main`が有効、`**`が無効であることを確認しました。
- `make ci`が成功しました。
- ブランチpush後、コミット276a79af35d9de43641a92a12d27df65c4871524に一致するPreview Deploymentが0件であることを確認しました。
