### PR TITLE
fix: 階層付きブランチのVercelデプロイを無効化

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
 	"git": {
 		"deploymentEnabled": {
 			"main": true,
-			"*": false
+			"**": false
 		}
 	}
 }


### PR DESCRIPTION
## 概要

main以外の階層付きブランチでもVercelの自動デプロイを無効化し、デプロイ対象をmainだけに限定します。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- `/` を含むブランチ名にも無効化設定を適用し、main以外のpushでVercel Deploymentが作成されないようにします。

### その他

- なし

## 動作確認

- なし
