### PR TITLE
chore: リリース Action を ReleaseActions へ移設し bump 指定に対応

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     steps:
-      - uses: HappyOnigiri/ShareSettings/actions/publish-release@main
+      - uses: HappyOnigiri/ReleaseActions/actions/publish-release@main
         with:
           branch: ${{ github.event.pull_request.head.ref }}
           pr-body: ${{ github.event.pull_request.body }}

--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -13,6 +13,6 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - uses: HappyOnigiri/ShareSettings/actions/release-reminder@main
+      - uses: HappyOnigiri/ReleaseActions/actions/release-reminder@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,24 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 1.3.0)"
-        required: true
+        description: "Release version (e.g. 1.3.0)。bump を使う場合は空にする"
+        required: false
         type: string
+      bump:
+        description: "バージョンの上げ方。version を指定する場合は none にする"
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - auto
+          - major
+          - minor
+          - patch
 
+# バージョンは実行後に確定するため、リリース同士は常に直列化する
 concurrency:
-  group: release-${{ inputs.version }}
+  group: release
   cancel-in-progress: false
 
 permissions:
@@ -20,8 +32,9 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: HappyOnigiri/ShareSettings/actions/prepare-release@main
+      - uses: HappyOnigiri/ReleaseActions/actions/prepare-release@main
         with:
           version: ${{ inputs.version }}
+          bump: ${{ inputs.bump }}
           version-bump-type: npm
           github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## 概要

リリースワークフローで次のバージョン番号を自分で決めずに、上げ方を選ぶだけでリリースを開始できるようにする。

## 変更内容

### UI/UX

- なし

### ロジック

- なし

### 開発体験

- Release ワークフローの手動実行で `bump`（`auto` / `major` / `minor` / `patch`）を選べるようになり、番号を調べる手間がなくなる。
- `version` が任意入力になり、`bump` を使うときは空のまま実行できる（両方指定・両方未指定は Action 側がエラーで停止する）。
- リリースの同時実行制御を固定キー `release` にし、実行後にバージョンが決まる `bump` 指定でもリリースが直列化される。
- 3 つのワークフローが参照する Action を ShareSettings から ReleaseActions へ切り替え、リリース関連の Action を 1 リポジトリで管理できるようにする。

### その他

- `bump: auto` は前回 GitHub Release 以降にマージされた PR タイトルの prefix から判定し、breaking change の検出時はエラーで停止する。

## 動作確認

- なし
